### PR TITLE
Expose BITS field in RX.ACTIVITY TCP push messages

### DIFF
--- a/JS8_Mainwindow/processRxActivity.cpp
+++ b/JS8_Mainwindow/processRxActivity.cpp
@@ -30,7 +30,8 @@ void UI_Constructor::processRxActivity() {
                  {"SNR", QVariant(d.snr)},
                  {"SPEED", QVariant(d.submode)},
                  {"TDRIFT", QVariant(d.tdrift)},
-                 {"UTC", QVariant(d.utcTimestamp.toMSecsSinceEpoch())}});
+                 {"UTC", QVariant(d.utcTimestamp.toMSecsSinceEpoch())},
+                 {"BITS", QVariant(d.bits)}});
         }
 
         // use the actual frequency and check its delta from our current


### PR DESCRIPTION
## Summary

Add the `BITS` parameter (from `ActivityDetail::bits`) to the `RX.ACTIVITY` network message sent via TCP port 2442.

This is a **1-line change** in `processRxActivity.cpp`.

## Problem

`RX.ACTIVITY` TCP push messages currently include FREQ, DIAL, OFFSET, SNR, SPEED, TDRIFT, and UTC — but **not** the frame type bits (`JS8CallFirst` / `JS8CallLast`).

TCP clients have no way to detect when a multi-part message is complete. They must resort to timeout-based deadlines (typically TRPeriod + margin), adding 12-40 seconds of unnecessary delay.

Note: `RX.DIRECTED` messages do not have this problem because `processCommandActivity.cpp` checks `isLast` **before** calling `sendNetworkMessage`, appending the EOT character. In contrast, `processRxActivity.cpp` calls `sendNetworkMessage` **before** the `isLast` check — an asymmetry that this PR addresses.

## Solution

Add `{"BITS", QVariant(d.bits)}` to the `RX.ACTIVITY` params map, exposing the existing `d.bits` field that already contains the frame type information.

TCP clients can then check:
- `BITS & 1` → `JS8CallFirst` (first frame of a message)
- `BITS & 2` → `JS8CallLast` (last frame — message complete)

## Use case

Headless JS8Call stations (e.g., Raspberry Pi) using the TCP API can finalize decoded messages **instantly** (0s delay) instead of waiting for a timeout, dramatically improving the user experience.

## Testing

Tested with JS8Call-Improved 2.5.2 compiled from source on Raspberry Pi 4 (arm64), receiving JS8 Fast mode signals via a QRP Labs QMX transceiver. Both single-fragment and multi-fragment messages are correctly detected and finalized immediately upon receiving the last frame.

## Backwards compatibility

This change only **adds** a new parameter to the existing TCP message. Clients that do not expect BITS will simply ignore it. No breaking changes.
