### PR TITLE
Fix duplicate callsign in RX.DIRECTED TCP messages

### DIFF
--- a/JS8_Mainwindow/processCommandActivity.cpp
+++ b/JS8_Mainwindow/processCommandActivity.cpp
@@ -150,7 +150,7 @@ void MainWindow::processCommandActivity() {
                  {"CMD", QVariant(d.cmd)},
                  {"GRID", QVariant(d.grid)},
                  {"EXTRA", QVariant(d.extra)},
-                 {"TEXT", QVariant(text)},
+                 {"TEXT", QVariant(d.text)},
                  {"FREQ", QVariant(d.dial + d.offset)},
                  {"DIAL", QVariant(d.dial)},
                  {"OFFSET", QVariant(d.offset)},


### PR DESCRIPTION
Summary

Fixed bug where the callsign was duplicated in TCP output for RX.DIRECTED messages.

The Problem

The TEXT param in the RX.DIRECTED JSON message contained the full formatted string (which already includes the FROM callsign). When TCP clients reconstruct the display using FROM + ": " + TEXT, the callsign appears twice.

DIRECTED.txt (correct):
2025-12-06 16:07:27    14.078000    2025    -03    K9BTR: N0ASH HEARTBEAT SNR -19 ♢
2025-12-06 16:07:27    14.078000    2025    +06    WA3YWU: N0ASH HEARTBEAT SNR -06 ♢

TCP output (buggy):
2025-12-06 16:07:27    14.078000    2025    -03    K9BTR: K9BTR: N0ASH HEARTBEAT SNR -19 ♢
2025-12-06 16:07:27    14.078000    2025    +06    WA3YWU: WA3YWU: N0ASH HEARTBEAT SNR -06 ♢

The Fix

Changed TEXT param from "text" (full formatted message) to "d.text" (message body only).