### PR TITLE
Reduce pre-TX CAT round-trips for FLRig/network rigs

### DIFF
--- a/JS8_Transceiver/HamlibTransceiver.cpp
+++ b/JS8_Transceiver/HamlibTransceiver.cpp
@@ -767,6 +767,12 @@ void HamlibTransceiver::do_frequency(Frequency f, MODE m, bool no_ignore) {
 /** Work around hamlib bug
  * [#1966](https://github.com/Hamlib/Hamlib/issues/1966). */
 void HamlibTransceiver::hamlib_bug_bandaid(TransceiverState const &s) {
+    // Avoid an extra network CAT round-trip for network-backed rigs such as
+    // flrig. That extra write can push TX start late on Linux.
+    if (rig_->caps->port_type == RIG_PORT_NETWORK) {
+        return;
+    }
+
     if (s.frequency() == s.tx_frequency() && s.split() && s.ptt()) {
         // Change the frequency ever so slightly without telling anybody.
         // Will not matter during the upcoming transmit and will be corrected

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -6728,9 +6728,9 @@ void UI_Constructor::setRig(Frequency f) {
     if ((m_monitoring || m_transmitting) && m_config.transceiver_online()) {
         if (m_config.split_mode()) {
             Q_EMIT m_config.transceiver_tx_frequency(m_freqTxNominal);
+        } else {
+            Q_EMIT m_config.transceiver_frequency(m_freqNominal);
         }
-
-        Q_EMIT m_config.transceiver_frequency(m_freqNominal);
     }
 }
 


### PR DESCRIPTION
**Summary**
This PR narrows the pre-transmit rig-control path to reduce timing latency seen on Linux with FLRig/network-backed Hamlib rigs.

**Changes**
- JS8_UI/mainwindow.cpp: in setRig(), emit transceiver_frequency(...) only in non-split mode.
- JS8_Transceiver/HamlibTransceiver.cpp: skip hamlib_bug_bandaid() for RIG_PORT_NETWORK backends to avoid an extra network CAT write before TX.

**Why**
FLRig users report delayed TX start. Both call sites above can add avoidable CAT round-trips in the critical pre-PTT path.

**Scope**
No API changes. No config/schema changes.

**Suggested validation**
1. Linux + FLRig + split none
2. Linux + FLRig + split fake-it
3. Linux + serial Hamlib CAT
4. Windows + FLRig Observe TX trigger-to-PTT delay and confirm no frequency regression in split mode.