### PR TITLE
Fix duplicate callsign in TCP API RX.DIRECTED messages

### DIFF
--- a/JS8_Mainwindow/processCommandActivity.cpp
+++ b/JS8_Mainwindow/processCommandActivity.cpp
@@ -150,7 +150,7 @@ void UI_Constructor::processCommandActivity() {
         // write all directed messages to api
         if (canSendNetworkMessage()) {
             sendNetworkMessage(
-                "RX.DIRECTED", text,
+                "RX.DIRECTED", d.text,
                 {{"_ID", QVariant(-1)},
                  {"FROM", QVariant(d.from)},
                  {"TO", QVariant(d.to)},


### PR DESCRIPTION
## Summary
- Fix duplicate callsign appearing in TCP API RX.DIRECTED messages
- Changed `value` field from formatted `text` to raw `d.text` to avoid FROM prefix duplication

When JS8Call sends directed messages via TCP API, the sender's callsign was appearing twice (e.g., `W9TEK: W9TEK: KC1QKM SNR -05`). This was because the `value` field used the formatted `text` variable which already includes the FROM prefix. TCP clients that reconstruct messages as `FROM + ": " + value` would get duplicates.

## Test plan
- [ ] Build the project
- [ ] Receive directed messages via TCP API
- [ ] Verify RX.DIRECTED `value` field no longer contains duplicate callsign

🤖 Generated with [Claude Code](https://claude.com/claude-code)