### PR TITLE
Fixes Failed to create popup. Ensure popup has a transientParent set.

### DIFF
--- a/JS8_Main/CPlotter.cpp
+++ b/JS8_Main/CPlotter.cpp
@@ -721,7 +721,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent *event) {
 
     QToolTip::showText(
         event->globalPosition().toPoint(),
-        QString::number(static_cast<int>(freqFromX(m_lastMouseX))));
+        QString::number(static_cast<int>(freqFromX(m_lastMouseX))), this);
 }
 
 void CPlotter::mouseReleaseEvent(QMouseEvent *event) {


### PR DESCRIPTION
Fixes this warning message on Linux:

Failed to create popup. Ensure popup  QWidgetWindow(xxx, name="qtooltip_labelWindow") has a transientParent set.