### PR TITLE
Fix for deprecated setTimeSpec in Qt 6.9

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -267,18 +267,12 @@ public:
 
     band_.setModel (filtered_bands_.data ());
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
-    switch_at_.setTimeSpec(Qt::UTC);
-#else
     switch_at_.setTimeZone(QTimeZone::utc());
-#endif
+
     switch_at_.setDisplayFormat("hh:mm");
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
-    switch_until_.setTimeSpec(Qt::UTC);
-#else
     switch_until_.setTimeZone(QTimeZone::utc());
-#endif
+
     switch_until_.setDisplayFormat("hh:mm");
 
     auto form_layout = new QFormLayout ();

--- a/logqso.ui
+++ b/logqso.ui
@@ -164,8 +164,8 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="TimeSpec">
-              <enum>Qt::UTC</enum>
+             <property name="timeZone">
+              <enum>QTimeZone::UTC</enum>
              </property>
              <property name="displayFormat">
               <string>yyyy-MM-dd HH:mm:ss</string>
@@ -222,8 +222,8 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="TimeSpec">
-              <enum>Qt::UTC</enum>
+             <property name="timeZone">
+              <enum>QTimeZone::UTC</enum>
              </property>
              <property name="displayFormat">
               <string>yyyy-MM-dd HH:mm:ss</string>


### PR DESCRIPTION
This will fix the compiler complaints re: deprecation of setTimeSpec in Qt 6.9 and later. Addresses issue https://github.com/Chris-AC9KH/JS8Call-improved/issues/25