### PR TITLE
Guard against too low TX delays.

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -174,6 +174,7 @@
 #include "FrequencyLineEdit.hpp"
 #include "CandidateKeyFilter.hpp"
 #include "ForeignKeyDelegate.hpp"
+#include "TransceiverBase.hpp"
 #include "TransceiverFactory.hpp"
 #include "Transceiver.hpp"
 #include "Bands.hpp"
@@ -432,6 +433,8 @@ private:
 
   void delete_stations ();
   void insert_station ();
+
+  void check_tx_delay();
 
   Q_SLOT void on_psk_reporter_check_box_toggled(bool checked);
   Q_SLOT void on_enable_aprs_spotting_check_box_toggled(bool checked);
@@ -1875,6 +1878,7 @@ void Configuration::impl::read_settings ()
   ui_->tableFontButton->setText(QString("Font (%1 %2)").arg(next_table_font_.family()).arg(next_table_font_.pointSize()));
 
   txDelay_ = settings_->value ("TxDelay",0.2).toDouble();
+  check_tx_delay();
   save_directory_.setPath(settings_->value ("SaveDir", default_save_directory_.absolutePath ()).toString ());
 
   // retrieve audio channel info
@@ -2462,6 +2466,27 @@ bool Configuration::impl::validate ()
   return true;
 }
 
+void Configuration::impl::check_tx_delay() {
+    const double MAX_TX_DELAY = 0.5;
+    if(txDelay_ < TransceiverBase::PTT_DELAY_MS/1000.0) {
+        txDelay_ = TransceiverBase::PTT_DELAY_MS/1000.0;
+        QMessageBox::warning(
+            nullptr,
+            "TX Delay Too Low",
+            QString("A TX Delay below %1 ms will cause too late transmission, "
+                    "leading to initial symbol drop in turbo mode. - Replaced by %1 ms."
+                    ).arg(TransceiverBase::PTT_DELAY_MS));
+    } else if (MAX_TX_DELAY < txDelay_) {
+        txDelay_ = MAX_TX_DELAY;
+        QMessageBox::warning(
+            nullptr,
+            "TX Delay Too High",
+            QString("A TX Delay above %1 s is not supported."
+                    " - Replaced by %1 s."
+                    ).arg(MAX_TX_DELAY));
+    }
+}
+
 int Configuration::impl::exec ()
 {
   // macros can be modified in the main window
@@ -2704,6 +2729,7 @@ void Configuration::impl::accept ()
   spot_to_aprs_ = ui_->enable_aprs_spotting_check_box->isChecked();
   psk_reporter_tcpip_ = ui_->psk_reporter_tcpip_check_box->isChecked ();
   txDelay_ = ui_->sbTxDelay->value ();
+  check_tx_delay();
   write_logs_ = ui_->write_logs_check_box->isChecked();
   reset_activity_ = ui_->reset_activity_check_box->isChecked();
   check_for_updates_ = ui_->checkForUpdates_checkBox->isChecked();

--- a/TransceiverBase.cpp
+++ b/TransceiverBase.cpp
@@ -70,7 +70,7 @@ void TransceiverBase::set (TransceiverState const& s,
             {
               do_ptt (false);
               do_post_ptt (false);
-              QThread::msleep (100); // some rigs cannot process CAT
+              QThread::msleep (PTT_DELAY_MS); // some rigs cannot process CAT
                                      // commands while switching from
                                      // Tx to Rx
             }

--- a/TransceiverBase.hpp
+++ b/TransceiverBase.hpp
@@ -60,6 +60,12 @@ class TransceiverBase
 {
   Q_OBJECT;
 
+public:
+  /**
+   * When you press PTT, it takes at least this long to get an answer:
+   */
+  static const unsigned PTT_DELAY_MS = 100;
+
 protected:
   TransceiverBase (QObject * parent)
     : Transceiver {parent}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4783,7 +4783,7 @@ void MainWindow::guiUpdate()
     m_TRperiod = period; // Investigate: Does anyone need this?
 
     // Propagate any tx delay change to m_hb_loop and m_cq_loop.
-    double tx_delay_now = m_config.txDelay();
+    const double tx_delay_now = m_config.txDelay();
     if(tx_delay_now != m_TxDelay) {
         m_TxDelay = tx_delay_now;
         qint64 tx_delay_ms = std::lround(tx_delay_now * 1000);


### PR DESCRIPTION
To continue the title: They can cause initial symbols to be dropped in turbo mode.

We had a premature push to our main branch. I object to the pull request solution that was merged, on the following grounds:

* It essentially undoes work that I had previously done. We need to keep the knowledge in the code that symbol time gets eaten if we use a delay below 0.1 s.  It took me a while to find that out, and I suggest we should strive to keep that knowledge in the code.
* The first step is to give those 0.1 s a name. In general, it is considered bad style to have unexplained magic constants somewhere hidden in the code. Just pulling that constant into the header file, giving it a comment explaining it, and giving it a proper name, is already an improvement I would not want undone.
* Unfortunately, the UI file does not seem to allow comments. So, in the UI file, we cannot help using magic constants.
* But putting some code in the configuration source that checks against the named constant makes it clearer why the UI file has the magic constant of 0.1 s instead of 0.
* Finally, that check code also guards against the case that some user edits the ini-file directly and uses tx delay values that are out of bounds. The checks in the configuration source explain that the user cannot do that. This is a better user experience, as compared to running into problems and never knowing why.