### PR TITLE
Update the About dialog to include FFmpeg notice

### DIFF
--- a/about.cpp
+++ b/about.cpp
@@ -3,47 +3,49 @@
 #include "revision_utils.hpp"
 #include "ui_about.h"
 
-CAboutDlg::CAboutDlg(QWidget *parent) :
-  QDialog(parent),
-  ui(new Ui::CAboutDlg)
+CAboutDlg::CAboutDlg(QWidget* parent) : QDialog(parent), ui(new Ui::CAboutDlg)
 {
-  ui->setupUi(this);
-  setWindowTitle("About JS8Call-improved");
-  ui->labelTxt->setText (QString{"<h2>%1</h2>"
-                         "<h3>What is JS8Call-improved?</h3>"
-                         "<p>It is the result of a team that continued development of js8call and added further improvements.<br />This team includes: <br />Chris AC9KH, Allan W6BAZ, Wyatt KJ4CTD, Joe K0OG, Andreas DJ3EI, Rob Ruchte K4RWR.</p>"
-                          "<p>The JS8Call-improved code lives in "
-                                 "<a href=\"https://github.com/JS8Call-improved/JS8Call-improved\">https://github.com/JS8Call-improved/JS8Call-improved</a> .</p>"
-                         "<h3>What is JS8Call?</h3>"
-                         "<p>JS8Call is a derivative of the WSJT-X application, "
-                         "restructured and redesigned for message passing. <br/>"
-                         "It is not supported by nor endorsed by the WSJT-X "
-                         "development group. <br/>JS8Call is "
-                         "licensed under and in accordance with the terms "
-                         "of the <a href=\"https://www.gnu.org/licenses/gpl-3.0.txt\">GPLv3 license</a>.<br/>"
-                         "The source code modifications are public and can be found in <a href=\"https://github.com/js8call/js8call\">this repository</a>.<br/><br/>"
-
-                         "JS8Call is heavily inspired by WSJT-X, Fldigi, "
-                         "and FSQCall <br/>and would not exist without the hard work and "
-                         "dedication of the many <br/>developers in the amateur radio "
-                         "community.<br /><br />"
-                         "JS8Call stands on the shoulder of giants...the takeoff angle "
-                         "is better up there.<br /><br />"
-                         "A special thanks goes out to:<br/><br/><strong>"
-                         "KC9QNE, "
-                         "KI6SSI, "
-                         "K0OG, "
-                         "LB9YH, "
-                         "M0IAX, "
-                         "N0JDS, "
-                         "OH8STN, "
-                         "VA3OSO, "
-                         "VK1MIC, "
-                         "W0FW, "
-                         "W6BAZ,</strong><br/><br/>and the many other amateur radio operators who have helped<br/>"
-                         "bring JS8Call into the world.</p>"}.arg(program_title()));
+    ui->setupUi(this);
+    setWindowTitle("About JS8Call-improved");
+    ui->labelTxt->setText(QString
+        {
+        "<h2>%1</h2>"
+        "<h3>What is JS8Call-improved?</h3>"
+        "<p align='left'>It is the result of a team that continued development of js8call and "
+        "added further improvements.<br />This team includes: <br />Chris AC9KH, Allan W6BAZ, "
+        "Wyatt KJ4CTD, Joe K0OG, Andreas DJ3EI, Rob K4RWR.<br /><br />"
+        "The JS8Call-improved code lives in "
+        "<a href=\"https://github.com/JS8Call-improved/JS8Call-improved\">https://github.com/"
+        "JS8Call-improved/JS8Call-improved</a> .<br /><br />"
+        "This software uses libraries from the FFmpeg project under the LGPLv2.1</p>"
+        "<h3>What is JS8Call?</h3>"
+        "<p align='left'>JS8Call is a derivative of the WSJT-X application, "
+        "restructured and redesigned for message passing. <br/>"
+        "It is not supported by nor endorsed by the WSJT-X "
+        "development group. <br/>JS8Call is "
+        "licensed under and in accordance with the terms "
+        "of the <a href=\"https://www.gnu.org/licenses/gpl-3.0.txt\">GPLv3 license</a>.<br/>"
+        "The source code modifications are public and can be found in <a "
+        "href=\"https://github.com/js8call/js8call\">this repository</a>.<br/><br/>"
+        
+        "JS8Call is heavily inspired by WSJT-X, Fldigi and FSQCall and would not exist without the hard work<br />"
+        "and dedication of the many developers in the amateur radio community.<br /><br />"
+        "JS8Call stands on the shoulder of giants...the takeoff angle is better up there.<br /><br />"
+        "A special thanks goes out to:<br/><br/><strong>"
+        "KC9QNE, "
+        "KI6SSI, "
+        "K0OG, "
+        "LB9YH, "
+        "M0IAX, "
+        "N0JDS, "
+        "OH8STN, "
+        "VA3OSO, "
+        "VK1MIC, "
+        "W0FW, "
+        "W6BAZ,</strong><br/><br/>"
+        "and the many other amateur radio operators who have helped bring JS8Call into the world.</p>"
+        }
+    .arg(program_title()));
 }
 
-CAboutDlg::~CAboutDlg()
-{
-}
+CAboutDlg::~CAboutDlg() {}


### PR DESCRIPTION
Update the About dialog to conform to the FFmpeg licensing. Reformatted the presentation so the text doesn't look like a christmas tree.

This is what it looks after the rebuild:

<img width="758" height="596" alt="Screenshot 2025-11-29 at 17 42 31" src="https://github.com/user-attachments/assets/878a9376-a86c-4308-b627-3afbc7e18bce" />

The width of the dialog auto-adjusts to the widest string. Get rid of the NOT_FOR_RELEASE in the header and box is narrower, but still a nicer presentation than it was.