### PR TITLE
Documenting the code via doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1158,7 +1158,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
This is just the config file for running _doxygen_ against the tree. 
Stores the generated html in ./docs/html/
