### PR TITLE
Add .clang-format configuration file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -182,7 +182,9 @@ PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer
-ReflowComments:  IndentOnly
+# IdentOnly is available only in 19+
+#ReflowComments:  IndentOnly
+ReflowComments:  false
 RemoveBracesLLVM: false
 RemoveParentheses: Leave
 RemoveSemicolon: false


### PR DESCRIPTION
This is just for **testing!!!** Uses **clang-format-18**.

Please give it a whirl, and let me know if this totally breaks your coding style. One note, and something I didn't even know was in the c++ standards was the use of apostrophes in large numbers (from c++14).
