### PR TITLE
Give directed commands higher priority over messaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,7 @@ set(PROJECT_COPYRIGHT "Copyright (C) 2001-2018 by Joe Taylor, K1JT, (C) 2018 by 
 set(PROJECT_HOMEPAGE https://groups.io/g/js8call)
 set(PROJECT_SUMMARY_DESCRIPTION "${PROJECT_NAME} - Digital Modes for Weak Signal Communications in Amateur Radio.")
 set(PROJECT_DESCRIPTION "${PROJECT_SUMMARY_DESCRIPTION}
- ${PROJECT_NAME} is a computer program designed to facilitate amateur
- radio communication using very weak signals.")
+ ${PROJECT_NAME} is a computer program designed to facilitate amateur radio communication using very weak signals.")
 
 #------------------------------------------------------------------------------#
 # Add our own CMake modules.
@@ -174,7 +173,7 @@ qt_add_executable(${TARGET} MACOSX_BUNDLE WIN32 ${ICON_FILE})
 set_target_properties(
   ${TARGET} PROPERTIES
   MACOSX_BUNDLE_INFO_PLIST             "${CMAKE_CURRENT_SOURCE_DIR}/Darwin/Info.plist.in"
-  MACOSX_BUNDLE_INFO_STRING            "JS8 mode providing weak signal communications for Amateur Radio"
+  MACOSX_BUNDLE_INFO_STRING            "JS8Call facilitates amateur radio communication using very weak signals.."
   MACOSX_BUNDLE_ICON_FILE              "${ICON_FILE}"
   MACOSX_BUNDLE_BUNDLE_VERSION         "${wsjtx_VERSION}"
   MACOSX_BUNDLE_SHORT_VERSION_STRING   "${wsjtx_SHORT_VERSION}"

--- a/JS8_Mainwindow/processCommandActivity.cpp
+++ b/JS8_Mainwindow/processCommandActivity.cpp
@@ -326,18 +326,14 @@ void UI_Constructor::processCommandActivity() {
         int freq = -1;
 
         // QUERIED SNR
-        // Only reply to a SNR request if there is no incoming MSG's and is not
-        // directed to AllCall
-        if (d.cmd == " SNR?" && !isAllCall && m_messageBuffer.isEmpty()) {
+        if (d.cmd == " SNR?" && !isAllCall) {
             reply = QString("%1 SNR %2")
                         .arg(d.from)
                         .arg(Varicode::formatSNR(d.snr));
         }
 
         // QUERIED INFO
-        // Only reply to a INFO request if there is no incoming MSG's and is not
-        // directed to AllCall
-        else if (d.cmd == " INFO?" && !isAllCall && m_messageBuffer.isEmpty()) {
+        else if (d.cmd == " INFO?" && !isAllCall) {
             QString info = m_config.my_info();
             if (info.isEmpty()) {
                 continue;
@@ -349,10 +345,7 @@ void UI_Constructor::processCommandActivity() {
         }
 
         // QUERIED ACTIVE
-        // Only reply to a STATUS request if there is no incoming MSG's and is
-        // not directed to AllCall
-        else if (d.cmd == " STATUS?" && !isAllCall &&
-                 m_messageBuffer.isEmpty()) {
+        else if (d.cmd == " STATUS?" && !isAllCall) {
             QString status = m_config.my_status();
             if (status.isEmpty()) {
                 continue;
@@ -364,9 +357,7 @@ void UI_Constructor::processCommandActivity() {
         }
 
         // QUERIED GRID
-        // Only reply to a GRID request if there is no incoming MSG's and is not
-        // directed to AllCall
-        else if (d.cmd == " GRID?" && !isAllCall && m_messageBuffer.isEmpty()) {
+        else if (d.cmd == " GRID?" && !isAllCall) {
             QString grid = m_config.my_grid();
             if (grid.isEmpty()) {
                 continue;
@@ -376,10 +367,7 @@ void UI_Constructor::processCommandActivity() {
         }
 
         // QUERIED STATIONS HEARD
-        // Only reply to a HEARING request if there is no incoming MSG's and is
-        // not directed to AllCall
-        else if (d.cmd == " HEARING?" && !isAllCall &&
-                 m_messageBuffer.isEmpty()) {
+        else if (d.cmd == " HEARING?" && !isAllCall) {
             auto calls = m_callActivity.keys();
 
             std::stable_sort(calls.begin(), calls.end(),
@@ -916,11 +904,8 @@ void UI_Constructor::processCommandActivity() {
         }
 
         // PROCESS BUFFERED QUERY MSGS
-        // Do not process this request if there is incoming MSG as it breaks the
-        // incoming
         else if (d.cmd == " QUERY MSGS" &&
-                 ui->actionModeAutoreply->isChecked() &&
-                 m_messageBuffer.isEmpty()) {
+                 ui->actionModeAutoreply->isChecked()) {
             auto who = d.from; // keep in mind, this is the sender, not the
                                // original requestor if relayed
             auto replyPath = d.from;
@@ -958,11 +943,8 @@ void UI_Constructor::processCommandActivity() {
         }
 
         // PROCESS BUFFERED QUERY CALL
-        // Do not process this request if there is incoming MSG as it breaks the
-        // incoming
         else if (d.cmd == " QUERY CALL" &&
-                 ui->actionModeAutoreply->isChecked() &&
-                 m_messageBuffer.isEmpty()) {
+                 ui->actionModeAutoreply->isChecked()) {
             auto replyPath = d.from;
             if (d.relayPath.contains(">")) {
                 replyPath = d.relayPath;

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -5433,8 +5433,6 @@ void UI_Constructor::displayTransmit() {
 bool UI_Constructor::presentlyWantHBReplies() {
     return ui->actionModeAutoreply->isChecked() &&
            ui->actionHeartbeatAcknowledgements->isChecked() &&
-           // The folloing line is disputed, as it disallows replies to HBs
-           // if there is any (unrelated) activity on the band:
            m_messageBuffer.isEmpty() &&
            (!m_config.heartbeat_qso_pause() ||
             m_prevSelectedCallsign.isEmpty());


### PR DESCRIPTION
On groups.io it is claimed people are not getting their regularly scheduled SNR reports on time. JS8Call is primarily an automatic beaconing and signal reporting system, messaging is secondary. For weak-signal messaging it is probably advisable to switch to Olivia 8/250 with Reed Solomon ID anyway since it is faster and much more reliable than JS8, and doesn't rely on frame timing.

So this changes JS8Call to full Automatic Animal Mode so it will break MSG'ing with directed commands, which is what people want because they don't care about MSG'ing - uncontrolled automatic operation is the main MO. But it retains suppressing HB ACK for an incoming MSG.

And changes the description of the program to be more accurate.

I would suggest cherry-picking this to current release and push out a 2.5.2 patch release, since people are upset about not getting their (RSSR's) Regularly Scheduled Signal Reports.