### PR TITLE
Addresses issue #182 - Notification sound playback problems

### DIFF
--- a/JS8_Audio/BWFFile.cpp
+++ b/JS8_Audio/BWFFile.cpp
@@ -156,6 +156,8 @@ class BWFFile::impl final {
     InfoDictionary info_dictionary_;
     qint64 header_length_;
     qint64 data_size_;
+    quint16 bits_per_sample_{0};
+    quint16 block_align_{0};
     FileError error_;
 };
 
@@ -212,36 +214,63 @@ bool BWFFile::impl::read_header() {
                         bext_ = file_.read(wave_size);
                     }
                     if (!memcmp(&wave_desc.id_, "fmt ", 4)) {
-                        FormatChunk fmt;
-                        if (file_.read(reinterpret_cast<char *>(&fmt),
-                                       sizeof fmt) != sizeof fmt)
+                        if (wave_size < sizeof(FormatChunk)) {
                             return false;
-                        auto audio_format =
-                            be ? qFromBigEndian<quint16>(fmt.audio_format)
-                               : qFromLittleEndian<quint16>(fmt.audio_format);
-                        if (audio_format != 0 && audio_format != 1)
+                        }
+
+                        FormatChunk fmt;
+                        if (file_.read(reinterpret_cast<char*>(&fmt), sizeof fmt) != sizeof fmt) {
+                            return false;
+                        }
+
+                        const auto audio_format = be ? qFromBigEndian<quint16>(fmt.audio_format)
+                                                     : qFromLittleEndian<quint16>(fmt.audio_format);
+                        if (audio_format != 0 && audio_format != 1 && audio_format != 3) {
                             return false; // not PCM nor undefined
-                        //                      format_.setByteOrder (be ?
-                        //                      QSysInfo::BigEndian :
-                        //                      QSysInfo::LittleEndian);
-                        format_.setChannelCount(
-                            be ? qFromBigEndian<quint16>(fmt.num_channels)
-                               : qFromLittleEndian<quint16>(fmt.num_channels));
-                        format_.setSampleRate(
-                            be ? qFromBigEndian<quint32>(fmt.sample_rate)
-                               : qFromLittleEndian<quint32>(fmt.sample_rate));
-                        //                      int bits_per_sample {be ?
-                        //                      qFromBigEndian<quint16>
-                        //                      (fmt.bits_per_sample) :
-                        //                      qFromLittleEndian<quint16>
-                        //                      (fmt.bits_per_sample)};
-                        format_.setSampleFormat(QAudioFormat::Int16);
-                        //                      format_.setSampleSize
-                        //                      (bits_per_sample);
-                        //                      format_.setSampleType (8 ==
-                        //                      bits_per_sample ?
-                        //                      QAudioFormat::UnSignedInt :
-                        //                      QAudioFormat::SignedInt);
+                        }
+
+                        const auto ch   = be ? qFromBigEndian<quint16>(fmt.num_channels)
+                                             : qFromLittleEndian<quint16>(fmt.num_channels);
+                        const auto rate = be ? qFromBigEndian<quint32>(fmt.sample_rate)
+                                             : qFromLittleEndian<quint32>(fmt.sample_rate);
+                        const auto bits = be ? qFromBigEndian<quint16>(fmt.bits_per_sample)
+                                             : qFromLittleEndian<quint16>(fmt.bits_per_sample);
+                        const auto ba   = be ? qFromBigEndian<quint16>(fmt.block_align)
+                                             : qFromLittleEndian<quint16>(fmt.block_align);
+
+                        if (audio_format == 3 && bits != 32) {
+                            return false;
+                        }
+
+                        bits_per_sample_ = bits;
+                        block_align_ = ba;
+
+                        format_.setChannelCount(ch);
+                        format_.setSampleRate(rate);
+
+                        switch (bits) {
+                            case 8:  format_.setSampleFormat(QAudioFormat::UInt8); break;
+                            case 16: format_.setSampleFormat(QAudioFormat::Int16); break;
+                            case 24: format_.setSampleFormat(QAudioFormat::Int32); break; // NOTE: we'll convert data to int32
+                            case 32:
+                                if (audio_format == 3) {
+                                    format_.setSampleFormat(QAudioFormat::Float);   // 32-bit float WAV
+                                } else {
+                                    format_.setSampleFormat(QAudioFormat::Int32);   // 32-bit int PCM
+                                }
+                                break;
+                        default:
+                            return false; // no 24-bit packed etc
+                        }
+
+                        if (bits != 24) {
+                            if (ba != format_.bytesPerFrame())
+                                return false;
+                        } else {
+                            // 24-bit packed: header must say 3 bytes/sample
+                            if (ba != ch * 3)
+                                return false;
+                        }
                     } else if (!memcmp(&wave_desc.id_, "data", 4)) {
                         data_size_ = wave_size;
                         header_length_ = file_.pos();
@@ -867,6 +896,9 @@ qint64 BWFFile::size() const {
 }
 
 bool BWFFile::isSequential() const { return m_->file_.isSequential(); }
+
+quint16 BWFFile::bitsPerSample() const { return m_->bits_per_sample_; }
+quint16 BWFFile::blockAlign() const { return m_->block_align_; }
 
 void BWFFile::close() {
     if (isOpen())

--- a/JS8_Audio/BWFFile.h
+++ b/JS8_Audio/BWFFile.h
@@ -181,6 +181,9 @@ class BWFFile : public QIODevice {
 
     bool isSequential() const override;
 
+    quint16 bitsPerSample() const;
+    quint16 blockAlign() const;
+
     // The reset  operation clears the  'bext' and LIST-INFO as  if they
     // were  never supplied.  If the  file  is writable  the 'bext'  and
     // LIST-INFO chunks will not be  written making the resulting file a

--- a/JS8_Audio/NotificationAudio.cpp
+++ b/JS8_Audio/NotificationAudio.cpp
@@ -66,12 +66,43 @@ void NotificationAudio::setDevice(QAudioDevice const &device,
 void NotificationAudio::play(QString const &filePath) {
     if (auto const it = m_cache.constFind(filePath); it != m_cache.constEnd()) {
         playEntry(it);
-    } else if (auto file = BWFFile(QAudioFormat{}, filePath);
-               file.open(QIODevice::ReadOnly)) {
-        if (auto data = file.readAll(); !data.isEmpty()) {
-            playEntry(m_cache.emplace(filePath, file.format(), data));
-        }
+        return;
     }
+
+    BWFFile file(QAudioFormat{}, filePath);
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    QByteArray data = file.readAll();
+    if (data.isEmpty())
+        return;
+
+    QAudioFormat fmt = file.format();
+
+    if (!m_device.isFormatSupported(fmt)) {
+        error("Requested output audio format is not supported on device.");
+        return;
+    }
+
+    // If source is 24-bit packed PCM, repack to Int32
+    if (file.bitsPerSample() == 24) {
+        QByteArray converted = pcm24le_to_int32le(data);
+        if (converted.isEmpty()) {
+            error("Bad 24-bit PCM size");
+            return;
+        }
+        data = std::move(converted);
+        fmt.setSampleFormat(QAudioFormat::Int32);
+        // keep sampleRate + channelCount from file.format()
+    }
+
+    // Mono -> stereo so mono files play through both speakers
+    if (!upmixMonoToStereoInPlace(fmt, data)) {
+        error("Unsupported mono upmix format");
+        return;
+    }
+
+    playEntry(m_cache.emplace(filePath, fmt, data));
 }
 
 /**
@@ -94,6 +125,137 @@ void NotificationAudio::playEntry(Cache::const_iterator const it) {
     if (m_buffer.open(QIODevice::ReadOnly)) {
         m_stream->setDeviceFormat(m_device, format, m_msBuffer);
         m_stream->restart(&m_buffer);
+    }
+}
+
+/**
+ * @brief Convert 24-bit PCM to 32-bit PCM
+ * @param PCM data byte array
+ */
+QByteArray NotificationAudio::pcm24le_to_int32le(const QByteArray& in)
+{
+    if ((in.size() % 3) != 0) return {};
+
+    const int samples = in.size() / 3;
+    QByteArray out;
+    out.resize(samples * 4);
+
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(in.constData());
+    int32_t* dst = reinterpret_cast<int32_t*>(out.data());
+
+    for (int i = 0; i < samples; ++i) {
+        int32_t v = (int32_t(src[0])      ) |
+                    (int32_t(src[1]) <<  8) |
+                    (int32_t(src[2]) << 16);
+
+        // sign extend 24 -> 32
+        if (v & 0x00800000) v |= 0xFF000000;
+
+        // scale to full 32-bit range (optional but common)
+        dst[i] = v << 8;
+
+        src += 3;
+    }
+    return out;
+}
+
+/**
+ * @brief Convert mono PCM data to stereo
+ * @param fmt The audio format
+ * @param data The audio data byte array
+ * @return true if upmix was successful, false otherwise
+ */
+bool NotificationAudio::upmixMonoToStereoInPlace(QAudioFormat& fmt, QByteArray& data)
+{
+    if (fmt.channelCount() != 1)
+        return true; // nothing to do
+
+    switch (fmt.sampleFormat()) {
+    case QAudioFormat::UInt8: {
+        // 1 byte/sample -> 2 bytes/frame (L,R)
+        QByteArray out;
+        out.resize(data.size() * 2);
+
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(data.constData());
+        uint8_t* dst = reinterpret_cast<uint8_t*>(out.data());
+
+        for (int i = 0; i < data.size(); ++i) {
+            const uint8_t s = src[i];
+            *dst++ = s; // L
+            *dst++ = s; // R
+        }
+
+        data = std::move(out);
+        fmt.setChannelCount(2);
+        return true;
+    }
+
+    case QAudioFormat::Int16: {
+        if ((data.size() % 2) != 0) return false;
+        const int samples = data.size() / 2;
+
+        QByteArray out;
+        out.resize(samples * 4);
+
+        const int16_t* src = reinterpret_cast<const int16_t*>(data.constData());
+        int16_t* dst = reinterpret_cast<int16_t*>(out.data());
+
+        for (int i = 0; i < samples; ++i) {
+            const int16_t s = src[i];
+            *dst++ = s; // L
+            *dst++ = s; // R
+        }
+
+        data = std::move(out);
+        fmt.setChannelCount(2);
+        return true;
+    }
+
+    case QAudioFormat::Int32: {
+        if ((data.size() % 4) != 0) return false;
+        const int samples = data.size() / 4;
+
+        QByteArray out;
+        out.resize(samples * 8);
+
+        const int32_t* src = reinterpret_cast<const int32_t*>(data.constData());
+        int32_t* dst = reinterpret_cast<int32_t*>(out.data());
+
+        for (int i = 0; i < samples; ++i) {
+            const int32_t s = src[i];
+            *dst++ = s; // L
+            *dst++ = s; // R
+        }
+
+        data = std::move(out);
+        fmt.setChannelCount(2);
+        return true;
+    }
+
+    case QAudioFormat::Float: {
+        // Qt float samples are 32-bit
+        if ((data.size() % 4) != 0) return false;
+        const int samples = data.size() / 4;
+
+        QByteArray out;
+        out.resize(samples * 8); // mono float32 -> stereo float32
+
+        const float* src = reinterpret_cast<const float*>(data.constData());
+        float* dst = reinterpret_cast<float*>(out.data());
+
+        for (int i = 0; i < samples; ++i) {
+            const float s = src[i];
+            *dst++ = s; // L
+            *dst++ = s; // R
+        }
+
+        data = std::move(out);
+        fmt.setChannelCount(2);
+        return true;
+    }
+
+    default:
+        return false; // unsupported here
     }
 }
 

--- a/JS8_Audio/NotificationAudio.h
+++ b/JS8_Audio/NotificationAudio.h
@@ -29,6 +29,8 @@ class NotificationAudio : public QObject {
     using Cache = QHash<QString, Entry>;
 
     void playEntry(Cache::const_iterator);
+    static QByteArray pcm24le_to_int32le(const QByteArray &in);
+    static bool upmixMonoToStereoInPlace(QAudioFormat &fmt, QByteArray &data);
 
     QScopedPointer<SoundOutput> m_stream;
     Cache m_cache;

--- a/JS8_Audio/SoundOutput.cpp
+++ b/JS8_Audio/SoundOutput.cpp
@@ -81,10 +81,12 @@ void SoundOutput::setDeviceFormat(QAudioDevice const &device,
                                   unsigned msBuffered) {
     if (!format.isValid()) {
         Q_EMIT error(tr("Requested output audio format is not valid."));
+        return;
     }
     if (!device.isFormatSupported(format)) {
         Q_EMIT error(
             tr("Requested output audio format is not supported on device."));
+        return;
     }
 
     m_device = device;


### PR DESCRIPTION
Fix 8bit playback - set the sample format appropriately based upon the bits per channel in the format chunk instead of defaulting to 16 bits

Enable 24bit playback

Upmix mono to stereo
