### PR TITLE
Create workflow to build docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,23 +1,25 @@
 name: Build and Deploy Docs
 # Trigger only if we have labeled the PR, a Release has been published or a manual trigger
 on: 
-  workflow_dispatch:
+  workflow_dispatch: 
   pull_request:
-    types: [labeled]
+    types: [labeled] 
   release:
     types: [published]
 
 permissions:
   contents: write
+  id-token: write
+  pages: write
 jobs:
-  build_and_deploy_docs:
+  build_docs:
     if: (contains(github.event.pull_request.labels.*.name, 'documentation') ||
       (contains(github.event_name, 'workflow_dispatch')) ||
       (contains(github.event_name, 'release')) )
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout 
         uses: actions/checkout@v4
 
       - name: Get doxygen and graphviz
@@ -28,7 +30,19 @@ jobs:
       - name: Build docs
         run: doxygen
 
-      - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: docs/html
+          path: docs/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build_docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This will build the source code docs as it stands now, and publish it to GitHub Pages.

This workflow is triggered only if we have labeled the PR with "documentation", a Release has been published or a manual trigger.

@Chris-AC9KH There's some stuff you may need to turn on, or you can wait on this until we go to Org.
This is setup for "gh-pages", don't merge until you set it :)

> You must configure your repository to deploy from the branch you push to. To do this, go to your repository settings, click on Pages, and choose Deploy from a Branch from the Source dropdown. From there select the branch you supplied to the action. In most cases this will be gh-pages as that's the default.

Part of #4