### PR TITLE
PSK Reporter Bug Fixes

### DIFF
--- a/PSKReporter.hpp
+++ b/PSKReporter.hpp
@@ -7,6 +7,7 @@
 
 class QString;
 class Configuration;
+class Bands;
 
 class PSKReporter final : public QObject
 {


### PR DESCRIPTION
Addresses issue #9 

Updates callsign cache to be band-aware
Fixes callsign cache timeout logic
Extends callsign cache expiration to 1 hour (formerly 5 minutes) 
Adds randomness to reporting interval
Removes mystery 49 MHz+ cache bypass inherited from WSJTX