### PR TITLE
Add API endpoints for TX enable and autoreply control

### DIFF
--- a/JS8_Mainwindow/networkMessage.cpp
+++ b/JS8_Mainwindow/networkMessage.cpp
@@ -27,6 +27,54 @@ void UI_Constructor::networkMessage(Message const &message) {
 
     qCDebug(mainwindow_js8) << "try processing network message" << type << id;
 
+    auto parseBoolean = [](QVariant const &raw, bool *ok = nullptr,
+                           bool default_value = false) {
+        if (!raw.isValid() || raw.isNull()) {
+            if (ok) {
+                *ok = false;
+            }
+            return default_value;
+        }
+
+        if (raw.canConvert<bool>() && raw.typeId() == QMetaType::Bool) {
+            if (ok) {
+                *ok = true;
+            }
+            return raw.toBool();
+        }
+
+        auto text = raw.toString().trimmed().toLower();
+        if (text == "1" || text == "true" || text == "on" || text == "yes" ||
+            text == "enable" || text == "enabled") {
+            if (ok) {
+                *ok = true;
+            }
+            return true;
+        }
+
+        if (text == "0" || text == "false" || text == "off" || text == "no" ||
+            text == "disable" || text == "disabled") {
+            if (ok) {
+                *ok = true;
+            }
+            return false;
+        }
+
+        if (ok) {
+            *ok = false;
+        }
+        return default_value;
+    };
+
+    auto messageBoolean = [&](QString const &param_name, bool *ok = nullptr,
+                              bool default_value = false) {
+        if (message.params().contains(param_name)) {
+            return parseBoolean(message.params().value(param_name), ok,
+                                default_value);
+        }
+        return parseBoolean(QVariant(message.value()), ok, default_value);
+    };
+
     // Inspired by FLDigi
     // TODO: MAIN.RX - Turn on RX
     // TODO: MAIN.TX - Transmit
@@ -546,6 +594,54 @@ if(type == "STATION.SET_SPOT") {
                            ui->extFreeTextMsgEdit->toPlainText().right(1024),
                            {
                                {"_ID", id},
+                           });
+        return;
+    }
+    /** @brief TX.GET_ENABLED: Retrieves whether TX is currently allowed. */
+    if (type == "TX.GET_ENABLED") {
+        sendNetworkMessage("TX.ENABLED", "",
+                           {
+                               {"_ID", id},
+                               {"ENABLED", ui->monitorTxButton->isChecked()},
+                           });
+        return;
+    }
+    /** @brief TX.SET_ENABLED: Enables or disables all transmissions. */
+    if (type == "TX.SET_ENABLED") {
+        bool ok = false;
+        bool const enabled = messageBoolean("ENABLED", &ok);
+        if (ok && ui->monitorTxButton->isChecked() != enabled) {
+            ui->monitorTxButton->setChecked(enabled);
+        }
+        sendNetworkMessage("TX.ENABLED", "",
+                           {
+                               {"_ID", id},
+                               {"ENABLED", ui->monitorTxButton->isChecked()},
+                           });
+        return;
+    }
+    /** @brief TX.GET_AUTOREPLY: Retrieves whether autoreply is enabled. */
+    if (type == "TX.GET_AUTOREPLY") {
+        sendNetworkMessage("TX.AUTOREPLY", "",
+                           {
+                               {"_ID", id},
+                               {"ENABLED",
+                                ui->actionModeAutoreply->isChecked()},
+                           });
+        return;
+    }
+    /** @brief TX.SET_AUTOREPLY: Enables or disables autoreply mode. */
+    if (type == "TX.SET_AUTOREPLY") {
+        bool ok = false;
+        bool const enabled = messageBoolean("ENABLED", &ok);
+        if (ok && ui->actionModeAutoreply->isChecked() != enabled) {
+            ui->actionModeAutoreply->setChecked(enabled);
+        }
+        sendNetworkMessage("TX.AUTOREPLY", "",
+                           {
+                               {"_ID", id},
+                               {"ENABLED",
+                                ui->actionModeAutoreply->isChecked()},
                            });
         return;
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,6 +54,10 @@ The steps above are
 | [RX.GET_BAND_ACTIVITY](#rxget_band_activity) | 2.5 |
 | [RX.GET_TEXT](#rxget_text)                   | 2.5 |
 | [TX.GET_TEXT](#txget_text)                   | 2.5 |
+| [TX.GET_ENABLED](#txget_enabled)             | 2.7 |
+| [TX.SET_ENABLED](#txset_enabled)             | 2.7 |
+| [TX.GET_AUTOREPLY](#txget_autoreply)         | 2.7 |
+| [TX.SET_AUTOREPLY](#txset_autoreply)         | 2.7 |
 | [TX.SET_TEXT](#txset_text)                   | 2.5 |
 | [TX.SEND_MESSAGE](#txsend_message)           | 2.5 |
 | [TX.GET_QUEUE_DEPTH](#txget_queue_depth)     | 2.6 |
@@ -536,6 +540,60 @@ Gets the text to be transmitted
 
 1) If text box is empty
 2) If text box has something in it
+
+# TX.GET_ENABLED
+[!note] API >= 2.7
+
+Gets whether JS8Call is currently allowed to transmit.
+
+| End Point |
+|-----------|
+|{"params":{},"type":"TX.GET_ENABLED","value":""}|
+
+| Response |
+|----------|
+|{"params":{"ENABLED":true,"_ID":270422213693},"type":"TX.ENABLED","value":""}|
+
+# TX.SET_ENABLED
+[!note] API >= 2.7
+
+Enables or disables all transmit activity, including autoreplies that would key
+the transmitter.
+
+| End Point |
+|-----------|
+|{"params":{"ENABLED":false},"type":"TX.SET_ENABLED","value":""}|
+
+| Response |
+|----------|
+|{"params":{"ENABLED":false,"_ID":270422213693},"type":"TX.ENABLED","value":""}|
+
+# TX.GET_AUTOREPLY
+[!note] API >= 2.7
+
+Gets whether autoreply mode is enabled.
+
+| End Point |
+|-----------|
+|{"params":{},"type":"TX.GET_AUTOREPLY","value":""}|
+
+| Response |
+|----------|
+|{"params":{"ENABLED":true,"_ID":270422213693},"type":"TX.AUTOREPLY","value":""}|
+
+# TX.SET_AUTOREPLY
+[!note] API >= 2.7
+
+Enables or disables autoreply mode without changing the general TX enable
+state.
+
+| End Point |
+|-----------|
+|{"params":{"ENABLED":false},"type":"TX.SET_AUTOREPLY","value":""}|
+
+| Response |
+|----------|
+|{"params":{"ENABLED":false,"_ID":270422213693},"type":"TX.AUTOREPLY","value":""}|
 
 # TX.SET_TEXT
 API <= 2.6


### PR DESCRIPTION
Summary
Adds explicit API control/readback for TX enable state and autoreply state. Added endpoints
- TX.GET_ENABLED -> TX.ENABLED
- TX.SET_ENABLED -> TX.ENABLED
- TX.GET_AUTOREPLY -> TX.AUTOREPLY
- TX.SET_AUTOREPLY -> TX.AUTOREPLY

 Files changed
- JS8_Mainwindow/networkMessage.cpp
- docs/API.md

 Notes
- Boolean parsing accepts common forms (true/false, on/off, 1/0, enable/disable).
- No changes to rig-control timing path in this PR (kept separate from #219 for easier review).


Edited for readability by wmiler.