### PR TITLE
Fix "Requested output audio format is not valid" startup bug

### DIFF
--- a/JS8_Audio/SoundInput.cpp
+++ b/JS8_Audio/SoundInput.cpp
@@ -177,6 +177,18 @@ void SoundInput::stop() {
 }
 
 /**
+ * @brief Tests whether device can be opened as an input
+ */
+
+bool SoundInput::canOpenAsInput(const QAudioDevice &dev) {
+    QAudioFormat fmt = dev.preferredFormat();
+    auto src = std::make_unique<QAudioSource>(dev, fmt);
+    src->start(); // opens device
+    src->stop();
+    return src->error() == QAudio::NoError;
+}
+
+/**
  * @brief Destructs the SoundInput object.
  */
 SoundInput::~SoundInput() { stop(); }

--- a/JS8_Audio/SoundInput.h
+++ b/JS8_Audio/SoundInput.h
@@ -21,6 +21,8 @@ class SoundInput : public QObject {
 
     ~SoundInput();
 
+    static bool canOpenAsInput(const QAudioDevice &dev);
+
     // sink must exist from the start call until the next start call or
     // stop call
     Q_SLOT void start(QAudioDevice const &, int framesPerBuffer,

--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -195,6 +195,7 @@
 #include <limits>
 #include <stdexcept>
 
+#include "JS8_Audio/SoundInput.h"
 #include "moc_Configuration.cpp"
 
 namespace {
@@ -4232,7 +4233,11 @@ Configuration::impl::find_audio_device(QAudioDevice::Mode const mode,
                                   : QMediaDevices::audioOutputs();
 
         for (auto const &p : devices) {
-            if (p.mode() == mode && p.description() == device_name) {
+            bool modeMatch = (mode == QAudioDevice::Input) ?
+                                SoundInput::canOpenAsInput(p):
+                                p.mode() == mode;
+
+            if (modeMatch && p.description() == device_name) {
                 combo_box->insertItem(0, p.description(),
                                       QVariant::fromValue(p));
                 combo_box->setCurrentIndex(0);


### PR DESCRIPTION
On Linux, QT can erroneously list QAudioDevice instance as having the mode QAudioDevice::Output when they are actually inputs. This results in the "Requested output audio format is not valid" error on startup, and requires the user to open the configuration and select the audio device in the input list before we can start it.

Adds SoundInput::canOpenAsInput to test if an QAudioDevice instance is actually a viable input

Updates Configuration::impl::find_audio_device to test if device is actually in input by using Adds SoundInput::canOpenAsInput, rather than trusting the mode listed in the device.