### PR TITLE
WSJT-X UDP protocol: recieve to decode state switching fixed

### DIFF
--- a/JS8_Mainwindow/networkMessage.cpp
+++ b/JS8_Mainwindow/networkMessage.cpp
@@ -109,7 +109,7 @@ void UI_Constructor::networkMessage(Message const &message) {
                 dx_call, m_config.my_callsign(), m_config.my_grid(), dx_grid,
                 true, // tx_enabled
                 m_transmitting,
-                m_decoderBusy || m_monitoring, // decoding
+                m_decoderBusy, // decoding (match WSJT-X: decoder busy only)
                 tx_message);
         }
 

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -1141,6 +1141,9 @@ void UI_Constructor::monitor(bool state) {
         Q_EMIT suspendAudioInputStream();
     }
     m_monitoring = state;
+
+    // Notify WSJT-X protocol clients of receive state change (Monitor on/off)
+    statusUpdate();
 }
 
 void UI_Constructor::on_actionAbout_triggered() // Display "About"
@@ -2095,6 +2098,9 @@ void UI_Constructor::decodeBusy(bool b) // decodeBusy()
         m_decoderBusyFreq = dialFrequency();
         m_decoderBusyBand = m_config.bands()->find(m_decoderBusyFreq);
     }
+
+    // Notify WSJT-X protocol clients of decode state change (start/end of decode round)
+    statusUpdate();
 }
 
 /**
@@ -6760,7 +6766,7 @@ void UI_Constructor::statusUpdate() {
             true, // tx_enabled - JS8Call always allows TX when not in
                   // special modes
             m_transmitting,
-            m_decoderBusy || m_monitoring, // decoding
+            m_decoderBusy, // decoding (match WSJT-X: decoder busy only)
             tx_message);
     }
 


### PR DESCRIPTION
Found a bug: clients like Gridtracker were not notified of state changes between Receive and Decode. So decodes could be missed on occasion.