### PR TITLE
Addresses issue #103, dark mode cleanup

### DIFF
--- a/JS8_UI/Configuration.h
+++ b/JS8_UI/Configuration.h
@@ -1,7 +1,9 @@
 #ifndef CONFIGURATION_HPP_
 #define CONFIGURATION_HPP_
 
+#include <QAction>
 #include <QFont>
+#include <QLineEdit>
 #include <QObject>
 
 #include "JS8_Audio/AudioDevice.h"

--- a/JS8_UI/Configuration.ui
+++ b/JS8_UI/Configuration.ui
@@ -2054,9 +2054,6 @@ transmitting periods.</string>
                 <property name="autoFillBackground">
                  <bool>false</bool>
                 </property>
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);</string>
-                </property>
                 <property name="text">
                  <string>TextLabel</string>
                 </property>
@@ -3101,28 +3098,7 @@ Click, SHIFT+Click and, CRTL+Click to select items</string>
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
 }
 
-QListView::item:alternate {
-    background: #EEEEEE;
-}
-
-QListView::item:selected {
-    border: 1px solid #6a6ea9;
-}
-
-QListView::item:selected:!active {
-    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                stop: 0 #ABAFE5, stop: 1 #8588B2);
-}
-
-QListView::item:selected:active {
-    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                stop: 0 #6a6ea9, stop: 1 #888dd9);
-}
-
-QListView::item:hover {
-    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                stop: 0 #FAFBFE, stop: 1 #DCDEF1);
-}</string>
+</string>
          </property>
          <property name="dragDropMode">
           <enum>QAbstractItemView::DragDropMode::InternalMove</enum>


### PR DESCRIPTION
- Removes explicit background color specifications
- Adds alert icons to the callsign and grid, entry fields when they are empty
- Removes custom styles from saved messages list