### PR TITLE
Rename MessageBox to JS8MessageBox as a safer fix to Microsoft's #define MessageBox madness.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ target_sources(
   main.cpp
   mainwindow.cpp
   Message.cpp
-  MessageBox.cpp
+  JS8MessageBox.cpp
   MessageClient.cpp
   MessageError.cpp
   messagereplydialog.cpp

--- a/CMakeLists.txt.legacy
+++ b/CMakeLists.txt.legacy
@@ -146,7 +146,7 @@ set (WSJT_QT_CONF_DESTINATION ${QT_CONF_DESTINATION} CACHE PATH "Path for the qt
 #
 set (wsjt_qt_CXXSRCS
   qt_helpers.cpp
-  MessageBox.cpp
+  JS8MessageBox.cpp
   MetaDataRegistry.cpp
   NetworkServerLookup.cpp
   revision_utils.cpp

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -182,7 +182,7 @@
 #include "FrequencyList.hpp"
 #include "StationList.hpp"
 #include "NetworkServerLookup.hpp"
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 #include "Maidenhead.hpp"
 #include "CallsignValidator.hpp"
 #include "LazyFillComboBox.hpp"
@@ -988,11 +988,11 @@ QSet<QString> Configuration::my_groups() const {
 
 void Configuration::addGroup(QString const &group){
     if(!Varicode::isGroupAllowed(group)){
-        MessageBox::critical_message (m_->window(), QString("%1 is a group that cannot be joined").arg(group));
+        JS8MessageBox::critical_message (m_->window(), QString("%1 is a group that cannot be joined").arg(group));
         return;
     }
     if(!Varicode::isCompoundCallsign(group)){
-        MessageBox::critical_message (m_->window(), QString("%1 is not a valid group").arg(group));
+        JS8MessageBox::critical_message (m_->window(), QString("%1 is not a valid group").arg(group));
         return;
     }
     QSet<QString> groups = my_groups();
@@ -1153,7 +1153,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
     // Find a suitable data file location
     if (!writeable_data_dir_.mkpath ("."))
       {
-        MessageBox::critical_message (this, tr ("Failed to create data directory"),
+        JS8MessageBox::critical_message (this, tr ("Failed to create data directory"),
                                       tr ("path: \"%1\"").arg (writeable_data_dir_.absolutePath ()));
         throw std::runtime_error {"Failed to create data directory"};
       }
@@ -1163,7 +1163,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
     default_save_directory_ = writeable_data_dir_;
     if (!default_save_directory_.mkpath (save_dir) || !default_save_directory_.cd (save_dir))
       {
-        MessageBox::critical_message (this, tr ("Failed to create save directory"),
+        JS8MessageBox::critical_message (this, tr ("Failed to create save directory"),
                                       tr ("path: \"%1\%")
                                       .arg (default_save_directory_.absoluteFilePath (save_dir)));
         throw std::runtime_error {"Failed to create save directory"};
@@ -1175,7 +1175,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
     QString samples_dir {"samples"};
     if (!default_save_directory_.mkpath (samples_dir))
       {
-        MessageBox::critical_message (this, tr ("Failed to create samples directory"),
+        JS8MessageBox::critical_message (this, tr ("Failed to create samples directory"),
                                       tr ("path: \"%1\"")
                                       .arg (default_save_directory_.absoluteFilePath (samples_dir)));
         throw std::runtime_error {"Failed to create samples directory"};
@@ -1184,7 +1184,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
     QString messages_dir {"messages"};
     if (!default_save_directory_.mkpath (messages_dir))
       {
-        MessageBox::critical_message (this, tr ("Failed to create messages directory"),
+        JS8MessageBox::critical_message (this, tr ("Failed to create messages directory"),
                                       tr ("path: \"%1\"")
                                       .arg (default_save_directory_.absoluteFilePath (messages_dir)));
         throw std::runtime_error {"Failed to create messages directory"};
@@ -2367,83 +2367,83 @@ QStringList splitWords(QString callsString){
 bool Configuration::impl::validate ()
 {
   if(ui_->eot_line_edit->text().trimmed().left(2).isEmpty()){
-      MessageBox::critical_message (this, tr ("Please enter an end of transmission character"));
+      JS8MessageBox::critical_message (this, tr ("Please enter an end of transmission character"));
       return false;
   }
 
   auto callsign = ui_->callsign_line_edit->text().toUpper().trimmed();
   if(!Varicode::isValidCallsign(callsign, nullptr) || callsign.startsWith("@")){
-      MessageBox::critical_message (this, tr ("The callsign format you provided is not supported"));
+      JS8MessageBox::critical_message (this, tr ("The callsign format you provided is not supported"));
       return false;
   }
 
   if (!ui_->grid_line_edit->hasAcceptableInput())
   {
-    MessageBox::critical_message (this, tr ("The grid you provided is not valid"));
+    JS8MessageBox::critical_message (this, tr ("The grid you provided is not valid"));
     return false;
   }
 
   foreach(auto group, splitGroups(ui_->groups_line_edit->text().toUpper().trimmed(), false)){
       if(!Varicode::isGroupAllowed(group)){
-          MessageBox::critical_message (this, QString("%1 is a group that cannot be joined").arg(group));
+          JS8MessageBox::critical_message (this, QString("%1 is a group that cannot be joined").arg(group));
           return false;
       }
       if(!Varicode::isCompoundCallsign(group)){
-          MessageBox::critical_message (this, QString("%1 is not a valid group").arg(group));
+          JS8MessageBox::critical_message (this, QString("%1 is not a valid group").arg(group));
           return false;
       }
   }
 
   foreach(auto call, splitWords(ui_->auto_whitelist_line_edit->text().toUpper().trimmed())){
       if(!Varicode::isValidCallsign(call, nullptr)){
-          MessageBox::critical_message (this, QString("%1 is not a valid callsign to whitelist").arg(call));
+          JS8MessageBox::critical_message (this, QString("%1 is not a valid callsign to whitelist").arg(call));
           return false;
       }
   }
 
   auto hb = ui_->hb_message_line_edit->text().toUpper().trimmed();
   if(!hb.isEmpty() && !(hb.startsWith("HB") || hb.contains(callsign))){
-      MessageBox::critical_message (this, QString("The HB message format is invalid. It must either start with \"HB\" or contain your callsign."));
+      JS8MessageBox::critical_message (this, QString("The HB message format is invalid. It must either start with \"HB\" or contain your callsign."));
       return false;
   }
 
   auto cq = ui_->cq_message_line_edit->text().toUpper().trimmed();
   if(!cq.isEmpty() && !(cq.startsWith("CQ") || cq.contains(callsign))){
-      MessageBox::critical_message (this, QString("The CQ message format is invalid. It must either start with \"CQ\" or contain your callsign."));
+      JS8MessageBox::critical_message (this, QString("The CQ message format is invalid. It must either start with \"CQ\" or contain your callsign."));
       return false;
   }
 
   if ((ui_->sound_input_combo_box->currentIndex() < 0) && next_audio_input_device_.isNull())
   {
     find_tab(ui_->sound_input_combo_box);
-    MessageBox::critical_message (this, tr ("Invalid audio input device"));
+    JS8MessageBox::critical_message (this, tr ("Invalid audio input device"));
     return false;
   }
 
   if ((ui_->sound_input_channel_combo_box->currentIndex () < 0) && next_audio_input_device_.isNull())
   {
     find_tab(ui_->sound_input_combo_box);
-    MessageBox::critical_message (this, tr ("Invalid audio input device"));
+    JS8MessageBox::critical_message (this, tr ("Invalid audio input device"));
     return false;
   }
 
   if ((ui_->sound_output_combo_box->currentIndex () < 0) && next_audio_output_device_.isNull())
   {
     find_tab(ui_->sound_output_combo_box);
-    MessageBox::information_message (this, tr ("Invalid audio output device"));
+    JS8MessageBox::information_message (this, tr ("Invalid audio output device"));
     // don't reject as we can work without an audio output
   }
 
   if ((ui_->notification_sound_output_combo_box->currentIndex () < 0) && next_notification_audio_output_device_.isNull())
   {
     find_tab(ui_->notification_sound_output_combo_box);
-    MessageBox::information_message (this, tr ("Invalid notification audio output device"));
+    JS8MessageBox::information_message (this, tr ("Invalid notification audio output device"));
     // don't reject as we can work without a notification audio output
   }
 
   if (!ui_->PTT_method_button_group->checkedButton ()->isEnabled ())
     {
-      MessageBox::critical_message (this, tr ("Invalid PTT method"));
+      JS8MessageBox::critical_message (this, tr ("Invalid PTT method"));
       return false;
     }
 
@@ -2455,7 +2455,7 @@ bool Configuration::impl::validate ()
                                ->item(ui_->PTT_port_combo_box->findText(ptt_port))
                                ->isEnabled())))
     {
-      MessageBox::critical_message (this, tr ("Invalid PTT port"));
+      JS8MessageBox::critical_message (this, tr ("Invalid PTT port"));
       return false;
     }
 
@@ -3289,7 +3289,7 @@ void Configuration::impl::load_frequencies ()
       auto const list = read_frequencies_file (file_name);
       if (list.size ()
           && (!next_frequencies_.frequency_list ().size ()
-              || MessageBox::Yes == MessageBox::query_message (this
+              || JS8MessageBox::Yes == JS8MessageBox::query_message (this
                                                                , tr ("Replace Working Frequencies")
                                                                , tr ("Are you sure you want to discard your current "
                                                                      "working frequencies and replace them with the "
@@ -3319,7 +3319,7 @@ FrequencyList_v2::FrequencyItems Configuration::impl::read_frequencies_file (QSt
   ids >> magic;
   if (qrg_magic != magic)
     {
-      MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Incorrect file magic"));
+      JS8MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Incorrect file magic"));
       return list;
     }
   quint32 version;
@@ -3328,7 +3328,7 @@ FrequencyList_v2::FrequencyItems Configuration::impl::read_frequencies_file (QSt
   // necessary
   if (version > qrg_version)
     {
-      MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Version is too new"));
+      JS8MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Version is too new"));
       return list;
     }
 
@@ -3338,7 +3338,7 @@ FrequencyList_v2::FrequencyItems Configuration::impl::read_frequencies_file (QSt
 
   if (ids.status () != QDataStream::Ok || !ids.atEnd ())
     {
-      MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Contents corrupt"));
+      JS8MessageBox::warning_message (this, tr ("Not a valid frequencies file"), tr ("Contents corrupt"));
       list.clear ();
       return list;
     }
@@ -3356,7 +3356,7 @@ void Configuration::impl::save_frequencies ()
       QDataStream ods {&frequencies_file};
       auto selection_model = ui_->frequencies_table_view->selectionModel ();
       if (selection_model->hasSelection ()
-          && MessageBox::Yes == MessageBox::query_message (this
+          && JS8MessageBox::Yes == JS8MessageBox::query_message (this
                                                            , tr ("Only Save Selected  Working Frequencies")
                                                            , tr ("Are you sure you want to save only the "
                                                                  "working frequencies that are currently selected? "
@@ -3374,7 +3374,7 @@ void Configuration::impl::save_frequencies ()
 
 void Configuration::impl::reset_frequencies ()
 {
-  if (MessageBox::Yes == MessageBox::query_message (this, tr ("Reset Working Frequencies")
+  if (JS8MessageBox::Yes == JS8MessageBox::query_message (this, tr ("Reset Working Frequencies")
                                                     , tr ("Are you sure you want to discard your current "
                                                           "working frequencies and replace them with default "
                                                           "ones?")))
@@ -3491,7 +3491,7 @@ bool Configuration::impl::have_rig ()
 {
   if (!open_rig ())
     {
-      MessageBox::critical_message (this, tr ("Rig control error")
+      JS8MessageBox::critical_message (this, tr ("Rig control error")
                                     , tr ("Failed to open connection to rig"));
     }
   return rig_active_;
@@ -3699,7 +3699,7 @@ void Configuration::impl::handle_transceiver_failure (QString const& reason)
 
   if (isVisible ())
     {
-      MessageBox::critical_message (this, tr ("Rig failure"), reason);
+      JS8MessageBox::critical_message (this, tr ("Rig failure"), reason);
     }
   else
     {

--- a/HelpTextWindow.cpp
+++ b/HelpTextWindow.cpp
@@ -7,7 +7,7 @@
 #include <QTextStream>
 
 #include "qt_helpers.hpp"
-#include <MessageBox.hpp>
+#include "JS8MessageBox.hpp"
 
 HelpTextWindow::HelpTextWindow (QString const& title, QString const& file_name, QFont const& font, QWidget * parent)
   : QLabel {parent, Qt::WindowCloseButtonHint | Qt::WindowMinimizeButtonHint}
@@ -15,7 +15,7 @@ HelpTextWindow::HelpTextWindow (QString const& title, QString const& file_name, 
   QFile source {file_name};
   if (!source.open (QIODevice::ReadOnly | QIODevice::Text))
     {
-      MessageBox::warning_message (this, tr ("Help file error")
+      JS8MessageBox::warning_message (this, tr ("Help file error")
                                    , tr ("Cannot open \"%1\" for reading").arg (source.fileName ())
                                    , tr ("Error: %1").arg (source.errorString ()));
       return;

--- a/JS8MessageBox.cpp
+++ b/JS8MessageBox.cpp
@@ -1,4 +1,4 @@
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 
 #include <QDialogButtonBox>
 #include <QPushButton>
@@ -6,66 +6,66 @@
 
 #include "revision_utils.hpp"
 
-MessageBox::MessageBox (QWidget * parent)
+JS8MessageBox::JS8MessageBox (QWidget * parent)
   : QMessageBox {parent}
 {
   setWindowTitle (program_title ());
 }
 
-MessageBox::MessageBox (Icon icon, QString const& text, StandardButtons buttons
+JS8MessageBox::JS8MessageBox (Icon icon, QString const& text, StandardButtons buttons
                         , QWidget * parent, Qt::WindowFlags flags)
   : QMessageBox {icon, QCoreApplication::applicationName (), text, buttons, parent, flags}
 {
 }
 
-void MessageBox::about_message (QWidget * parent, QString const& text)
+void JS8MessageBox::about_message (QWidget * parent, QString const& text)
 {
   QMessageBox::about (parent, program_title (), text);
 }
 
-void MessageBox::about_Qt_message (QWidget * parent)
+void JS8MessageBox::about_Qt_message (QWidget * parent)
 {
   QMessageBox::aboutQt (parent, program_title ());
 }
 
 namespace
 {
-  QMessageBox::StandardButton show_it (QWidget * parent, MessageBox::Icon icon
+  QMessageBox::StandardButton show_it (QWidget * parent, JS8MessageBox::Icon icon
                                        , QString const& text
                                        , QString const& informative
                                        , QString const& detail
-                                       , MessageBox::StandardButtons buttons
-                                       , MessageBox::StandardButton default_button)
+                                       , JS8MessageBox::StandardButtons buttons
+                                       , JS8MessageBox::StandardButton default_button)
   {
-    MessageBox mb {icon, text, MessageBox::NoButton, parent};
+    JS8MessageBox mb {icon, text, JS8MessageBox::NoButton, parent};
     QDialogButtonBox * button_box = mb.findChild<QDialogButtonBox *> ();
     Q_ASSERT (button_box);
 
-    uint mask = MessageBox::FirstButton;
-    while (mask <= MessageBox::LastButton) {
+    uint mask = JS8MessageBox::FirstButton;
+    while (mask <= JS8MessageBox::LastButton) {
       uint sb = buttons & mask;
       mask <<= 1;
       if (!sb)
         continue;
-      QPushButton * button = mb.addButton (static_cast<MessageBox::StandardButton> (sb));
+      QPushButton * button = mb.addButton (static_cast<JS8MessageBox::StandardButton> (sb));
       // Choose the first accept role as the default
       if (mb.defaultButton ())
         continue;
-      if ((default_button == MessageBox::NoButton
+      if ((default_button == JS8MessageBox::NoButton
            && button_box->buttonRole (button) == QDialogButtonBox::AcceptRole)
-          || (default_button != MessageBox::NoButton
+          || (default_button != JS8MessageBox::NoButton
               && sb == static_cast<uint> (default_button)))
         mb.setDefaultButton (button);
     }
     mb.setInformativeText (informative);
     mb.setDetailedText (detail);
     if (mb.exec() == -1)
-      return MessageBox::Cancel;
+      return JS8MessageBox::Cancel;
     return mb.standardButton (mb.clickedButton ());
   }
 }
 
-auto MessageBox::information_message (QWidget * parent, QString const& text
+auto JS8MessageBox::information_message (QWidget * parent, QString const& text
                                       , QString const& informative
                                       , QString const& detail
                                       , StandardButtons buttons
@@ -74,7 +74,7 @@ auto MessageBox::information_message (QWidget * parent, QString const& text
   return show_it (parent, Information, text, informative, detail, buttons, default_button);
 }
 
-auto MessageBox::query_message (QWidget * parent, QString const& text
+auto JS8MessageBox::query_message (QWidget * parent, QString const& text
                                 , QString const& informative
                                 , QString const& detail
                                 , StandardButtons buttons
@@ -83,7 +83,7 @@ auto MessageBox::query_message (QWidget * parent, QString const& text
   return show_it (parent, Question, text, informative, detail, buttons, default_button);
 }
 
-auto MessageBox::warning_message (QWidget * parent, QString const& text
+auto JS8MessageBox::warning_message (QWidget * parent, QString const& text
                                   , QString const& informative
                                   , QString const& detail
                                   , StandardButtons buttons
@@ -92,7 +92,7 @@ auto MessageBox::warning_message (QWidget * parent, QString const& text
   return show_it (parent, Warning, text, informative, detail, buttons, default_button);
 }
 
-auto MessageBox::critical_message (QWidget * parent, QString const& text
+auto JS8MessageBox::critical_message (QWidget * parent, QString const& text
                                    , QString const& informative
                                    , QString const& detail
                                    , StandardButtons buttons

--- a/JS8MessageBox.hpp
+++ b/JS8MessageBox.hpp
@@ -3,21 +3,19 @@
 
 #include <QMessageBox>
 
-// get rid of the nasty MS define
-#ifdef MessageBox
-#undef MessageBox
-#endif
-
-//
-// MessageBox - wrap the Qt QMessageBox class to give a more platform
-// 							neutral and functional interface
-//
-class MessageBox
+/**
+ * JS8MessageBox - wrap the Qt QMessageBox class to give a more platform
+ *							neutral and functional interface.
+ *
+ * Microsoft chose to #define MessageBox.
+ * We dogde the resulting problems by calling our MessageBox JS8MessageBox.
+ */
+class JS8MessageBox
   : public QMessageBox
 {
 public:
-  explicit MessageBox (QWidget * parent = nullptr);
-  explicit MessageBox (Icon, QString const& text, StandardButtons = NoButton
+  explicit JS8MessageBox (QWidget * parent = nullptr);
+  explicit JS8MessageBox (Icon, QString const& text, StandardButtons = NoButton
                        , QWidget * parent = nullptr
                        , Qt::WindowFlags = Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
 

--- a/MultiSettings.cpp
+++ b/MultiSettings.cpp
@@ -30,7 +30,7 @@
 #include "SettingsGroup.hpp"
 #include "qt_helpers.hpp"
 #include "SettingsGroup.hpp"
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 
 #include "pimpl_impl.hpp"
 
@@ -668,7 +668,7 @@ void MultiSettings::impl::clone_into_configuration (QMenu const * menu)
     {
       QString source_name {1 == sources.size () ? sources.at (0) : dialog.name ()};
       if (main_window_
-          && MessageBox::Yes == MessageBox::query_message (main_window_,
+          && JS8MessageBox::Yes == JS8MessageBox::query_message (main_window_,
                                                         tr ("Clone Into Configuration"),
                                                         tr ("Confirm overwrite of all values for configuration \"%1\" with values from \"%2\"?")
                                                         .arg (unescape_ampersands (target_name))
@@ -714,7 +714,7 @@ void MultiSettings::impl::reset_configuration (QMenu const * menu)
   auto const& target_name = menu->title ();
 
   if (!main_window_
-      || MessageBox::Yes != MessageBox::query_message (main_window_,
+      || JS8MessageBox::Yes != JS8MessageBox::query_message (main_window_,
                                                     tr ("Reset Configuration"),
                                                     tr ("Confirm reset to default values for configuration \"%1\"?")
                                                     .arg (unescape_ampersands (target_name))))
@@ -801,7 +801,7 @@ void MultiSettings::impl::delete_configuration (QMenu * menu)
   else
     {
       if (!main_window_
-          || MessageBox::Yes != MessageBox::query_message (main_window_,
+          || JS8MessageBox::Yes != JS8MessageBox::query_message (main_window_,
                                                         tr ("Delete Configuration"),
                                                         tr ("Confirm deletion of configuration \"%1\"?")
                                                         .arg (unescape_ampersands (target_name))))

--- a/NetworkAccessManager.hpp
+++ b/NetworkAccessManager.hpp
@@ -7,7 +7,7 @@
 #include <QNetworkReply>
 #include <QString>
 
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 
 class QNetworkRequest;
 class QIODevice;
@@ -44,7 +44,7 @@ public:
               {
                 certs += cert.toText () + '\n';
               }
-            if (MessageBox::Ignore == MessageBox::query_message (parent, tr ("Network SSL Errors"), message, certs, MessageBox::Abort | MessageBox::Ignore))
+            if (JS8MessageBox::Ignore == JS8MessageBox::query_message (parent, tr ("Network SSL Errors"), message, certs, JS8MessageBox::Abort | JS8MessageBox::Ignore))
               {
                 // accumulate new SSL error exceptions that have been allowed
                 allowed_ssl_errors_.append (new_errors);

--- a/js8call.pro
+++ b/js8call.pro
@@ -65,7 +65,7 @@ SOURCES += \
   main.cpp decodedtext.cpp messageaveraging.cpp \
   Modes.cpp \
   MessageAggregator.cpp qt_helpers.cpp\
-  MultiSettings.cpp PhaseEqualizationDialog.cpp IARURegions.cpp MessageBox.cpp \
+  MultiSettings.cpp PhaseEqualizationDialog.cpp IARURegions.cpp JS8MessageBox.cpp \
   EqualizationToolsDialog.cpp \
     varicode.cpp \
     NetworkMessage.cpp \
@@ -109,7 +109,7 @@ HEADERS  += qt_helpers.hpp \
   logbook/logbook.h logbook/countrydat.h logbook/countriesworked.h logbook/adif.h \
   messageaveraging.h Modes.hpp \
   MultiSettings.hpp PhaseEqualizationDialog.hpp \
-  IARURegions.hpp MessageBox.hpp EqualizationToolsDialog.hpp \
+  IARURegions.hpp JS8MessageBox.hpp EqualizationToolsDialog.hpp \
     qorderedmap.h \
     varicode.h \
     qpriorityqueue.h \

--- a/logqso.cpp
+++ b/logqso.cpp
@@ -10,7 +10,7 @@
 #include <QAbstractItemView>
 
 #include "logbook/adif.h"
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 #include "Configuration.hpp"
 #include "Bands.hpp"
 #include "Maidenhead.hpp"
@@ -270,14 +270,14 @@ void LogQSO::accept()
 
   if (!adifile.addQSOToFile (ADIF))
   {
-    MessageBox::warning_message (this, tr ("Log file error"),
+    JS8MessageBox::warning_message (this, tr ("Log file error"),
                                  tr ("Cannot open \"%1\"").arg (adifilePath));
   }
 
   //Log this QSO to file "js8call.log"
   static QFile f {QDir {QStandardPaths::writableLocation (QStandardPaths::AppLocalDataLocation)}.absoluteFilePath ("js8call.log")};
   if(!f.open(QIODevice::Text | QIODevice::Append)) {
-    MessageBox::warning_message (this, tr ("Log file error"),
+    JS8MessageBox::warning_message (this, tr ("Log file error"),
                                  tr ("Cannot open \"%1\" for append").arg (f.fileName ()),
                                  tr ("Error: %1").arg (f.errorString ()));
   } else {

--- a/main.cpp
+++ b/main.cpp
@@ -34,7 +34,7 @@
 #include "commons.h"
 #include "Radio.hpp"
 #include "FrequencyList.hpp"
-#include "MessageBox.hpp"       // last to avoid nasty MS macro definitions
+#include "JS8MessageBox.hpp"       // last to avoid nasty MS macro definitions
 
 #include "DriftingDateTime.h"
 
@@ -178,18 +178,18 @@ int main(int argc, char *argv[])
         {
           if (QLockFile::LockFailedError == instance_lock.error ())
             {
-              switch (MessageBox::query_message (nullptr
+              switch (JS8MessageBox::query_message (nullptr
                                                  , a.translate ("main", "Another instance may be running")
                                                  , a.translate ("main", "try to remove stale lock file?")
                                                  , QString {}
-                                                 , MessageBox::Yes | MessageBox::Retry | MessageBox::No
-                                                 , MessageBox::Yes))
+                                                 , JS8MessageBox::Yes | JS8MessageBox::Retry | JS8MessageBox::No
+                                                 , JS8MessageBox::Yes))
                 {
-                case MessageBox::Yes:
+                case JS8MessageBox::Yes:
                   instance_lock.removeStaleLockFile ();
                   break;
 
-                case MessageBox::Retry:
+                case JS8MessageBox::Retry:
                   break;
 
                 default:
@@ -217,19 +217,19 @@ int main(int argc, char *argv[])
           if (!temp_dir.mkpath (unique_directory)
               || !temp_dir.cd (unique_directory))
             {
-              MessageBox::critical_message (nullptr,
+              JS8MessageBox::critical_message (nullptr,
                                             a.translate ("main", "Failed to create a temporary directory"),
                                             a.translate ("main", "Path: \"%1\"").arg (temp_dir.absolutePath ()));
               throw std::runtime_error {"Failed to create a temporary directory"};
             }
           if (!temp_dir.isReadable () || !(temp_ok = QTemporaryFile {temp_dir.absoluteFilePath ("test")}.open ()))
             {
-              auto button =  MessageBox::critical_message (nullptr,
+              auto button =  JS8MessageBox::critical_message (nullptr,
                                                            a.translate ("main", "Failed to create a usable temporary directory"),
                                                            a.translate ("main", "Another application may be locking the directory"),
                                                            a.translate ("main", "Path: \"%1\"").arg (temp_dir.absolutePath ()),
-                                                           MessageBox::Retry | MessageBox::Cancel);
-              if (MessageBox::Cancel == button)
+                                                           JS8MessageBox::Retry | JS8MessageBox::Cancel);
+              if (JS8MessageBox::Cancel == button)
                 {
                   throw std::runtime_error {"Failed to create a usable temporary directory"};
                 }
@@ -279,12 +279,12 @@ int main(int argc, char *argv[])
     }
   catch (std::exception const& e)
     {
-      MessageBox::critical_message (nullptr, "Fatal error", e.what ());
+      JS8MessageBox::critical_message (nullptr, "Fatal error", e.what ());
       std::cerr << "Error: " << e.what () << '\n';
     }
   catch (...)
     {
-      MessageBox::critical_message (nullptr, "Unexpected fatal error");
+      JS8MessageBox::critical_message (nullptr, "Unexpected fatal error");
       std::cerr << "Unexpected fatal error\n";
       throw;			// hoping the runtime might tell us more about the exception
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -328,8 +328,8 @@ MainWindow::MainWindow(QString  const & program_info,
   m_settings_read {false},
   ui(new Ui::MainWindow),
   m_config {temp_directory, m_settings, this},
-  m_rigErrorMessageBox {MessageBox::Critical, tr ("Rig Control Error")
-      , MessageBox::Cancel | MessageBox::Ok | MessageBox::Retry},
+  m_rigErrorMessageBox {JS8MessageBox::Critical, tr ("Rig Control Error")
+      , JS8MessageBox::Cancel | JS8MessageBox::Ok | JS8MessageBox::Retry},
   m_wideGraph (new WideGraph(m_settings)),
   // no parent so that it has a taskbar icon
   m_logDlg (new LogQSO (program_title (), m_settings, &m_config, nullptr)),
@@ -417,7 +417,7 @@ MainWindow::MainWindow(QString  const & program_info,
 
   // parts of the rig error message box that are fixed
   m_rigErrorMessageBox.setInformativeText (tr ("Do you want to reconfigure the radio interface?"));
-  m_rigErrorMessageBox.setDefaultButton (MessageBox::Ok);
+  m_rigErrorMessageBox.setDefaultButton (JS8MessageBox::Ok);
 
   // start audio thread and hook up slots & signals for shutdown management
   // these objects need to be in the audio thread so that invoking
@@ -1104,7 +1104,7 @@ MainWindow::MainWindow(QString  const & program_info,
           if(Varicode::isCompoundCallsign(callsign)){
               m_config.addGroup(callsign);
           } else {
-              MessageBox::critical_message (this, QString("%1 is not a valid group").arg(callsign));
+              JS8MessageBox::critical_message (this, QString("%1 is not a valid group").arg(callsign));
           }
 
       } else {
@@ -1113,7 +1113,7 @@ MainWindow::MainWindow(QString  const & program_info,
               cd.call = callsign;
               m_callActivity[callsign] = cd;
           } else {
-              MessageBox::critical_message (this, QString("%1 is not a valid callsign or group").arg(callsign));
+              JS8MessageBox::critical_message (this, QString("%1 is not a valid callsign or group").arg(callsign));
           }
       }
 
@@ -2535,12 +2535,12 @@ void MainWindow::dataSink(qint64 frames)
 
 void MainWindow::showSoundInError(const QString& errorMsg)
 {
-  MessageBox::critical_message (this, tr ("Error in Sound Input"), errorMsg);
+  JS8MessageBox::critical_message (this, tr ("Error in Sound Input"), errorMsg);
 }
 
 void MainWindow::showSoundOutError(const QString& errorMsg)
 {
-  MessageBox::critical_message (this, tr ("Error in Sound Output"), errorMsg);
+  JS8MessageBox::critical_message (this, tr ("Error in Sound Output"), errorMsg);
 }
 
 void MainWindow::showStatusMessage(const QString& statusMsg)
@@ -3247,7 +3247,7 @@ void MainWindow::on_actionCopyright_Notice_triggered()
                            "Philip Karn, KA9Q; and other members of the WSJT Development Group.\n\n"
                            "Further, the source code of JS8Call contains material Copyright (C) "
                            "2018-2019 by Jordan Sherer, KN4CRD.\"");
-  MessageBox::warning_message(this, message);
+  JS8MessageBox::warning_message(this, message);
 }
 
 /**
@@ -4581,7 +4581,7 @@ void MainWindow::refuseToSendIn30mWSPRBand() {
                 QTimer::singleShot (
                     0,
                     [this]{
-                        MessageBox::warning_message(
+                        JS8MessageBox::warning_message(
                             this,
                             tr("WSPR Guard Band"),
                             tr("Please choose another Tx frequency."
@@ -5406,13 +5406,13 @@ void MainWindow::resetMessageUI(){
 
 bool MainWindow::ensureCallsignSet(bool alert){
     if(m_config.my_callsign().trimmed().isEmpty()){
-        if(alert) MessageBox::warning_message(this, tr ("Please enter your callsign in the settings."));
+        if(alert) JS8MessageBox::warning_message(this, tr ("Please enter your callsign in the settings."));
         openSettings();
         return false;
     }
 
     if(m_config.my_grid().trimmed().isEmpty()){
-        if(alert) MessageBox::warning_message(this, tr ("Please enter your grid locator in the settings."));
+        if(alert) JS8MessageBox::warning_message(this, tr ("Please enter your grid locator in the settings."));
         openSettings();
         return false;
     }
@@ -5967,7 +5967,7 @@ void MainWindow::acceptQSO (QDateTime const& QSO_date_off, QString const& call, 
     if (rzult == -1) {
       bool hidden = m_logDlg->isHidden();
       m_logDlg->setHidden(true);
-      MessageBox::warning_message (this, tr ("Error sending log to N1MM"),
+      JS8MessageBox::warning_message (this, tr ("Error sending log to N1MM"),
                                    tr ("Write returned \"%1\"").arg (rzult));
       m_logDlg->setHidden(hidden);
     }
@@ -6039,7 +6039,7 @@ void MainWindow::acceptQSO (QDateTime const& QSO_date_off, QString const& call, 
       } else {
           bool hidden = m_logDlg->isHidden();
           m_logDlg->setHidden(true);
-          MessageBox::warning_message (this, tr ("Error sending log to N3FJP"),
+          JS8MessageBox::warning_message (this, tr ("Error sending log to N3FJP"),
                                        tr ("Write failed for \"%1:%2\"").arg (host).arg(port));
           m_logDlg->setHidden(hidden);
       }
@@ -6215,9 +6215,9 @@ MainWindow::setFreq(int const n)
 
 void MainWindow::on_actionErase_ALL_TXT_triggered()          //Erase ALL.TXT
 {
-  int ret = MessageBox::query_message (this, tr ("Confirm Erase"),
+  int ret = JS8MessageBox::query_message (this, tr ("Confirm Erase"),
                                          tr ("Are you sure you want to erase file ALL.TXT?"));
-  if(ret==MessageBox::Yes) {
+  if(ret==JS8MessageBox::Yes) {
     QFile f {m_config.writeable_data_dir ().absoluteFilePath ("ALL.TXT")};
     f.remove();
     m_RxLog=1;
@@ -6226,9 +6226,9 @@ void MainWindow::on_actionErase_ALL_TXT_triggered()          //Erase ALL.TXT
 
 void MainWindow::on_actionErase_js8call_log_adi_triggered()
 {
-  int ret = MessageBox::query_message (this, tr ("Confirm Erase"),
+  int ret = JS8MessageBox::query_message (this, tr ("Confirm Erase"),
                                        tr ("Are you sure you want to erase file js8call_log.adi?"));
-  if(ret==MessageBox::Yes) {
+  if(ret==JS8MessageBox::Yes) {
     QFile f {m_config.writeable_data_dir ().absoluteFilePath ("js8call_log.adi")};
     f.remove();
 
@@ -7843,16 +7843,16 @@ void MainWindow::rigFailure (QString const& reason)
         {
           switch (m_rigErrorMessageBox.standardButton (clicked_button))
             {
-            case MessageBox::Ok:
+            case JS8MessageBox::Ok:
               m_config.select_tab (1);
               QTimer::singleShot (0, this, &MainWindow::on_actionSettings_triggered);
               break;
 
-            case MessageBox::Retry:
+            case JS8MessageBox::Retry:
               QTimer::singleShot (0, this, &MainWindow::rigOpen);
               break;
 
-            case MessageBox::Cancel:
+            case JS8MessageBox::Cancel:
               QTimer::singleShot (0, this, &MainWindow::close);
               break;
 
@@ -11369,7 +11369,7 @@ void MainWindow::write_frequency_entry (QString const& file_name){
       this,
       message = tr("Cannot open \"%1\" for append: %2").arg(f2.fileName()).arg(f2.errorString())
     ]{
-      MessageBox::warning_message(this, tr("Log File Error"), message);
+      JS8MessageBox::warning_message(this, tr("Log File Error"), message);
     });
   }
 }
@@ -11399,7 +11399,7 @@ void MainWindow::write_transmit_entry (QString const& file_name)
         this,
         message = tr("Cannot open \"%1\" for append: %2").arg(f.fileName()).arg(f.errorString())
       ] {
-        MessageBox::warning_message(this, tr("Log File Error"), message);
+        JS8MessageBox::warning_message(this, tr("Log File Error"), message);
       });
     }
 }
@@ -11436,7 +11436,7 @@ MainWindow::writeAllTxt(QStringView message)
   }
   else
   {
-    MessageBox::warning_message(this,
+    JS8MessageBox::warning_message(this,
                                tr("File Open Error"),
                                tr("Cannot open \"%1\" for append: %2")
                                .arg(f.fileName())
@@ -11469,7 +11469,7 @@ MainWindow::writeMsgTxt(QStringView message,
     }
     else
     {
-      MessageBox::warning_message(this,
+      JS8MessageBox::warning_message(this,
                                   tr("File Open Error"),
                                   tr("Cannot open \"%1\" for append: %2")
                                   .arg(f.fileName())

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -43,7 +43,7 @@
 #include "PSKReporter.hpp"
 #include "logbook/logbook.h"
 #include "commons.h"
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 #include "NetworkAccessManager.hpp"
 #include "qpriorityqueue.h"
 #include "varicode.h"
@@ -435,7 +435,7 @@ private:
 
   // other windows
   Configuration m_config;
-  MessageBox m_rigErrorMessageBox;
+  JS8MessageBox m_rigErrorMessageBox;
 
   QScopedPointer<WideGraph> m_wideGraph;
   QScopedPointer<LogQSO> m_logDlg;

--- a/widegraph.cpp
+++ b/widegraph.cpp
@@ -12,7 +12,7 @@
 #include "Configuration.hpp"
 #include "DriftingDateTime.h"
 #include "EventFilter.hpp"
-#include "MessageBox.hpp"
+#include "JS8MessageBox.hpp"
 #include "SettingsGroup.hpp"
 #include "varicode.h"
 
@@ -790,7 +790,7 @@ WideGraph::readPalette()
   }
   catch (std::exception const & e)
   {
-    MessageBox::warning_message(this, tr("Read Palette"), e.what());
+    JS8MessageBox::warning_message(this, tr("Read Palette"), e.what());
   }
 }
 
@@ -821,7 +821,7 @@ WideGraph::on_adjust_palette_push_button_clicked(bool)
   }
   catch (std::exception const & e)
   {
-    MessageBox::warning_message(this, tr("Read Palette"), e.what());
+    JS8MessageBox::warning_message(this, tr("Read Palette"), e.what());
   }
 }
 


### PR DESCRIPTION
When compiling for MS Windows, the usual suspect MS compilers `#define` a macro `MessageBox`.

We previously tried to stay sane in this madness by `#undef MessageBox` , but this turned out to be an unstable fix in view of updates that our intended code format utility does.  For this specific reason and for general stability, it is better to evade the problem by renaming our `MessageBox` class to something else. This systematic renaming is done in this PR.