### PR TITLE
Implement pill formatting of commands in message text

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ target_sources(
   JS8_Main/CallsignValidator.cpp
   JS8_Main/CandidateKeyFilter.cpp
   JS8_Main/CPlotter.cpp
+  JS8_Main/DirectedMessageHighlighter.cpp
+  JS8_Main/DirectedMessageParser.cpp
   JS8_Main/DriftingDateTime.cpp
   JS8_Main/Flatten.cpp
   JS8_Main/ForeignKeyDelegate.cpp
@@ -251,6 +253,7 @@ target_sources(
   JS8_Main/fileutils.cpp
   JS8_Main/main.cpp
   JS8_Main/Modes.cpp
+  JS8_Main/PillRenderer.cpp
   JS8_Main/ProcessThread.cpp
   JS8_Main/qt_helpers.cpp
   JS8_Main/Radio.cpp
@@ -259,6 +262,7 @@ target_sources(
   JS8_Main/SelfDestructMessageBox.cpp
   JS8_Main/SignalMeter.cpp
   JS8_Main/TraceFile.cpp
+  JS8_Main/TransmitTextSourceMirror.cpp
   JS8_Main/TransmitTextEdit.cpp
   JS8_Main/TwoPhaseSignal.cpp
   JS8_Main/Varicode.cpp

--- a/JS8_Main/DirectedMessageHighlighter.cpp
+++ b/JS8_Main/DirectedMessageHighlighter.cpp
@@ -1,0 +1,171 @@
+/**
+ * @file DirectedMessageHighlighter.cpp
+ * @brief Syntax highlighter for JS8 directed message routing tokens.
+ *
+ * Highlights addressing (recipient/relay chains), commands, storage targets,
+ * and groups with colored pill-style backgrounds. Relay chains are rendered
+ * as a single pill with the final recipient in bold. Rich contextual tooltips
+ * describe the routing.
+ */
+
+#include "DirectedMessageHighlighter.h"
+#include "DirectedMessageParser.h"
+#include "DirectedMessageTooltipUtils.h"
+
+#include <QTextDocument>
+
+namespace {
+
+QString explicitTargetTooltip(const QString &baseTip,
+                              const QString &selectedCallsign,
+                              const QString &explicitTarget) {
+    if (selectedCallsign.isEmpty() || selectedCallsign == explicitTarget)
+        return baseTip;
+
+    return QString("%1. Overrides selected %2.")
+        .arg(baseTip, selectedCallsign);
+}
+
+QString tokenTooltip(const DirectedMessageParser::Token &token,
+                     const QString &upperText,
+                     const QString &selectedCallsign) {
+    switch (token.type) {
+    case DirectedMessageParser::Token::Sender:
+    case DirectedMessageParser::Token::Command:
+        return token.tooltip;
+    case DirectedMessageParser::Token::Recipient: {
+        const QString recipient = upperText.mid(token.start, token.length);
+        return explicitTargetTooltip(token.tooltip, selectedCallsign,
+                                     recipient);
+    }
+    case DirectedMessageParser::Token::Group: {
+        const QString group = upperText.mid(token.start, token.length);
+        return explicitTargetTooltip(token.tooltip, selectedCallsign, group);
+    }
+    case DirectedMessageParser::Token::RelayChain:
+        if (!token.partial)
+            return token.tooltip;
+
+        if (selectedCallsign.isEmpty()) {
+            const QString recipient =
+                (token.recipientHopIndex >= 0 &&
+                 token.recipientHopIndex < token.hops.size())
+                    ? upperText.mid(token.hops[token.recipientHopIndex].first,
+                                    token.hops[token.recipientHopIndex].second)
+                    : QStringLiteral("the final recipient");
+            return QString("Partial relay to %1. First hop comes from the "
+                           "selected callsign, but no station is currently "
+                           "selected.")
+                .arg(recipient);
+        }
+
+        QStringList hops;
+        hops.append(selectedCallsign);
+        for (const auto &hop : token.hops)
+            hops.append(upperText.mid(hop.first, hop.second));
+        return DirectedMessageTooltipUtils::routingTooltipFromTexts(hops);
+    }
+
+    return token.tooltip;
+}
+
+} // namespace
+
+DirectedMessageHighlighter::DirectedMessageHighlighter(QTextDocument *parent)
+    : QSyntaxHighlighter(parent) {
+    m_addressColor = QColor("#2980b9"); // blue
+    m_addressFontColor = Qt::white;
+    m_commandColor = QColor("#e67e22"); // orange
+    m_commandFontColor = Qt::white;
+    m_groupColor = QColor("#16a085");   // teal
+    m_groupFontColor = Qt::white;
+    m_senderColor = QColor("#7f8c8d");  // grey/slate
+    m_senderFontColor = Qt::white;
+}
+
+void DirectedMessageHighlighter::setEnabled(bool enabled) {
+    m_enabled = enabled;
+}
+
+void DirectedMessageHighlighter::setPillColors(const PillColorScheme &scheme) {
+    m_addressColor = scheme.recipientBg;
+    m_addressFontColor = scheme.recipientFg;
+    m_commandColor = scheme.commandBg;
+    m_commandFontColor = scheme.commandFg;
+    m_groupColor = scheme.groupBg;
+    m_groupFontColor = scheme.groupFg;
+    m_senderColor = scheme.senderBg;
+    m_senderFontColor = scheme.senderFg;
+}
+
+void DirectedMessageHighlighter::setSelectedCallsign(const QString &callsign) {
+    m_selectedCallsign = callsign.toUpper();
+}
+
+QTextCharFormat DirectedMessageHighlighter::makePillFormat(
+    QColor pillColor, QColor fg, QColor bg, int pillGroup,
+    const QString &tooltip, bool bold) const {
+    QTextCharFormat fmt;
+    fmt.setForeground(fg);
+    fmt.setBackground(bg);
+    fmt.setProperty(PillColorProperty, pillColor);
+    fmt.setProperty(PillGroupProperty, pillGroup);
+    fmt.setToolTip(tooltip);
+    if (bold)
+        fmt.setFontWeight(QFont::Bold);
+    return fmt;
+}
+
+void DirectedMessageHighlighter::highlightBlock(const QString &text) {
+    if (!m_enabled)
+        return;
+
+    const QString upperText = text.toUpper();
+    const auto tokens =
+        DirectedMessageParser::parseTokensForLine(text, m_selectedCallsign);
+    int pillGroup = 0;
+
+    for (const auto &token : tokens) {
+        QColor color;
+        QColor fontColor;
+        switch (token.type) {
+        case DirectedMessageParser::Token::Sender:
+            color = m_senderColor;
+            fontColor = m_senderFontColor;
+            break;
+        case DirectedMessageParser::Token::Recipient:
+            color = m_addressColor;
+            fontColor = m_addressFontColor;
+            break;
+        case DirectedMessageParser::Token::RelayChain:
+            color = m_addressColor;
+            fontColor = m_addressFontColor;
+            break;
+        case DirectedMessageParser::Token::Command:
+            color = m_commandColor;
+            fontColor = m_commandFontColor;
+            break;
+        case DirectedMessageParser::Token::Group:
+            color = m_groupColor;
+            fontColor = m_groupFontColor;
+            break;
+        }
+
+        const QString tooltip =
+            tokenTooltip(token, upperText, m_selectedCallsign);
+        setFormat(token.start, token.length,
+                  makePillFormat(color, fontColor, color, pillGroup,
+                                 tooltip));
+
+        if (token.type == DirectedMessageParser::Token::RelayChain &&
+            token.recipientHopIndex >= 0 &&
+            token.recipientHopIndex < token.hops.size()) {
+            const auto hop = token.hops[token.recipientHopIndex];
+            setFormat(hop.first, hop.second,
+                      makePillFormat(color, fontColor, color, pillGroup,
+                                     tooltip, true));
+        }
+
+        pillGroup++;
+    }
+}

--- a/JS8_Main/DirectedMessageHighlighter.h
+++ b/JS8_Main/DirectedMessageHighlighter.h
@@ -1,0 +1,52 @@
+#ifndef DIRECTEDMESSAGEHIGHLIGHTER_H
+#define DIRECTEDMESSAGEHIGHLIGHTER_H
+
+#include <QColor>
+#include <QString>
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+#include <QTextFormat>
+
+/// Background and foreground colors for each pill category.
+struct PillColorScheme {
+    QColor recipientBg, recipientFg;
+    QColor commandBg, commandFg;
+    QColor groupBg, groupFg;
+    QColor senderBg, senderFg;
+};
+
+class DirectedMessageHighlighter : public QSyntaxHighlighter {
+    Q_OBJECT
+  public:
+    explicit DirectedMessageHighlighter(QTextDocument *parent = nullptr);
+
+    void setEnabled(bool enabled);
+    void setPillColors(const PillColorScheme &scheme);
+    void setSelectedCallsign(const QString &callsign);
+
+    // Custom QTextFormat properties for pill identification.
+    static constexpr int PillColorProperty = QTextFormat::UserProperty + 1;
+    static constexpr int PillGroupProperty = QTextFormat::UserProperty + 2;
+
+  protected:
+    void highlightBlock(const QString &text) override;
+
+  private:
+    QTextCharFormat makePillFormat(QColor pillColor, QColor fg, QColor bg,
+                                   int pillGroup, const QString &tooltip,
+                                   bool bold = false) const;
+
+    QColor m_addressColor;      // blue — recipient + relay chains
+    QColor m_addressFontColor;  // font color for recipient pills
+    QColor m_commandColor;      // orange — commands + MSG TO: storage
+    QColor m_commandFontColor;  // font color for command pills
+    QColor m_groupColor;        // teal — @GROUP
+    QColor m_groupFontColor;    // font color for group pills
+    QColor m_senderColor;       // grey/slate — sender callsign prefix
+    QColor m_senderFontColor;   // font color for sender pills
+
+    QString m_selectedCallsign;
+    bool m_enabled = true;
+};
+
+#endif // DIRECTEDMESSAGEHIGHLIGHTER_H

--- a/JS8_Main/DirectedMessageParser.cpp
+++ b/JS8_Main/DirectedMessageParser.cpp
@@ -1,0 +1,435 @@
+/**
+ * @file DirectedMessageParser.cpp
+ * @brief Shared parser for directed-message pills.
+ */
+
+#include "DirectedMessageParser.h"
+
+#include "DirectedMessageTooltipUtils.h"
+#include "Varicode.h"
+
+#include <algorithm>
+#include <QRegularExpression>
+
+namespace {
+
+struct PillCommandDef {
+    const char *command;
+    const char *tooltip;
+    bool includesArg;
+    bool allowsBare;
+};
+
+static const PillCommandDef s_commandDefs[] = {
+    // Directed-message commands.
+    {"AGN?", "Request: Please repeat", false, false},
+    {"QSL?", "Query: Did you receive?", false, false},
+    {"HW CPY?", "Query: How do you copy me?", false, false},
+    {"SNR?", "Query: Request signal report", false, false},
+    {"INFO?", "Query: Request station information", false, false},
+    {"GRID?", "Query: Request grid locator", false, false},
+    {"STATUS?", "Query: Request station status", false, false},
+    {"QUERY MSGS?", "Query: Do you have stored messages for me?", false,
+     false},
+    {"HEARING?", "Query: What stations do you hear?", false, false},
+    {"MSG TO:", "Store message at relay for %1", true, false},
+    {"HEARTBEAT SNR", "Heartbeat signal report", false, false},
+    {"QUERY MSGS", "Query: Do you have stored messages for me?", false,
+     false},
+    {"QUERY CALL", "Query: Can you reach %1?", true, false},
+    {"QUERY MSG", "Query: Deliver stored message %1", true, false},
+    {"QUERY", "Generic query", false, false},
+    {"DIT DIT", "Two dits - casual sign-off", false, false},
+    {"STATUS", "Station status message", false, false},
+    {"HEARING", "Stations heard list", false, false},
+    {"CMD", "Generic command", false, false},
+    {"MSG", "Send a complete message", false, false},
+    {"NACK", "Negative acknowledge", false, false},
+    {"ACK", "Acknowledge receipt", false, false},
+    {"SNR", "Signal report value", false, false},
+    {"QSL", "Confirm: I received your message", false, false},
+    {"INFO", "Station information", false, false},
+    {"GRID", "My grid locator is %1", true, false},
+    {"73", "Best regards - end of contact", false, false},
+    {"YES", "Affirmative", false, false},
+    {"NO", "Negative", false, false},
+    {"RR", "Roger received", false, false},
+    {"SK", "End of contact - signing off", false, false},
+    {"FB", "Fine business - excellent", false, false},
+
+    // Bare-capable CQ/HB variants.
+    {"CQ CQ CQ", "Calling all stations", false, true},
+    {"CQ CONTEST", "Calling all stations (contest)", false, true},
+    {"CQ FIELD", "Calling all stations (field day)", false, true},
+    {"CQ DX", "Calling all stations (DX)", false, true},
+    {"CQ QRP", "Calling all stations (low power)", false, true},
+    {"CQ FD", "Calling all stations (field day)", false, true},
+    {"CQ CQ", "Calling all stations", false, true},
+    {"CQ", "Calling all stations", false, true},
+    {"HB", "Heartbeat - automatic presence beacon", true, true},
+    {"HEARTBEAT", "Heartbeat - automatic presence beacon", true, true},
+};
+
+struct CommandMatch {
+    const PillCommandDef *def = nullptr;
+    QString commandText;
+    QString argText;
+    int start = 0;
+    int finalLength = 0;
+    bool hasMatch = false;
+};
+
+template <std::size_t N>
+QList<const PillCommandDef *> sortedCommandDefs(const PillCommandDef (&defs)[N]) {
+    QList<const PillCommandDef *> sorted;
+    sorted.reserve(static_cast<qsizetype>(N));
+    for (const auto &def : defs)
+        sorted.append(&def);
+
+    std::sort(sorted.begin(), sorted.end(),
+              [](const PillCommandDef *lhs, const PillCommandDef *rhs) {
+                  const auto left = QLatin1String(lhs->command);
+                  const auto right = QLatin1String(rhs->command);
+                  if (left.size() != right.size())
+                      return left.size() > right.size();
+                  return left < right;
+              });
+
+    return sorted;
+}
+
+const QRegularExpression &callsignRe() {
+    static const QRegularExpression re(R"([@]?[A-Z0-9/]+)");
+    return re;
+}
+
+const QRegularExpression &relayChainRe() {
+    static const QRegularExpression re(
+        R"(^([@]?[A-Z0-9/]+)(\s*>\s*[@]?[A-Z0-9/]+)+)");
+    return re;
+}
+
+const QRegularExpression &partialRelayRe() {
+    static const QRegularExpression re(R"(^(\s*>\s*[@]?[A-Z0-9/]+)+)");
+    return re;
+}
+
+const QRegularExpression &grid4Re() {
+    static const QRegularExpression re(R"(^[A-R]{2}[0-9]{2}$)");
+    return re;
+}
+
+const PillCommandDef *findCommandDef(const QString &cmd) {
+    for (const auto &def : s_commandDefs) {
+        if (cmd == QLatin1String(def.command))
+            return &def;
+    }
+    return nullptr;
+}
+
+bool commandNeedsWordBoundary(const QString &cmd) {
+    if (cmd.isEmpty())
+        return false;
+
+    const QChar last = cmd.at(cmd.length() - 1);
+    return last != '?' && last != ':';
+}
+
+bool isHeartbeatCommand(const QString &cmd) {
+    return cmd == QLatin1String("HB") || cmd == QLatin1String("HEARTBEAT");
+}
+
+CommandMatch buildCommandMatch(const PillCommandDef *def, const QString &text,
+                               int start, bool bareOnly) {
+    CommandMatch match;
+    if (!def)
+        return match;
+
+    const QString cmd = QLatin1String(def->command);
+    match.def = def;
+    match.commandText = cmd;
+    match.start = start;
+    match.finalLength = cmd.length();
+    match.hasMatch = true;
+
+    if (!def->includesArg)
+        return match;
+
+    int argStart = start + cmd.length();
+    while (argStart < text.length() && text.at(argStart) == ' ')
+        argStart++;
+    if (argStart >= text.length())
+        return match;
+
+    int argEnd = argStart;
+    while (argEnd < text.length() && text.at(argEnd) != ' ')
+        argEnd++;
+
+    const QString argText = text.mid(argStart, argEnd - argStart);
+    if (isHeartbeatCommand(cmd) &&
+        !grid4Re().match(argText).hasMatch()) {
+        if (bareOnly)
+            return CommandMatch{};
+        return match;
+    }
+
+    match.argText = argText;
+    match.finalLength = argEnd - start;
+    return match;
+}
+
+CommandMatch matchCommandAt(const QString &text, int start, bool bareOnly) {
+    if (start < 0 || start >= text.length())
+        return CommandMatch{};
+
+    static const QList<const PillCommandDef *> sorted =
+        sortedCommandDefs(s_commandDefs);
+
+    for (const auto *def : sorted) {
+        const QString cmd = QLatin1String(def->command);
+        if (text.indexOf(cmd, start) != start)
+            continue;
+
+        const int afterCmd = start + cmd.length();
+        if (commandNeedsWordBoundary(cmd) && afterCmd < text.length() &&
+            text.at(afterCmd) != ' ') {
+            continue;
+        }
+
+        if (bareOnly && !def->allowsBare)
+            return CommandMatch{};
+
+        return buildCommandMatch(def, text, start, bareOnly);
+    }
+
+    if (!bareOnly && text.at(start) == '?') {
+        CommandMatch compat;
+        compat.commandText = QStringLiteral("?");
+        compat.start = start;
+        compat.finalLength = 1;
+        compat.hasMatch = true;
+        return compat;
+    }
+
+    return CommandMatch{};
+}
+
+QString commandTooltip(const QString &cmd) {
+    if (const auto *def = findCommandDef(cmd))
+        return QString::fromUtf8(def->tooltip);
+    if (cmd.startsWith(QLatin1String("CQ")))
+        return QStringLiteral("Calling all stations");
+    return QString("Command: %1").arg(cmd);
+}
+
+QString formatCommandTooltip(const CommandMatch &match,
+                             const QString &implicitTarget,
+                             bool usedImplicitTarget) {
+    QString tip = commandTooltip(match.commandText);
+    if (tip.contains(QLatin1String("%1"))) {
+        tip = tip.arg(match.argText.isEmpty() ? QStringLiteral("\xe2\x80\xa6")
+                                              : match.argText);
+    }
+
+    if (usedImplicitTarget && !implicitTarget.isEmpty()) {
+        tip = QString("%1. Directed to selected %2.")
+                  .arg(tip, implicitTarget);
+    }
+
+    return tip;
+}
+
+QList<QPair<int, int>> parseHops(const QString &chainText) {
+    QList<QPair<int, int>> hops;
+    int scanPos = 0;
+    while (scanPos < chainText.length()) {
+        while (scanPos < chainText.length() &&
+               (chainText[scanPos] == ' ' || chainText[scanPos] == '>')) {
+            scanPos++;
+        }
+        if (scanPos >= chainText.length())
+            break;
+        int callStart = scanPos;
+        while (scanPos < chainText.length() &&
+               chainText[scanPos] != '>' && chainText[scanPos] != ' ')
+            scanPos++;
+        if (scanPos > callStart)
+            hops.append({callStart, scanPos - callStart});
+    }
+    return hops;
+}
+
+QList<DirectedMessageParser::Token> parseTokensUpper(
+    const QString &text, const QString &implicitTarget) {
+    QList<DirectedMessageParser::Token> tokens;
+
+    if (text.isEmpty() || text.startsWith('`'))
+        return tokens;
+
+    int contentOffset = 0;
+    {
+        int colonPos = text.indexOf(':');
+        if (colonPos > 0 && colonPos + 1 < text.length() &&
+            text.at(colonPos + 1) == ' ') {
+            QString maybeSender = text.left(colonPos);
+            auto match = callsignRe().match(maybeSender);
+            if (match.hasMatch() && match.capturedStart() == 0 &&
+                match.capturedLength() == maybeSender.length() &&
+                !maybeSender.startsWith('@') &&
+                Varicode::isValidCallsign(maybeSender, nullptr)) {
+                DirectedMessageParser::Token t;
+                t.start = 0;
+                t.length = colonPos + 1;
+                t.type = DirectedMessageParser::Token::Sender;
+                t.tooltip = QString("Sent from %1").arg(maybeSender);
+                tokens.append(t);
+                contentOffset = colonPos + 2;
+            }
+        }
+    }
+
+    const QString content =
+        (contentOffset > 0) ? text.mid(contentOffset) : text;
+
+    int pos = 0;
+    bool explicitTargetPresent = false;
+
+    auto relayMatch = relayChainRe().match(content);
+    if (relayMatch.hasMatch()) {
+        DirectedMessageParser::Token t;
+        t.start = 0;
+        t.length = relayMatch.capturedLength();
+        t.type = DirectedMessageParser::Token::RelayChain;
+
+        QString chainText = relayMatch.captured();
+        t.hops = parseHops(chainText);
+        t.recipientHopIndex = t.hops.size() - 1;
+        t.tooltip = DirectedMessageTooltipUtils::relayTooltip(chainText,
+                                                              t.hops);
+
+        tokens.append(t);
+        pos = t.length;
+        explicitTargetPresent = true;
+    } else {
+        int firstSpace = content.indexOf(' ');
+        QString addressPart =
+            (firstSpace >= 0) ? content.left(firstSpace) : content;
+
+        bool foundAddress = false;
+        int addressEndPos = -1;
+
+        if (!addressPart.isEmpty()) {
+            if (addressPart.startsWith('@')) {
+                DirectedMessageParser::Token t;
+                t.start = 0;
+                t.length = addressPart.length();
+                t.type = DirectedMessageParser::Token::Group;
+                t.tooltip = QString("Group call to %1").arg(addressPart);
+                tokens.append(t);
+                foundAddress = true;
+                explicitTargetPresent = true;
+                addressEndPos = addressPart.length();
+            } else {
+                auto match = callsignRe().match(addressPart);
+                if (match.hasMatch() && match.capturedStart() == 0 &&
+                    match.capturedLength() == addressPart.length() &&
+                    Varicode::isValidCallsign(addressPart, nullptr)) {
+                    DirectedMessageParser::Token t;
+                    t.start = 0;
+                    t.length = addressPart.length();
+                    t.type = DirectedMessageParser::Token::Recipient;
+                    t.tooltip = QString("Directed to %1").arg(addressPart);
+                    tokens.append(t);
+                    foundAddress = true;
+                    explicitTargetPresent = true;
+                    addressEndPos = addressPart.length();
+                }
+            }
+        }
+
+        if (!foundAddress && content.startsWith('>')) {
+            auto partialMatch = partialRelayRe().match(content);
+            if (partialMatch.hasMatch()) {
+                DirectedMessageParser::Token t;
+                t.start = 0;
+                t.length = partialMatch.capturedLength();
+                t.type = DirectedMessageParser::Token::RelayChain;
+                t.partial = true;
+
+                QString chainText = partialMatch.captured();
+                t.hops = parseHops(chainText);
+                t.recipientHopIndex = t.hops.size() - 1;
+                t.tooltip = DirectedMessageTooltipUtils::relayTooltip(
+                    chainText, t.hops);
+
+                tokens.append(t);
+                foundAddress = true;
+                explicitTargetPresent = true;
+                addressEndPos = t.length;
+            }
+        }
+
+        if (foundAddress) {
+            pos = (addressEndPos >= 0)
+                      ? addressEndPos
+                      : ((firstSpace >= 0) ? firstSpace : content.length());
+        }
+    }
+
+    if (!explicitTargetPresent) {
+        const auto bareMatch = matchCommandAt(content, 0, true);
+        if (bareMatch.hasMatch) {
+            DirectedMessageParser::Token t;
+            t.start = bareMatch.start;
+            t.length = bareMatch.finalLength;
+            t.type = DirectedMessageParser::Token::Command;
+            t.tooltip = formatCommandTooltip(bareMatch, QString(), false);
+            tokens.append(t);
+
+            for (auto &tok : tokens) {
+                if (tok.type != DirectedMessageParser::Token::Sender)
+                    tok.start += contentOffset;
+            }
+            return tokens;
+        }
+    }
+
+    const bool hasTarget =
+        explicitTargetPresent || !implicitTarget.isEmpty();
+    if (hasTarget && pos < content.length()) {
+        while (pos < content.length() && content[pos] == ' ')
+            pos++;
+
+        if (pos < content.length()) {
+            const auto cmdMatch = matchCommandAt(content, pos, false);
+            if (cmdMatch.hasMatch) {
+                DirectedMessageParser::Token t;
+                t.start = cmdMatch.start;
+                t.length = cmdMatch.finalLength;
+                t.type = DirectedMessageParser::Token::Command;
+                t.tooltip = formatCommandTooltip(
+                    cmdMatch, implicitTarget,
+                    !explicitTargetPresent && !implicitTarget.isEmpty());
+                tokens.append(t);
+            }
+        }
+    }
+
+    for (auto &tok : tokens) {
+        if (tok.type == DirectedMessageParser::Token::Sender)
+            continue;
+        tok.start += contentOffset;
+        for (auto &hop : tok.hops)
+            hop.first += contentOffset;
+    }
+
+    return tokens;
+}
+
+} // namespace
+
+QList<DirectedMessageParser::Token>
+DirectedMessageParser::parseTokensForLine(const QString &text,
+                                          const QString &implicitTarget) {
+    return parseTokensUpper(text.toUpper(), implicitTarget.toUpper());
+}

--- a/JS8_Main/DirectedMessageParser.h
+++ b/JS8_Main/DirectedMessageParser.h
@@ -1,0 +1,30 @@
+#ifndef DIRECTEDMESSAGEPARSER_H
+#define DIRECTEDMESSAGEPARSER_H
+
+#include <QList>
+#include <QPair>
+#include <QString>
+
+class DirectedMessageParser {
+  public:
+    struct Token {
+        int start = 0;
+        int length = 0;
+        enum Type {
+            Sender,
+            Recipient,
+            RelayChain,
+            Command,
+            Group
+        } type = Recipient;
+        QString tooltip;
+        QList<QPair<int, int>> hops;
+        int recipientHopIndex = -1;
+        bool partial = false;
+    };
+
+    static QList<Token> parseTokensForLine(
+        const QString &text, const QString &implicitTarget = QString());
+};
+
+#endif // DIRECTEDMESSAGEPARSER_H

--- a/JS8_Main/DirectedMessageTooltipUtils.h
+++ b/JS8_Main/DirectedMessageTooltipUtils.h
@@ -1,0 +1,43 @@
+#ifndef DIRECTEDMESSAGETOOLTIPUTILS_H
+#define DIRECTEDMESSAGETOOLTIPUTILS_H
+
+#include <QList>
+#include <QPair>
+#include <QString>
+#include <QStringList>
+
+namespace DirectedMessageTooltipUtils {
+
+inline QString joinHumanList(const QStringList &items) {
+    if (items.isEmpty())
+        return QString();
+    if (items.size() == 1)
+        return items.first();
+    return items.mid(0, items.size() - 1).join(", ") +
+           QStringLiteral(" and ") + items.last();
+}
+
+inline QString routingTooltipFromTexts(const QStringList &hops) {
+    if (hops.isEmpty())
+        return QString();
+    if (hops.size() == 1)
+        return QString("Relay to %1").arg(hops.first());
+
+    const QString destination = hops.last();
+    const QStringList relays = hops.mid(0, hops.size() - 1);
+    return QString("Routing through %1 to %2")
+        .arg(joinHumanList(relays), destination);
+}
+
+inline QString relayTooltip(const QString &chainText,
+                            const QList<QPair<int, int>> &hops) {
+    QStringList hopTexts;
+    hopTexts.reserve(hops.size());
+    for (const auto &hop : hops)
+        hopTexts.append(chainText.mid(hop.first, hop.second));
+    return routingTooltipFromTexts(hopTexts);
+}
+
+} // namespace DirectedMessageTooltipUtils
+
+#endif // DIRECTEDMESSAGETOOLTIPUTILS_H

--- a/JS8_Main/PillRenderer.cpp
+++ b/JS8_Main/PillRenderer.cpp
@@ -1,0 +1,422 @@
+/**
+ * @file PillRenderer.cpp
+ * @brief Implementation of PillRenderer — pill painting, tooltips,
+ *        and letter-spacing.
+ */
+
+#include "PillRenderer.h"
+#include "DirectedMessageHighlighter.h"
+#include "TransmitTextEdit.h"
+
+#include <QAbstractTextDocumentLayout>
+#include <QHelpEvent>
+#include <QPainter>
+#include <QScrollBar>
+#include <QSignalBlocker>
+#include <QTextBlock>
+#include <QTextCharFormat>
+#include <QTextCursor>
+#include <QTextEdit>
+#include <QTextFragment>
+#include <QTextLayout>
+#include <QToolTip>
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+PillRenderer::PillRenderer(TransmitTextEdit *host, QObject *parent)
+    : QObject(parent), m_host(host) {
+    m_highlighter = new DirectedMessageHighlighter(host->document());
+    m_defaultDocumentMargin = host->document()->documentMargin();
+    m_defaultBlockFormat = host->document()->firstBlock().blockFormat();
+
+    {
+        QSignalBlocker blocker(host->document());
+        host->beginInternalDocumentMutation();
+
+        // Margin >= PillHPad so the first pill's left padding doesn't clip.
+        host->document()->setDocumentMargin(PillRenderer::PillHPad);
+
+        // Line height 140% gives pills vertical breathing room.
+        QTextCursor cursor(host->document());
+        cursor.select(QTextCursor::Document);
+        QTextBlockFormat blockFmt;
+        blockFmt.setLineHeight(140, QTextBlockFormat::ProportionalHeight);
+        cursor.mergeBlockFormat(blockFmt);
+
+        host->endInternalDocumentMutation();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pill painting
+// ---------------------------------------------------------------------------
+
+void PillRenderer::paintPills(QPaintEvent * /*event*/) {
+    if (!m_enabled)
+        return;
+
+    QPainter painter(m_host->viewport());
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+
+    auto *doc = m_host->document();
+    auto *docLayout = doc->documentLayout();
+    QPointF offset(-m_host->horizontalScrollBar()->value(),
+                   -m_host->verticalScrollBar()->value());
+
+    QFontMetricsF fm(doc->defaultFont());
+    qreal capH = fm.capHeight();
+
+    QTextBlock block = doc->firstBlock();
+    while (block.isValid()) {
+        auto *layout = block.layout();
+        if (layout) {
+            QRectF blockRect = docLayout->blockBoundingRect(block);
+            blockRect.translate(offset);
+
+            // Group pill rectangles by pill ID within each visual line.
+            struct PillInfo {
+                QColor color;
+                QRectF rect;
+                int lineIndex = 0;
+            };
+            QHash<quint64, PillInfo> pillGroups;
+
+            auto pillFragmentKey = [](int groupId, int lineIndex) {
+                quint64 pillId = static_cast<quint64>(
+                    static_cast<quint32>(groupId));
+                return (pillId << 32) | static_cast<quint32>(lineIndex);
+            };
+
+            for (const auto &range : layout->formats()) {
+                auto colorVar = range.format.property(
+                    DirectedMessageHighlighter::PillColorProperty);
+                if (!colorVar.isValid())
+                    continue;
+
+                auto groupVar = range.format.property(
+                    DirectedMessageHighlighter::PillGroupProperty);
+                int groupId = groupVar.isValid() ? groupVar.toInt() : -1;
+
+                QColor pillColor = colorVar.value<QColor>();
+                int rangeStart = range.start;
+                int rangeLen = range.length;
+
+                for (int li = 0; li < layout->lineCount(); ++li) {
+                    QTextLine line = layout->lineAt(li);
+                    if (rangeStart >= line.textStart() + line.textLength())
+                        continue;
+                    if (rangeStart + rangeLen <= line.textStart())
+                        break;
+
+                    int lineRangeStart = qMax(rangeStart, line.textStart());
+                    int lineRangeEnd = qMin(
+                        rangeStart + rangeLen,
+                        line.textStart() + line.textLength());
+
+                    qreal x1 =
+                        qRound(line.cursorToX(lineRangeStart) * 2.0) / 2.0;
+                    qreal x2 =
+                        qRound(line.cursorToX(lineRangeEnd) * 2.0) / 2.0;
+                    QRectF lineRect = line.rect();
+
+                    // Bias vertical centering toward cap-height; 0.35 blends
+                    // between tight cap-height and full line-height.
+                    qreal baseline = lineRect.y() + line.ascent();
+                    qreal extra = (lineRect.height() - capH) * 0.35;
+                    qreal textTop = baseline - capH - extra;
+                    qreal textH = capH + 2.0 * extra;
+
+                    QRectF rangeRect(blockRect.x() + qMin(x1, x2),
+                                     blockRect.y() + textTop, qAbs(x2 - x1),
+                                     textH);
+
+                    quint64 fragmentKey =
+                        pillFragmentKey(groupId >= 0 ? groupId : rangeStart,
+                                        li);
+
+                    if (pillGroups.contains(fragmentKey)) {
+                        pillGroups[fragmentKey].rect =
+                            pillGroups[fragmentKey].rect.united(rangeRect);
+                    } else {
+                        pillGroups[fragmentKey] = {pillColor, rangeRect, li};
+                    }
+                }
+            }
+
+            // Add padding around each pill fragment and keep overlap handling
+            // scoped to the visual line where it is drawn.
+            struct DrawnPill {
+                QRectF baseRect;
+                QRectF rect;
+                QColor color;
+            };
+            QHash<int, QList<DrawnPill>> pillsByLine;
+            for (auto it = pillGroups.constBegin(); it != pillGroups.constEnd();
+                 ++it) {
+                DrawnPill pill;
+                pill.baseRect = it.value().rect;
+                pill.rect = pill.baseRect.adjusted(
+                    -PillRenderer::PillHPad,
+                    -PillRenderer::PillVPad,
+                    PillRenderer::PillHPad,
+                    PillRenderer::PillVPad);
+                pill.color = it.value().color;
+                pillsByLine[it.value().lineIndex].append(pill);
+            }
+
+            QList<int> lineIndexes = pillsByLine.keys();
+            std::sort(lineIndexes.begin(), lineIndexes.end());
+
+            for (int lineIndex : lineIndexes) {
+                auto &pills = pillsByLine[lineIndex];
+
+                std::sort(pills.begin(), pills.end(),
+                          [](const DrawnPill &a, const DrawnPill &b) {
+                              return a.rect.left() < b.rect.left();
+                          });
+
+                // Shrink overlapping padding symmetrically, clamped to
+                // PillMinHPad, only among pills that share this visual line.
+                for (int i = 0; i + 1 < pills.size(); ++i) {
+                    qreal overlap =
+                        pills[i].rect.right() - pills[i + 1].rect.left() +
+                        PillRenderer::PillMinGap;
+                    if (overlap > 0) {
+                        qreal shrink = overlap / 2.0;
+                        pills[i].rect.setRight(
+                            qMax(pills[i].rect.right() - shrink,
+                                 pills[i].baseRect.right() +
+                                     PillRenderer::PillMinHPad));
+                        pills[i + 1].rect.setLeft(
+                            qMin(pills[i + 1].rect.left() + shrink,
+                                 pills[i + 1].baseRect.left() -
+                                     PillRenderer::PillMinHPad));
+                    }
+                }
+
+                for (auto &pill : pills) {
+                    if (pill.rect.left() < 1.0)
+                        pill.rect.setLeft(1.0);
+                }
+
+                for (const auto &pill : pills) {
+                    qreal halfHeight = pill.rect.height() / 2.0;
+                    qreal r = qMin(PillRenderer::PillMaxRadius, halfHeight);
+                    r = qMax(r, PillRenderer::PillMinRadius);
+
+                    painter.setBrush(pill.color);
+                    painter.drawRoundedRect(pill.rect, r, r);
+                }
+            }
+        }
+        block = block.next();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip handling
+// ---------------------------------------------------------------------------
+
+bool PillRenderer::handleTooltip(QHelpEvent *helpEvent) {
+    if (!m_enabled)
+        return false;
+
+    auto *doc = m_host->document();
+    QPointF pos = helpEvent->pos();
+    int charPos = doc->documentLayout()->hitTest(
+        pos + QPointF(m_host->horizontalScrollBar()->value(),
+                      m_host->verticalScrollBar()->value()),
+        Qt::ExactHit);
+
+    if (charPos >= 0) {
+        QTextBlock block = doc->findBlock(charPos);
+        if (block.isValid() && block.layout()) {
+            int posInBlock = charPos - block.position();
+            for (const auto &range : block.layout()->formats()) {
+                if (posInBlock >= range.start &&
+                    posInBlock < range.start + range.length) {
+                    QString tip = range.format.toolTip();
+                    if (!tip.isEmpty()) {
+                        QToolTip::showText(helpEvent->globalPos(), tip,
+                                           m_host);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    QToolTip::hideText();
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Highlighting + letter-spacing
+// ---------------------------------------------------------------------------
+
+void PillRenderer::applyPillHighlighting() {
+    refreshPillState();
+}
+
+// ---------------------------------------------------------------------------
+// Enable / disable
+// ---------------------------------------------------------------------------
+
+void PillRenderer::setEnabled(bool enabled) {
+    if (m_enabled == enabled)
+        return;
+
+    m_enabled = enabled;
+    m_highlighter->setEnabled(enabled);
+    m_host->highlight();
+}
+
+void PillRenderer::setPillColors(const PillColorScheme &scheme) {
+    m_highlighter->setPillColors(scheme);
+}
+
+void PillRenderer::setSelectedCallsign(const QString &callsign) {
+    if (callsign.compare(m_selectedCallsign, Qt::CaseInsensitive) == 0)
+        return;
+
+    m_selectedCallsign = callsign.toUpper();
+    m_highlighter->setSelectedCallsign(callsign);
+    m_host->highlight();
+}
+
+void PillRenderer::refreshPillState() {
+    auto *doc = m_host->document();
+    if (!doc)
+        return;
+
+    Q_ASSERT(m_host->isInternalDocumentMutationActive());
+
+    doc->setDocumentMargin(m_enabled ? PillRenderer::PillHPad
+                                     : m_defaultDocumentMargin);
+    applyLineHeight(m_enabled);
+    m_highlighter->rehighlight();
+    clearPillLetterSpacing();
+    if (m_enabled)
+        applyPillLetterSpacing();
+
+    m_host->viewport()->update();
+}
+
+void PillRenderer::applyLineHeight(bool enabled) const {
+    QTextBlock block = m_host->document()->firstBlock();
+    while (block.isValid()) {
+        QTextBlockFormat blockFmt = block.blockFormat();
+        const int targetHeight =
+            enabled ? 140 : m_defaultBlockFormat.lineHeight();
+        const auto targetType = enabled ? QTextBlockFormat::ProportionalHeight
+                                        : m_defaultBlockFormat.lineHeightType();
+
+        if (blockFmt.lineHeight() != targetHeight ||
+            blockFmt.lineHeightType() != targetType) {
+            blockFmt.setLineHeight(targetHeight, targetType);
+            QTextCursor cursor(block);
+            cursor.setBlockFormat(blockFmt);
+        }
+        block = block.next();
+    }
+}
+
+void PillRenderer::clearPillLetterSpacing() const {
+    auto *doc = m_host->document();
+    const qreal interPillMargin =
+        2.0 * PillRenderer::PillHPad + PillRenderer::PillMinGap;
+    const auto isPillSpacing = [interPillMargin](const QTextCharFormat &fmt) {
+        if (fmt.fontLetterSpacingType() != QFont::AbsoluteSpacing)
+            return false;
+        return qFuzzyCompare(fmt.fontLetterSpacing() + 1.0,
+                             PillRenderer::PillHPad + 1.0) ||
+               qFuzzyCompare(fmt.fontLetterSpacing() + 1.0,
+                             interPillMargin + 1.0);
+    };
+
+    const QFont defaultFont = doc->defaultFont();
+    QTextBlock block = doc->firstBlock();
+    while (block.isValid()) {
+        for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
+            const QTextFragment fragment = it.fragment();
+            if (!fragment.isValid())
+                continue;
+
+            const QTextCharFormat currentFmt = fragment.charFormat();
+            if (!isPillSpacing(currentFmt))
+                continue;
+
+            QTextCursor cursor(doc);
+            cursor.setPosition(fragment.position());
+            cursor.setPosition(fragment.position() + fragment.length(),
+                               QTextCursor::KeepAnchor);
+
+            QTextCharFormat resetFmt;
+            resetFmt.setFontLetterSpacing(defaultFont.letterSpacing());
+            resetFmt.setFontLetterSpacingType(defaultFont.letterSpacingType());
+            cursor.mergeCharFormat(resetFmt);
+        }
+        block = block.next();
+    }
+}
+
+void PillRenderer::applyPillLetterSpacing() const {
+    auto *doc = m_host->document();
+    const qreal pillMargin = PillRenderer::PillHPad;
+    const qreal interPillMargin =
+        2.0 * PillRenderer::PillHPad + PillRenderer::PillMinGap;
+
+    struct SpaceInfo {
+        int absPos;
+        qreal spacing;
+    };
+    QList<SpaceInfo> spacesToAdjust;
+
+    QTextBlock block = doc->firstBlock();
+    while (block.isValid()) {
+        QTextLayout *layout = block.layout();
+        if (layout) {
+            QHash<int, int> groupEnds;
+            QSet<int> pillStarts;
+            for (const auto &range : layout->formats()) {
+                auto colorVar = range.format.property(
+                    DirectedMessageHighlighter::PillColorProperty);
+                if (!colorVar.isValid())
+                    continue;
+                auto groupVar = range.format.property(
+                    DirectedMessageHighlighter::PillGroupProperty);
+                int groupId = groupVar.isValid() ? groupVar.toInt() : -1;
+                int end = range.start + range.length;
+                if (!groupEnds.contains(groupId) || end > groupEnds[groupId])
+                    groupEnds[groupId] = end;
+                pillStarts.insert(range.start);
+            }
+
+            const QString text = block.text();
+            for (auto it = groupEnds.constBegin(); it != groupEnds.constEnd();
+                 ++it) {
+                const int end = it.value();
+                if (end < text.length() && text.at(end) == QLatin1Char(' ')) {
+                    const bool nextIsPill = pillStarts.contains(end + 1);
+                    const qreal spacing =
+                        nextIsPill ? interPillMargin : pillMargin;
+                    spacesToAdjust.append({block.position() + end, spacing});
+                }
+            }
+        }
+        block = block.next();
+    }
+
+    for (const auto &si : spacesToAdjust) {
+        QTextCursor cursor(doc);
+        cursor.setPosition(si.absPos);
+        cursor.movePosition(QTextCursor::NextCharacter,
+                            QTextCursor::KeepAnchor);
+        QTextCharFormat fmt;
+        fmt.setFontLetterSpacing(si.spacing);
+        fmt.setFontLetterSpacingType(QFont::AbsoluteSpacing);
+        cursor.mergeCharFormat(fmt);
+    }
+}

--- a/JS8_Main/PillRenderer.h
+++ b/JS8_Main/PillRenderer.h
@@ -1,0 +1,83 @@
+/**
+ * @file PillRenderer.h
+ * @brief Pill-shaped visual highlights for directed message tokens.
+ */
+
+#ifndef PILLRENDERER_H
+#define PILLRENDERER_H
+
+#include <QObject>
+#include <QString>
+#include <QTextBlockFormat>
+
+class QHelpEvent;
+class QPaintEvent;
+class DirectedMessageHighlighter;
+class TransmitTextEdit;
+struct PillColorScheme;
+
+/**
+ * @class PillRenderer
+ * @brief Renders pill-shaped backgrounds for a QTextEdit host.
+ *
+ * Owns a DirectedMessageHighlighter and drives it during each highlight cycle.
+ * Paints rounded-rectangle pill backgrounds behind highlighted tokens, handles
+ * tooltips on hover, and adjusts letter-spacing for proper pill padding.
+ */
+class PillRenderer : public QObject {
+    Q_OBJECT
+
+  public:
+    // Pill geometry constants — used by paintPills() and applyPillHighlighting().
+    static constexpr qreal PillHPad      = 8.0;   ///< Horizontal padding.
+    static constexpr qreal PillVPad      = 3.0;   ///< Vertical padding.
+    static constexpr qreal PillMaxRadius = 11.0;   ///< Maximum corner radius.
+    static constexpr qreal PillMinRadius = 7.0;    ///< Minimum corner radius.
+    static constexpr qreal PillMinHPad   = 5.0;   ///< Floor during overlap resolution.
+    static constexpr qreal PillMinGap    = 5.0;    ///< Minimum gap between adjacent pills.
+
+    /**
+     * @brief Construct a PillRenderer attached to the given text edit.
+     * @param host   TransmitTextEdit whose document is highlighted and whose
+     *               viewport receives pill painting.
+     * @param parent QObject parent (typically the host itself).
+     */
+    explicit PillRenderer(TransmitTextEdit *host, QObject *parent = nullptr);
+
+    /**
+     * @brief Paint pill backgrounds behind highlighted tokens.
+     *        Call *before* the base-class paintEvent so pills appear behind text.
+     */
+    void paintPills(QPaintEvent *event);
+
+    /**
+     * @brief Handle a tooltip event by hit-testing pill format ranges.
+     * @return true if a tooltip was shown, false otherwise.
+     */
+    bool handleTooltip(QHelpEvent *helpEvent);
+
+    /**
+     * @brief Run the syntax highlighter and adjust letter-spacing around pills.
+     */
+    void applyPillHighlighting();
+
+    void setEnabled(bool enabled);
+    bool isEnabled() const;
+    void setPillColors(const PillColorScheme &scheme);
+    void setSelectedCallsign(const QString &callsign);
+
+  private:
+    void refreshPillState();
+    void applyLineHeight(bool enabled) const;
+    void clearPillLetterSpacing() const;
+    void applyPillLetterSpacing() const;
+
+    TransmitTextEdit *m_host;
+    DirectedMessageHighlighter *m_highlighter;
+    qreal m_defaultDocumentMargin = 0.0;
+    QTextBlockFormat m_defaultBlockFormat;
+    bool m_enabled = true;
+    QString m_selectedCallsign;
+};
+
+#endif // PILLRENDERER_H

--- a/JS8_Main/TransmitTextEdit.cpp
+++ b/JS8_Main/TransmitTextEdit.cpp
@@ -4,14 +4,79 @@
  */
 
 #include "TransmitTextEdit.h"
+
 #include "JS8_Include/commons.h"
+#include "JS8_Include/pimpl_impl.h"
+#include "PillRenderer.h"
+#include "TransmitTextSourceMirror.h"
 #include "Varicode.h"
 
+#include <QHelpEvent>
+#include <QKeyEvent>
 #include <QLoggingCategory>
+#include <QSignalBlocker>
+#include <QTextDocument>
 
 #include <iterator>
 
 Q_DECLARE_LOGGING_CATEGORY(transmittextedit_js8)
+
+namespace {
+
+QString normalizeText(const QString &text) {
+#if JS8_ALLOW_EXTENDED
+    QString normalized = text;
+#else
+    QString normalized = text.normalized(QString::NormalizationForm_KD);
+#endif
+
+    QString result;
+    std::copy_if(normalized.begin(), normalized.end(),
+                 std::back_inserter(result), [](auto const c) {
+                     auto const lc = c.toLatin1();
+                     return (lc && (lc == 0x10 || lc == 0x1A ||
+                                    ((lc >= 32) && (lc <= 127))))
+#if JS8_ALLOW_UNICODE
+                            || c.isPrint();
+#elif JS8_ALLOW_EXTENDED
+        || Varicode::extendedChars().contains(c.toUpper())
+#endif
+                     ;
+                 });
+
+    return result;
+}
+
+void assertSourceMirrorSynchronized(const TransmitTextEdit *edit) {
+#ifndef NDEBUG
+    Q_ASSERT(normalizeText(edit->QTextEdit::toPlainText().toUpper()) ==
+             edit->toPlainText());
+#else
+    Q_UNUSED(edit)
+#endif
+}
+
+} // namespace
+
+class ScopedDocumentMutation {
+  public:
+    explicit ScopedDocumentMutation(TransmitTextEdit *edit)
+        : m_edit(edit), m_blocker(edit ? edit->document() : nullptr) {
+        if (m_edit) {
+            m_edit->beginInternalDocumentMutation();
+        }
+    }
+
+    ~ScopedDocumentMutation() {
+        if (m_edit) {
+            m_edit->endInternalDocumentMutation();
+        }
+    }
+
+  private:
+    TransmitTextEdit *m_edit;
+    QSignalBlocker m_blocker;
+};
 
 void setTextEditFont(QTextEdit *edit, QFont font) {
     // all uppercase
@@ -67,27 +132,8 @@ void setTextEditStyle(QTextEdit *edit, QColor fg, QColor bg, QFont font) {
 
 void highlightBlock(QTextBlock block, QFont font, QColor foreground,
                     QColor background) {
+    Q_UNUSED(background)
     QTextCursor cursor(block);
-
-    // Set background color
-    QTextBlockFormat blockFormat = cursor.blockFormat();
-    blockFormat.setBackground(background);
-    cursor.setBlockFormat(blockFormat);
-
-    // Set font
-    /*
-    for (QTextBlock::iterator it = cursor.block().begin(); !(it.atEnd()); ++it)
-    { QTextCharFormat charFormat = it.fragment().charFormat();
-      charFormat.setFont(font);
-      charFormat.setFontCapitalization(QFont::AllUppercase);
-      charFormat.setForeground(QBrush(foreground));
-
-      QTextCursor tempCursor = cursor;
-      tempCursor.setPosition(it.fragment().position());
-      tempCursor.setPosition(it.fragment().position() + it.fragment().length(),
-    QTextCursor::KeepAnchor); tempCursor.setCharFormat(charFormat);
-    }
-    */
     cursor.select(QTextCursor::BlockUnderCursor);
 
     auto charFormat = cursor.charFormat();
@@ -98,7 +144,8 @@ void highlightBlock(QTextBlock block, QFont font, QColor foreground,
 }
 
 TransmitTextEdit::TransmitTextEdit(QWidget *parent)
-    : QTextEdit(parent), m_sent{0}, m_protected{false} {
+    : QTextEdit(parent), m_sent{0}, m_protected{false}, m_pillRenderer{nullptr},
+      m_sourceMirror{this} {
     connect(this, &QTextEdit::selectionChanged, this,
             &TransmitTextEdit::on_selectionChanged);
     connect(this, &QTextEdit::cursorPositionChanged, this,
@@ -106,54 +153,66 @@ TransmitTextEdit::TransmitTextEdit(QWidget *parent)
     connect(this->document(), &QTextDocument::contentsChange, this,
             &TransmitTextEdit::on_textContentsChanged);
     installEventFilter(this);
+
+    // The visible document is presentation-only. Real undo/redo lives in the
+    // hidden source document so pill formatting cannot pollute history.
+    document()->setUndoRedoEnabled(false);
+
+    m_pillRenderer = new PillRenderer(this, this);
 }
 
+TransmitTextEdit::~TransmitTextEdit() {}
+
 void TransmitTextEdit::setCharsSent(int n) {
-    // Never can send more than the document length.
-    // From the QTextDocument::characterCount() documentation:
-    // As a QTextDocument always contains at least one
-    // QChar::ParagraphSeparator, this method will return at least 1. We do not
-    // send that paragraph separator.
-    n = qMin(n, document()->characterCount() - 1);
-
-    // update sent display
-    auto c = textCursor();
-    c.movePosition(QTextCursor::Start);
-    c.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, n);
-
-    // keep track of sent text
-    m_textSent = c.selectedText().toUpper();
+    n = qMin(n, m_sourceMirror->plainText().size());
     m_sent = n;
-
-    // highlight the sent text
+    m_sourceMirror->updateSentCache();
     highlight();
 }
 
 // override
 QString TransmitTextEdit::toPlainText() const {
-    return QTextEdit::toPlainText().toUpper();
+    return m_sourceMirror->plainText();
 }
 
 // override
 void TransmitTextEdit::setPlainText(const QString &text) {
     m_textSent.clear();
     m_sent = 0;
-    // Do this last, as it may trigger events that, during processing, like to
-    // see m_textSent and m_sent reset.
-    QTextEdit::setPlainText(text);
+    const QString normalized = normalizeText(text.toUpper());
+    if (QTextEdit::toPlainText() == normalized) {
+        m_sourceMirror->syncDocument(normalized);
+        m_sourceMirror->updateSentCache();
+        m_lastText = normalized;
+        m_dirty = true;
+        assertSourceMirrorSynchronized(this);
+        highlight();
+        return;
+    }
+
+    m_sourceMirror->syncDocument(normalized);
+    m_sourceMirror->beginSuppression();
+    QTextEdit::setPlainText(normalized);
+    m_sourceMirror->endSuppression();
 }
 
 //
 void TransmitTextEdit::replaceUnsentText(const QString &text, bool keepCursor) {
+    const QString normalized = normalizeText(text.toUpper());
+
+    m_sourceMirror->replaceUnsentText(m_sent, normalized);
+
+    m_sourceMirror->beginSuppression();
     auto rel = relativeTextCursorPosition(textCursor());
     auto c = textCursor();
+    c.beginEditBlock();
     c.movePosition(QTextCursor::Start);
     c.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, m_sent);
     c.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
     c.removeSelectedText();
-    c.insertText(text);
+    c.insertText(normalized);
+    c.endEditBlock();
 
-    // keep cursor
     if (keepCursor) {
         c.movePosition(QTextCursor::End);
         c.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
@@ -162,33 +221,22 @@ void TransmitTextEdit::replaceUnsentText(const QString &text, bool keepCursor) {
                        rel.second - rel.first);
         setTextCursor(c);
     }
+    m_sourceMirror->endSuppression();
 }
 
 //
 void TransmitTextEdit::replacePlainText(const QString &text, bool keepCursor) {
-    auto rel = relativeTextCursorPosition(textCursor());
-    auto c = textCursor();
-    c.movePosition(QTextCursor::Start);
-    c.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
-    c.removeSelectedText();
-    c.insertText(text);
-
-    // keep cursor
-    if (keepCursor) {
-        c.movePosition(QTextCursor::End);
-        c.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
-                       rel.first);
-        c.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor,
-                       rel.second - rel.first);
-        setTextCursor(c);
-    }
+    const QString normalized = normalizeText(text.toUpper());
+    m_sourceMirror->syncDocument(normalized);
+    m_sourceMirror->beginSuppression();
+    m_sourceMirror->replaceVisiblePlainText(normalized, keepCursor);
+    m_sourceMirror->endSuppression();
 }
 
 //
 void TransmitTextEdit::setFont(QFont f) {
     m_font = f;
 
-    // then rehighlight
     highlight();
 }
 
@@ -198,7 +246,46 @@ void TransmitTextEdit::setFont(QFont f, QColor fg, QColor bg) {
     m_fg = fg;
     m_bg = bg;
 
-    // then rehighlight
+    highlight();
+}
+
+void TransmitTextEdit::undo() {
+    auto *sourceDocument = m_sourceMirror->document();
+    if (!sourceDocument || !sourceDocument->isUndoAvailable()) {
+        return;
+    }
+
+    auto cursorState = m_sourceMirror->captureCursorState();
+    sourceDocument->undo();
+    m_sourceMirror->updateSentCache();
+    m_lastText = m_sourceMirror->plainText();
+    m_dirty = true;
+    m_sourceMirror->beginSyncFromSource();
+    {
+        ScopedDocumentMutation guard(this);
+        m_sourceMirror->syncDisplayFromSource(cursorState, true);
+    }
+    m_sourceMirror->endSyncFromSource();
+    highlight();
+}
+
+void TransmitTextEdit::redo() {
+    auto *sourceDocument = m_sourceMirror->document();
+    if (!sourceDocument || !sourceDocument->isRedoAvailable()) {
+        return;
+    }
+
+    auto cursorState = m_sourceMirror->captureCursorState();
+    sourceDocument->redo();
+    m_sourceMirror->updateSentCache();
+    m_lastText = m_sourceMirror->plainText();
+    m_dirty = true;
+    m_sourceMirror->beginSyncFromSource();
+    {
+        ScopedDocumentMutation guard(this);
+        m_sourceMirror->syncDisplayFromSource(cursorState, true);
+    }
+    m_sourceMirror->endSyncFromSource();
     highlight();
 }
 
@@ -206,9 +293,20 @@ void TransmitTextEdit::setFont(QFont f, QColor fg, QColor bg) {
 void TransmitTextEdit::clear() {
     m_textSent.clear();
     m_sent = 0;
-    // Do this last, as it may trigger events that, during processing, like to
-    // see m_textSent and m_sent reset.
+    if (QTextEdit::toPlainText().isEmpty()) {
+        m_sourceMirror->syncDocument(QString());
+        m_sourceMirror->updateSentCache();
+        m_lastText.clear();
+        m_dirty = true;
+        assertSourceMirrorSynchronized(this);
+        highlight();
+        return;
+    }
+
+    m_sourceMirror->syncDocument(QString());
+    m_sourceMirror->beginSuppression();
     QTextEdit::clear();
+    m_sourceMirror->endSuppression();
 }
 
 void TransmitTextEdit::setProtected(bool protect) { m_protected = protect; }
@@ -257,53 +355,49 @@ void TransmitTextEdit::on_selectionChanged() {
 }
 
 // slot
-void TransmitTextEdit::on_textContentsChanged(int /*pos*/, int rem, int add) {
+void TransmitTextEdit::on_textContentsChanged(int pos, int rem, int add) {
+    if (isInternalDocumentMutationActive() ||
+        m_sourceMirror->isSyncingFromSource()) {
+        return;
+    }
+
     if (rem == 0 && add == 0) {
         return;
     }
 
-    QString text = toPlainText();
-    if (text == m_lastText) {
+    const QString visibleText = QTextEdit::toPlainText();
+    const QString displayText = visibleText.toUpper();
+    QString text = normalizeText(displayText);
+
+    if (!m_sourceMirror->isSuppressing() && text == m_lastText) {
         return;
     }
 
-#if JS8_ALLOW_EXTENDED
-    QString normalized = text;
-#else
-    QString normalized = text.normalized(QString::NormalizationForm_KD);
-#endif
-
-    QString result;
-    std::copy_if(normalized.begin(), normalized.end(),
-                 std::back_inserter(result), [](auto const c) {
-                     auto const lc = c.toLatin1();
-                     return (lc && (lc == 0x10 || lc == 0x1A ||
-                                    ((lc >= 32) && (lc <= 127))))
-#if JS8_ALLOW_UNICODE
-                            || c.isPrint();
-#elif JS8_ALLOW_EXTENDED
-        || Varicode::extendedChars().contains(c.toUpper())
-#endif
-                     ;
-                 });
-
-    if (result != text) {
-        bool blocked = signalsBlocked();
-        blockSignals(true);
+    if (text != displayText) {
         {
-            replacePlainText(result, true);
-            text = result;
+            ScopedDocumentMutation guard(this);
+            m_sourceMirror->replaceVisiblePlainText(text, true);
         }
-        blockSignals(blocked);
+        m_sourceMirror->syncDocument(text);
+    } else if (!m_sourceMirror->isSuppressing()) {
+        const int sourcePos = qBound(0, pos, m_sourceMirror->plainText().size());
+        m_sourceMirror->applyChange(sourcePos, rem, displayText.mid(sourcePos, add));
     }
 
-    highlight();
+    if (m_sourceMirror->plainText() != text) {
+        m_sourceMirror->syncDocument(text);
+    }
 
+    m_sourceMirror->updateSentCache();
     m_dirty = true;
     m_lastText = text;
+    assertSourceMirrorSynchronized(this);
+    highlight();
 }
 
 void TransmitTextEdit::highlightBase() {
+    Q_ASSERT(isInternalDocumentMutationActive());
+
     auto d = document();
     if (!d) {
         return;
@@ -317,6 +411,8 @@ void TransmitTextEdit::highlightBase() {
 }
 
 void TransmitTextEdit::highlightCharsSent() {
+    Q_ASSERT(isInternalDocumentMutationActive());
+
     if (!m_sent) {
         return;
     }
@@ -334,14 +430,52 @@ void TransmitTextEdit::highlightCharsSent() {
     c.movePosition(QTextCursor::Start);
     c.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, m_sent);
 
+    QTextCharFormat defaultFormat;
     auto ch = c.charFormat();
+    ch.setFontUnderline(false);
+    ch.setUnderlineStyle(QTextCharFormat::NoUnderline);
+    ch.setUnderlineColor(defaultFormat.underlineColor());
     ch.setFontStrikeOut(true);
     c.mergeCharFormat(ch);
 }
 
+void TransmitTextEdit::paintEvent(QPaintEvent *event) {
+    m_pillRenderer->paintPills(event);
+    QTextEdit::paintEvent(event);
+}
+
+bool TransmitTextEdit::event(QEvent *e) {
+    if (e->type() == QEvent::ToolTip &&
+        m_pillRenderer->handleTooltip(static_cast<QHelpEvent *>(e)))
+        return true;
+    return QTextEdit::event(e);
+}
+
 void TransmitTextEdit::highlight() {
-    highlightBase();
-    highlightCharsSent();
+    if (m_isHighlighting)
+        return;
+    m_isHighlighting = true;
+
+    {
+        ScopedDocumentMutation guard(this);
+        highlightBase();
+        highlightCharsSent();
+        m_pillRenderer->applyPillHighlighting();
+    }
+
+    m_isHighlighting = false;
+}
+
+void TransmitTextEdit::beginInternalDocumentMutation() {
+    m_sourceMirror->beginInternalMutation();
+}
+
+void TransmitTextEdit::endInternalDocumentMutation() {
+    m_sourceMirror->endInternalMutation();
+}
+
+bool TransmitTextEdit::isInternalDocumentMutationActive() const {
+    return m_sourceMirror->isInternalMutationActive();
 }
 
 QTextCursor::MoveOperation deleteKeyEventToMoveOperation(QKeyEvent *e) {
@@ -457,6 +591,10 @@ bool TransmitTextEdit::eventFilter(QObject * /*o*/, QEvent *e) {
         return false;
     }
 
+    if (k == QKeySequence::Undo || k == QKeySequence::Redo) {
+        return false;
+    }
+
     auto c = textCursor();
 
     auto c2 = QTextCursor(c);
@@ -515,6 +653,22 @@ bool TransmitTextEdit::eventFilter(QObject * /*o*/, QEvent *e) {
     }
 
     return true;
+}
+
+void TransmitTextEdit::keyPressEvent(QKeyEvent *e) {
+    if (e == QKeySequence::Undo) {
+        undo();
+        e->accept();
+        return;
+    }
+
+    if (e == QKeySequence::Redo) {
+        redo();
+        e->accept();
+        return;
+    }
+
+    QTextEdit::keyPressEvent(e);
 }
 
 Q_LOGGING_CATEGORY(transmittextedit_js8, "transmittextedit.js8", QtWarningMsg)

--- a/JS8_Main/TransmitTextEdit.h
+++ b/JS8_Main/TransmitTextEdit.h
@@ -1,6 +1,7 @@
 #ifndef TRANSMITTEXTEDIT_H
 #define TRANSMITTEXTEDIT_H
 
+#include "JS8_Include/pimpl_h.h"
 #include "qt_helpers.h"
 
 #include <QBrush>
@@ -10,14 +11,21 @@
 #include <QTextCursor>
 #include <QTextEdit>
 
+class PillRenderer;
+class ScopedDocumentMutation;
+
 void setTextEditFont(QTextEdit *edit, QFont font);
 void setTextEditStyle(QTextEdit *edit, QColor fg, QColor bg, QFont font);
 void highlightBlock(QTextBlock block, QFont font, QColor foreground,
                     QColor background);
 
 class TransmitTextEdit : public QTextEdit {
+    friend class PillRenderer;
+    friend class ScopedDocumentMutation;
+
   public:
-    TransmitTextEdit(QWidget *parent);
+    explicit TransmitTextEdit(QWidget *parent);
+    ~TransmitTextEdit();
 
     static QPair<int, int> relativeTextCursorPosition(QTextCursor cursor) {
         auto c = QTextCursor(cursor);
@@ -42,6 +50,8 @@ class TransmitTextEdit : public QTextEdit {
     void setPlainText(const QString &text);
     void replaceUnsentText(const QString &text, bool keepCursor);
     void replacePlainText(const QString &text, bool keepCursor);
+    void undo();
+    void redo();
 
     void setFont(QFont f);
     void setFont(QFont f, QColor fg, QColor bg);
@@ -55,25 +65,39 @@ class TransmitTextEdit : public QTextEdit {
     bool isDirty() const { return m_dirty; }
     void setClean() { m_dirty = false; }
 
+    PillRenderer *pillRenderer() const { return m_pillRenderer; }
+
     void highlightBase();
     void highlightCharsSent();
     void highlight();
 
-    bool eventFilter(QObject * /*o*/, QEvent *e);
+    void paintEvent(QPaintEvent *event) override;
+    bool event(QEvent *e) override;
+    bool eventFilter(QObject * /*o*/, QEvent *e) override;
+    void keyPressEvent(QKeyEvent *e) override;
 
   public slots:
     void on_selectionChanged();
     void on_textContentsChanged(int pos, int rem, int add);
 
   private:
+    class source_mirror;
+
+    void beginInternalDocumentMutation();
+    void endInternalDocumentMutation();
+    bool isInternalDocumentMutationActive() const;
+
     QString m_lastText;
     int m_sent;
     QString m_textSent;
     bool m_protected;
-    bool m_dirty;
+    bool m_dirty = false;
     QFont m_font;
     QColor m_fg;
     QColor m_bg;
+    PillRenderer *m_pillRenderer;
+    bool m_isHighlighting = false;
+    pimpl<source_mirror> m_sourceMirror;
 };
 
 #endif // TRANSMITTEXTEDIT_H

--- a/JS8_Main/TransmitTextSourceMirror.cpp
+++ b/JS8_Main/TransmitTextSourceMirror.cpp
@@ -1,0 +1,167 @@
+#include "TransmitTextSourceMirror.h"
+
+#include <QTextCursor>
+#include <QTextDocument>
+
+TransmitTextEdit::source_mirror::source_mirror(TransmitTextEdit *owner)
+    : owner_(owner), document_(new QTextDocument(owner)) {
+    document_->setUndoRedoEnabled(true);
+}
+
+QString TransmitTextEdit::source_mirror::plainText() const {
+    return document_->toPlainText();
+}
+
+TransmitTextEdit::source_mirror::CursorState
+TransmitTextEdit::source_mirror::captureCursorState() const {
+    const QTextCursor cursor = owner_->textCursor();
+    return {cursor.anchor(), cursor.position()};
+}
+
+void TransmitTextEdit::source_mirror::restoreCursorState(
+    const CursorState &state) const {
+    QTextCursor cursor = owner_->textCursor();
+    const int length = owner_->QTextEdit::toPlainText().size();
+    const int anchor = qBound(0, state.anchor, length);
+    const int position = qBound(0, state.position, length);
+    cursor.setPosition(anchor);
+    cursor.setPosition(position, QTextCursor::KeepAnchor);
+    owner_->setTextCursor(cursor);
+}
+
+void TransmitTextEdit::source_mirror::replaceVisiblePlainText(
+    const QString &text, bool keepCursor) const {
+    auto rel =
+        TransmitTextEdit::relativeTextCursorPosition(owner_->textCursor());
+    auto c = owner_->textCursor();
+    c.beginEditBlock();
+    c.movePosition(QTextCursor::Start);
+    c.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    c.removeSelectedText();
+    c.insertText(text);
+    c.endEditBlock();
+
+    if (keepCursor) {
+        c.movePosition(QTextCursor::End);
+        c.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
+                       rel.first);
+        c.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor,
+                       rel.second - rel.first);
+        owner_->setTextCursor(c);
+    }
+}
+
+void TransmitTextEdit::source_mirror::syncDocument(const QString &text) {
+    if (document_->toPlainText() == text) {
+        return;
+    }
+
+    QTextCursor cursor(document_);
+    cursor.beginEditBlock();
+    cursor.select(QTextCursor::Document);
+    cursor.removeSelectedText();
+    cursor.insertText(text);
+    cursor.endEditBlock();
+}
+
+void TransmitTextEdit::source_mirror::replaceUnsentText(int sent,
+                                                        const QString &text) {
+    QTextCursor cursor(document_);
+    cursor.beginEditBlock();
+    cursor.movePosition(QTextCursor::Start);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor,
+                        sent);
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    cursor.removeSelectedText();
+    cursor.insertText(text);
+    cursor.endEditBlock();
+}
+
+void TransmitTextEdit::source_mirror::applyChange(int pos, int rem,
+                                                  const QString &insertedText) {
+    QTextCursor cursor(document_);
+    const int textLength = document_->toPlainText().size();
+    cursor.setPosition(qBound(0, pos, textLength));
+    cursor.beginEditBlock();
+    if (rem > 0) {
+        cursor.movePosition(QTextCursor::NextCharacter,
+                            QTextCursor::KeepAnchor, rem);
+        cursor.removeSelectedText();
+    }
+    if (!insertedText.isEmpty()) {
+        cursor.insertText(insertedText);
+    }
+    cursor.endEditBlock();
+}
+
+void TransmitTextEdit::source_mirror::syncDisplayFromSource(
+    const CursorState &state, bool keepCursor) const {
+    const QString sourceText = plainText();
+    if (owner_->QTextEdit::toPlainText() != sourceText) {
+        owner_->QTextEdit::setPlainText(sourceText);
+    }
+
+    if (keepCursor) {
+        restoreCursorState(state);
+    } else {
+        QTextCursor cursor = owner_->textCursor();
+        cursor.movePosition(QTextCursor::End);
+        owner_->setTextCursor(cursor);
+    }
+}
+
+void TransmitTextEdit::source_mirror::updateSentCache() const {
+    const QString text = plainText();
+    owner_->m_sent = qBound(0, owner_->m_sent, text.size());
+    owner_->m_textSent = text.left(owner_->m_sent);
+}
+
+QTextDocument *TransmitTextEdit::source_mirror::document() const {
+    return document_;
+}
+
+void TransmitTextEdit::source_mirror::beginSuppression() {
+    ++suppressionDepth_;
+}
+
+void TransmitTextEdit::source_mirror::endSuppression() {
+    if (suppressionDepth_ == 0) {
+        return;
+    }
+
+    --suppressionDepth_;
+}
+
+bool TransmitTextEdit::source_mirror::isSuppressing() const {
+    return suppressionDepth_ > 0;
+}
+
+void TransmitTextEdit::source_mirror::beginSyncFromSource() { ++syncDepth_; }
+
+void TransmitTextEdit::source_mirror::endSyncFromSource() {
+    if (syncDepth_ == 0) {
+        return;
+    }
+
+    --syncDepth_;
+}
+
+bool TransmitTextEdit::source_mirror::isSyncingFromSource() const {
+    return syncDepth_ > 0;
+}
+
+void TransmitTextEdit::source_mirror::beginInternalMutation() {
+    ++internalMutationDepth_;
+}
+
+void TransmitTextEdit::source_mirror::endInternalMutation() {
+    if (internalMutationDepth_ == 0) {
+        return;
+    }
+
+    --internalMutationDepth_;
+}
+
+bool TransmitTextEdit::source_mirror::isInternalMutationActive() const {
+    return internalMutationDepth_ > 0;
+}

--- a/JS8_Main/TransmitTextSourceMirror.h
+++ b/JS8_Main/TransmitTextSourceMirror.h
@@ -1,0 +1,50 @@
+#ifndef TRANSMITTEXTSOURCEMIRROR_H
+#define TRANSMITTEXTSOURCEMIRROR_H
+
+#include "TransmitTextEdit.h"
+
+class QTextDocument;
+
+class TransmitTextEdit::source_mirror final {
+  public:
+    struct CursorState {
+        int anchor = 0;
+        int position = 0;
+    };
+
+    explicit source_mirror(TransmitTextEdit *owner);
+
+    QString plainText() const;
+    CursorState captureCursorState() const;
+    void restoreCursorState(const CursorState &state) const;
+    void replaceVisiblePlainText(const QString &text, bool keepCursor) const;
+    void syncDocument(const QString &text);
+    void replaceUnsentText(int sent, const QString &text);
+    void applyChange(int pos, int rem, const QString &insertedText);
+    void syncDisplayFromSource(const CursorState &state,
+                               bool keepCursor) const;
+    void updateSentCache() const;
+
+    QTextDocument *document() const;
+
+    void beginSuppression();
+    void endSuppression();
+    bool isSuppressing() const;
+
+    void beginSyncFromSource();
+    void endSyncFromSource();
+    bool isSyncingFromSource() const;
+
+    void beginInternalMutation();
+    void endInternalMutation();
+    bool isInternalMutationActive() const;
+
+  private:
+    TransmitTextEdit *owner_;
+    QTextDocument *document_ = nullptr;
+    int suppressionDepth_ = 0;
+    int syncDepth_ = 0;
+    int internalMutationDepth_ = 0;
+};
+
+#endif // TRANSMITTEXTSOURCEMIRROR_H

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -398,6 +398,10 @@ UI_Constructor::UI_Constructor(QString const &program_info,
                                         m_config.color_compose_foreground(),
                                         m_config.color_compose_background());
 
+        // update pill enabled state, colors, and rehighlight compose box
+        applyPillSettings();
+        ui->extFreeTextMsgEdit->highlight();
+
         // rehighlight
         auto d = ui->textEditRX->document();
         if (d) {
@@ -419,6 +423,9 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             }
         }
     });
+
+    // Apply initial pill settings (colors_changed is not emitted at startup)
+    applyPillSettings();
 
     setWindowTitle(program_title());
     buildColumnLabelMap();

--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -470,6 +470,10 @@ class Configuration::impl final : public QDialog {
     void fill_port_combo_box(QComboBox *);
     Frequency apply_calibration(Frequency) const;
     Frequency remove_calibration(Frequency) const;
+    void updatePillPreview(QLabel *label, const QColor &bg, const QColor &fg);
+    void choosePillPreviewColor(QColor &target, QLabel *label,
+                                const QColor &bg, const QColor &fg,
+                                const QString &title);
 
     void delete_frequencies();
     void load_frequencies();
@@ -532,6 +536,14 @@ class Configuration::impl final : public QDialog {
     Q_SLOT void on_composeFontButton_clicked();
     Q_SLOT void on_txForegroundButton_clicked();
     Q_SLOT void on_txFontButton_clicked();
+    Q_SLOT void on_pillRecipientBgButton_clicked();
+    Q_SLOT void on_pillRecipientFgButton_clicked();
+    Q_SLOT void on_pillCommandBgButton_clicked();
+    Q_SLOT void on_pillCommandFgButton_clicked();
+    Q_SLOT void on_pillGroupBgButton_clicked();
+    Q_SLOT void on_pillGroupFgButton_clicked();
+    Q_SLOT void on_pillSenderBgButton_clicked();
+    Q_SLOT void on_pillSenderFgButton_clicked();
 
     // typenames used as arguments must match registered type names :(
     Q_SIGNAL void start_transceiver(unsigned seqeunce_number) const;
@@ -669,6 +681,23 @@ class Configuration::impl final : public QDialog {
     QColor next_color_DXCC_;
     QColor color_NewCall_;
     QColor next_color_NewCall_;
+    bool pills_enabled_;
+    QColor color_pill_recipient_bg_;
+    QColor next_color_pill_recipient_bg_;
+    QColor color_pill_recipient_fg_;
+    QColor next_color_pill_recipient_fg_;
+    QColor color_pill_command_bg_;
+    QColor next_color_pill_command_bg_;
+    QColor color_pill_command_fg_;
+    QColor next_color_pill_command_fg_;
+    QColor color_pill_group_bg_;
+    QColor next_color_pill_group_bg_;
+    QColor color_pill_group_fg_;
+    QColor next_color_pill_group_fg_;
+    QColor color_pill_sender_bg_;
+    QColor next_color_pill_sender_bg_;
+    QColor color_pill_sender_fg_;
+    QColor next_color_pill_sender_fg_;
     double txDelay_;
     bool write_logs_;
     bool reset_activity_;
@@ -845,6 +874,15 @@ QColor Configuration::color_compose_foreground() const {
 }
 QColor Configuration::color_DXCC() const { return m_->color_DXCC_; }
 QColor Configuration::color_NewCall() const { return m_->color_NewCall_; }
+bool Configuration::pills_enabled() const { return m_->pills_enabled_; }
+QColor Configuration::color_pill_recipient_bg() const { return m_->color_pill_recipient_bg_; }
+QColor Configuration::color_pill_recipient_fg() const { return m_->color_pill_recipient_fg_; }
+QColor Configuration::color_pill_command_bg() const { return m_->color_pill_command_bg_; }
+QColor Configuration::color_pill_command_fg() const { return m_->color_pill_command_fg_; }
+QColor Configuration::color_pill_group_bg() const { return m_->color_pill_group_bg_; }
+QColor Configuration::color_pill_group_fg() const { return m_->color_pill_group_fg_; }
+QColor Configuration::color_pill_sender_bg() const { return m_->color_pill_sender_bg_; }
+QColor Configuration::color_pill_sender_fg() const { return m_->color_pill_sender_fg_; }
 QFont Configuration::table_font() const { return m_->table_font_; }
 QFont Configuration::text_font() const { return m_->font_; }
 QFont Configuration::rx_text_font() const { return m_->rx_text_font_; }
@@ -1809,6 +1847,15 @@ void Configuration::impl::initialize_models() {
         QString("background: %1; color: %2")
             .arg(color_compose_background_.name())
             .arg(color_compose_foreground_.name()));
+    ui_->pills_enabled_check_box->setChecked(pills_enabled_);
+    updatePillPreview(ui_->pillRecipientLabel, next_color_pill_recipient_bg_,
+                      next_color_pill_recipient_fg_);
+    updatePillPreview(ui_->pillCommandLabel, next_color_pill_command_bg_,
+                      next_color_pill_command_fg_);
+    updatePillPreview(ui_->pillGroupLabel, next_color_pill_group_bg_,
+                      next_color_pill_group_fg_);
+    updatePillPreview(ui_->pillSenderLabel, next_color_pill_sender_bg_,
+                      next_color_pill_sender_fg_);
 
     ui_->sbTxDelay->setValue(txDelay_);
     ui_->PTT_method_button_group->button(rig_params_.ptt_type)
@@ -2109,6 +2156,25 @@ void Configuration::impl::read_settings() {
         settings_->value("colorTableHighlight", "#3498db").toString();
     next_color_table_foreground_ = color_table_foreground_ =
         settings_->value("colorTableForeground", "#000000").toString();
+
+    pills_enabled_ = settings_->value("PillsEnabled", true).toBool();
+
+    next_color_pill_recipient_bg_ = color_pill_recipient_bg_ =
+        settings_->value("colorPillRecipientBg", "#2980b9").toString();
+    next_color_pill_recipient_fg_ = color_pill_recipient_fg_ =
+        settings_->value("colorPillRecipientFg", "#ffffff").toString();
+    next_color_pill_command_bg_ = color_pill_command_bg_ =
+        settings_->value("colorPillCommandBg", "#e67e22").toString();
+    next_color_pill_command_fg_ = color_pill_command_fg_ =
+        settings_->value("colorPillCommandFg", "#ffffff").toString();
+    next_color_pill_group_bg_ = color_pill_group_bg_ =
+        settings_->value("colorPillGroupBg", "#16a085").toString();
+    next_color_pill_group_fg_ = color_pill_group_fg_ =
+        settings_->value("colorPillGroupFg", "#ffffff").toString();
+    next_color_pill_sender_bg_ = color_pill_sender_bg_ =
+        settings_->value("colorPillSenderBg", "#7f8c8d").toString();
+    next_color_pill_sender_fg_ = color_pill_sender_fg_ =
+        settings_->value("colorPillSenderFg", "#ffffff").toString();
 
     if (next_font_.fromString(
             settings_->value("Font", QGuiApplication::font().toString())
@@ -2529,6 +2595,16 @@ void Configuration::impl::write_settings() {
     settings_->setValue("colorTableBackground", color_table_background_);
     settings_->setValue("colorTableHighlight", color_table_highlight_);
     settings_->setValue("colorTableForeground", color_table_foreground_);
+
+    settings_->setValue("PillsEnabled", pills_enabled_);
+    settings_->setValue("colorPillRecipientBg", color_pill_recipient_bg_);
+    settings_->setValue("colorPillRecipientFg", color_pill_recipient_fg_);
+    settings_->setValue("colorPillCommandBg", color_pill_command_bg_);
+    settings_->setValue("colorPillCommandFg", color_pill_command_fg_);
+    settings_->setValue("colorPillGroupBg", color_pill_group_bg_);
+    settings_->setValue("colorPillGroupFg", color_pill_group_fg_);
+    settings_->setValue("colorPillSenderBg", color_pill_sender_bg_);
+    settings_->setValue("colorPillSenderFg", color_pill_sender_fg_);
 
     settings_->setValue("Font", font_.toString());
     settings_->setValue("RXTextFont", rx_text_font_.toString());
@@ -3098,6 +3174,15 @@ void Configuration::impl::accept() {
     color_table_background_ = next_color_table_background_;
     color_table_highlight_ = next_color_table_highlight_;
     color_table_foreground_ = next_color_table_foreground_;
+    pills_enabled_ = ui_->pills_enabled_check_box->isChecked();
+    color_pill_recipient_bg_ = next_color_pill_recipient_bg_;
+    color_pill_recipient_fg_ = next_color_pill_recipient_fg_;
+    color_pill_command_bg_ = next_color_pill_command_bg_;
+    color_pill_command_fg_ = next_color_pill_command_fg_;
+    color_pill_group_bg_ = next_color_pill_group_bg_;
+    color_pill_group_fg_ = next_color_pill_group_fg_;
+    color_pill_sender_bg_ = next_color_pill_sender_bg_;
+    color_pill_sender_fg_ = next_color_pill_sender_fg_;
 
     Q_EMIT self_->colors_changed();
 
@@ -3479,6 +3564,24 @@ QColor getColor(QColor initial, QWidget *parent, QString title) {
     }
 }
 
+void Configuration::impl::updatePillPreview(QLabel *label, const QColor &bg,
+                                            const QColor &fg) {
+    label->setStyleSheet(QString("background: %1; color: %2")
+                             .arg(bg.name())
+                             .arg(fg.name()));
+}
+
+void Configuration::impl::choosePillPreviewColor(
+    QColor &target, QLabel *label, const QColor &bg, const QColor &fg,
+    const QString &title) {
+    auto color = getColor(target, this, title);
+    if (!color.isValid())
+        return;
+
+    target = color;
+    updatePillPreview(label, bg, fg);
+}
+
 void Configuration::impl::on_cqMessagesButton_clicked() {
     auto new_color = getColor(next_color_cq_, this, "CQ Messages Color");
     if (new_color.isValid()) {
@@ -3707,6 +3810,64 @@ void Configuration::impl::on_composeFontButton_clicked() {
         QString("Font (%1 %2)")
             .arg(next_compose_text_font_.family())
             .arg(next_compose_text_font_.pointSize()));
+}
+
+void Configuration::impl::on_pillRecipientBgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_recipient_bg_,
+                           ui_->pillRecipientLabel,
+                           next_color_pill_recipient_bg_,
+                           next_color_pill_recipient_fg_,
+                           QStringLiteral("Recipient Pill Background"));
+}
+
+void Configuration::impl::on_pillRecipientFgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_recipient_fg_,
+                           ui_->pillRecipientLabel,
+                           next_color_pill_recipient_bg_,
+                           next_color_pill_recipient_fg_,
+                           QStringLiteral("Recipient Pill Font"));
+}
+
+void Configuration::impl::on_pillCommandBgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_command_bg_, ui_->pillCommandLabel,
+                           next_color_pill_command_bg_,
+                           next_color_pill_command_fg_,
+                           QStringLiteral("Command Pill Background"));
+}
+
+void Configuration::impl::on_pillCommandFgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_command_fg_, ui_->pillCommandLabel,
+                           next_color_pill_command_bg_,
+                           next_color_pill_command_fg_,
+                           QStringLiteral("Command Pill Font"));
+}
+
+void Configuration::impl::on_pillGroupBgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_group_bg_, ui_->pillGroupLabel,
+                           next_color_pill_group_bg_,
+                           next_color_pill_group_fg_,
+                           QStringLiteral("Group Pill Background"));
+}
+
+void Configuration::impl::on_pillGroupFgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_group_fg_, ui_->pillGroupLabel,
+                           next_color_pill_group_bg_,
+                           next_color_pill_group_fg_,
+                           QStringLiteral("Group Pill Font"));
+}
+
+void Configuration::impl::on_pillSenderBgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_sender_bg_, ui_->pillSenderLabel,
+                           next_color_pill_sender_bg_,
+                           next_color_pill_sender_fg_,
+                           QStringLiteral("Sender Pill Background"));
+}
+
+void Configuration::impl::on_pillSenderFgButton_clicked() {
+    choosePillPreviewColor(next_color_pill_sender_fg_, ui_->pillSenderLabel,
+                           next_color_pill_sender_bg_,
+                           next_color_pill_sender_fg_,
+                           QStringLiteral("Sender Pill Font"));
 }
 
 void Configuration::impl::on_PTT_port_combo_box_activated(int /* index */) {

--- a/JS8_UI/Configuration.h
+++ b/JS8_UI/Configuration.h
@@ -239,6 +239,15 @@ class Configuration final : public QObject {
     QColor color_compose_foreground() const;
     QColor color_DXCC() const;
     QColor color_NewCall() const;
+    bool pills_enabled() const;
+    QColor color_pill_recipient_bg() const;
+    QColor color_pill_recipient_fg() const;
+    QColor color_pill_command_bg() const;
+    QColor color_pill_command_fg() const;
+    QColor color_pill_group_bg() const;
+    QColor color_pill_group_fg() const;
+    QColor color_pill_sender_bg() const;
+    QColor color_pill_sender_fg() const;
     bool pwrBandTxMemory() const;
     bool pwrBandTuneMemory() const;
 

--- a/JS8_UI/Configuration.ui
+++ b/JS8_UI/Configuration.ui
@@ -3963,19 +3963,6 @@ Click, SHIFT+Click and, CRTL+Click to select items</string>
                <property name="bottomMargin">
                 <number>0</number>
                </property>
-               <item row="3" column="1">
-                <spacer name="verticalSpacer_12">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
                <item row="0" column="0">
                 <widget class="QLabel" name="composeLabel">
                  <property name="enabled">
@@ -4018,6 +4005,170 @@ Click, SHIFT+Click and, CRTL+Click to select items</string>
                   <string>Font</string>
                  </property>
                 </widget>
+               </item>
+               <item row="3" column="0" colspan="2">
+                <widget class="QCheckBox" name="pills_enabled_check_box">
+                 <property name="text">
+                  <string>Display callsigns and commands as pills</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0" colspan="2">
+                <widget class="QLabel" name="pillColorsHeaderLabel">
+                 <property name="text">
+                  <string>Pill Colors:</string>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="pillRecipientLabel">
+                 <property name="minimumSize">
+                  <size>
+                   <width>80</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">QLabel{background-color: #2980b9; color: #ffffff}</string>
+                 </property>
+                 <property name="text">
+                  <string>Recipient</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QPushButton" name="pillRecipientBgButton">
+                 <property name="text">
+                  <string>Recipient Background</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QPushButton" name="pillRecipientFgButton">
+                 <property name="text">
+                  <string>Recipient Foreground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="pillCommandLabel">
+                 <property name="minimumSize">
+                  <size>
+                   <width>80</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">QLabel{background-color: #e67e22; color: #ffffff}</string>
+                 </property>
+                 <property name="text">
+                  <string>Command</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QPushButton" name="pillCommandBgButton">
+                 <property name="text">
+                  <string>Command Background</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QPushButton" name="pillCommandFgButton">
+                 <property name="text">
+                  <string>Command Foreground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="pillGroupLabel">
+                 <property name="minimumSize">
+                  <size>
+                   <width>80</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">QLabel{background-color: #16a085; color: #ffffff}</string>
+                 </property>
+                 <property name="text">
+                  <string>Group</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QPushButton" name="pillGroupBgButton">
+                 <property name="text">
+                  <string>Group Background</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QPushButton" name="pillGroupFgButton">
+                 <property name="text">
+                  <string>Group Foreground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="pillSenderLabel">
+                 <property name="minimumSize">
+                  <size>
+                   <width>80</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">QLabel{background-color: #7f8c8d; color: #ffffff}</string>
+                 </property>
+                 <property name="text">
+                  <string>Sender</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QPushButton" name="pillSenderBgButton">
+                 <property name="text">
+                  <string>Sender Background</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QPushButton" name="pillSenderFgButton">
+                 <property name="text">
+                  <string>Sender Foreground</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <spacer name="verticalSpacer_compose">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -442,6 +442,20 @@ void UI_Constructor::writeSettings() {
     m_settings->endGroup();
 }
 
+void UI_Constructor::applyPillSettings() {
+    if (auto *pr = ui->extFreeTextMsgEdit->pillRenderer()) {
+        pr->setPillColors({m_config.color_pill_recipient_bg(),
+                           m_config.color_pill_recipient_fg(),
+                           m_config.color_pill_command_bg(),
+                           m_config.color_pill_command_fg(),
+                           m_config.color_pill_group_bg(),
+                           m_config.color_pill_group_fg(),
+                           m_config.color_pill_sender_bg(),
+                           m_config.color_pill_sender_fg()});
+        pr->setEnabled(m_config.pills_enabled());
+    }
+}
+
 //---------------------------------------------------------- readSettings()
 void UI_Constructor::readSettings() {
     m_settings->beginGroup("UI_Constructor");
@@ -555,6 +569,8 @@ void UI_Constructor::readSettings() {
     ui->extFreeTextMsgEdit->setFont(m_config.compose_text_font(),
                                     m_config.color_compose_foreground(),
                                     m_config.color_compose_background());
+    applyPillSettings();
+    ui->extFreeTextMsgEdit->highlight();
 
     m_settings->endGroup();
 
@@ -5926,6 +5942,7 @@ void UI_Constructor::callsignSelectedChanged(QString /*old*/,
         }
     }
     ui->extFreeTextMsgEdit->setPlaceholderText(placeholderText);
+    ui->extFreeTextMsgEdit->pillRenderer()->setSelectedCallsign(selectedCall);
 
 #if SHOW_CALL_DETAIL_BROWSER
     auto html = generateCallDetail(selectedCall);

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -14,6 +14,7 @@
 #include "JS8_Main/APRSISClient.h"
 #include "JS8_Main/AprsInboundRelay.h"
 #include "JS8_Main/Bands.h"
+#include "JS8_Main/DirectedMessageHighlighter.h"
 #include "JS8_Main/DriftingDateTime.h"
 #include "JS8_Main/FrequencyList.h"
 #include "JS8_Main/Geodesic.h"
@@ -24,6 +25,7 @@
 #include "JS8_Main/MessageServer.h"
 #include "JS8_Main/Modes.h"
 #include "JS8_Main/MultiSettings.h"
+#include "JS8_Main/PillRenderer.h"
 #include "JS8_Main/ProcessThread.h"
 #include "JS8_Main/Radio.h"
 #include "JS8_Main/SelfDestructMessageBox.h"
@@ -533,6 +535,7 @@ class UI_Constructor : public QMainWindow {
     void currentTextChanged();
     void tableSelectionChanged(QItemSelection const &, QItemSelection const &);
     void setupJS8();
+    void applyPillSettings();
 
     int freq() const { return m_freq; }
 


### PR DESCRIPTION
Hi there. I recently had the idee of visibly showing special commands, destination and relay hops in the input text field. See #227 . As nobody replied yet, i have done a few experiments. This is just a draft to illustrate what i meant in my issue. It is coded entirely with ai. If you check it out, the input text field will highlight:
- target call including relay hops as visible pill shape blueish
- special commands like heartbeat, snr, grid, msg and msg to: as orange pill shape.

Have a look ;-)