### PR TITLE
Add 5363kHz to the frequency list for the new 60m band segment

### DIFF
--- a/FrequencyList.cpp
+++ b/FrequencyList.cpp
@@ -28,6 +28,7 @@ namespace
     {
       {  1842000, Modes::JS8, IARURegions::ALL}, // 2 above
       {  3578000, Modes::JS8, IARURegions::ALL}, // 5 above
+      {  5363000, Modes::JS8, IARURegions::ALL}, // not known at this time where FT8 will be
       {  7078000, Modes::JS8, IARURegions::ALL}, // 4 above
       { 10130000, Modes::JS8, IARURegions::ALL}, // 6 below
       { 14078000, Modes::JS8, IARURegions::ALL}, // 4 above


### PR DESCRIPTION
This adds the 5363 kHz frequency to the frequency list for the new 60m band segment when it becomes available.