### PR TITLE
Disable confusing interactions in the band activity and callsign tables

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -965,6 +965,10 @@ MainWindow::MainWindow(QString  const & program_info,
   auto logAction = new QAction(QString("Log..."), ui->tableWidgetCalls);
   connect(logAction, &QAction::triggered, this, &MainWindow::on_logQSOButton_clicked);
 
+  // Disable default header mouseover and click behaviors, they are confusing to users because they give the
+  // appearance of allowing sorting by header clicks, which is not actually implemented
+  ui->tableWidgetRXAll->horizontalHeader()->setHighlightSections(false);
+  ui->tableWidgetRXAll->horizontalHeader()->setSectionsClickable(false);
 
   ui->tableWidgetRXAll->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(ui->tableWidgetRXAll->horizontalHeader(), &QHeaderView::customContextMenuRequested, this, [this](QPoint const &point){
@@ -1218,6 +1222,11 @@ MainWindow::MainWindow(QString  const & program_info,
 
       addCommandToStorage("STORE", d);
   });
+
+  // Disable default header mouseover and click behaviors, they are confusing to users because they give the
+  // appearance of allowing sorting by header clicks, which is not actually implemented
+  ui->tableWidgetCalls->horizontalHeader()->setHighlightSections(false);
+  ui->tableWidgetCalls->horizontalHeader()->setSectionsClickable(false);
 
   ui->tableWidgetCalls->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(ui->tableWidgetCalls->horizontalHeader(), &QHeaderView::customContextMenuRequested, this, [this](QPoint const &point){

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -998,9 +998,9 @@ QPushButton:checked {
           <pointsize>12</pointsize>
          </font>
         </property>
-        <property name="toolTip">
+        <!--property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Received band activity is displayed with time since last heard, SNR, and the text received for each frequency offset in the passband.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
+        </property-->
         <property name="sizeAdjustPolicy">
          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContentsOnFirstShow</enum>
         </property>
@@ -1191,9 +1191,9 @@ QTextEdit[transmitting=&quot;true&quot;] {
            <pointsize>12</pointsize>
           </font>
          </property>
-         <property name="toolTip">
+         <!--property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Received callsigns are displayed with time since last heard, SNR, and grid locator (if reported).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
+         </property-->
          <property name="autoScroll">
           <bool>false</bool>
          </property>


### PR DESCRIPTION
Addresses #18 

Disables mouseover and click behavior on table headers in band activity and callsign tables
Disables "Received band activity is displayed" tooltip in band activity table
Disables "Received callsigns are displayed" tooltip in callsign table

The interaction in the table headers seemed to indicate that the headers could be used to sort on click, but this is not the case. To prevent confusion, these interactions have been disabled.

The tooltips in the tables are unnecessary, they simply describe what the tables contain. Users have reported annoyance at their constant presence.