### PR TITLE
Add non-versioned development builds for master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,13 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
 
 #------------------------------------------------------------------------------#
-# Project
+# Project configuration. The software build version is set here. If the version
+# is set to 0.0.0 the build will be unversioned and marked as "Development"
 #------------------------------------------------------------------------------#
 
 project(
   JS8Call
-  VERSION   2.6.0
+  VERSION   0.0.0
   LANGUAGES C CXX
 )
 

--- a/JS8_Main/revision_utils.cpp
+++ b/JS8_Main/revision_utils.cpp
@@ -9,22 +9,24 @@
 
 QString version() {
 #if defined(CMAKE_BUILD)
-    QString v{JS8CALL_VERSION};
-#else
-    QString v{"Not for Release"};
-#endif
-
+    QString v = (JS8CALL_VERSION);
+    if (v == ("0.0.0")) {
+        v = QStringLiteral("Development Build %1").arg(QLatin1String(GITSHORT));
+    }
     return v;
+#else
+    QString v{QStringLiteral("Not for Release")};
+#endif
 }
 
 QString program_title() {
-    return QString{"%1(v%2) de KN4CRD"}
+    return QString{"%1 %2"}
         .arg(QCoreApplication::applicationName())
         .arg(QCoreApplication::applicationVersion());
 }
 
 QString program_version() {
-    return QString{"%1 v%2"}
+    return QString{"%1 %2"}
         .arg(QCoreApplication::applicationName())
         .arg(QCoreApplication::applicationVersion());
 }


### PR DESCRIPTION
This is the final implementation of the new CMake versioning system. It removes versioned builds done on master. Only release builds are versioned. It adds an explanation in CMakeLists.txt where the version is set that a 0.0.0 string will result in a development build. Development builds are displayed like so:

<img width="1552" height="1400" alt="Screenshot 2026-03-30 at 20 27 05" src="https://github.com/user-attachments/assets/dbc71936-6cfb-4fc2-bd32-f8883089bdbc" />

If you put any other valid major.minor.patch version in there then it switches to a versioned build, which in this case I changed to the latest release version of MacOS 26.

<img width="1578" height="960" alt="Screenshot 2026-03-30 at 20 49 43" src="https://github.com/user-attachments/assets/7c89eca8-dc22-4557-aa6c-e9c11c8544a4" />

I left in place Allan's "Not for Release" in the event a build is done without being configured with CMake. That is basically a "catch all" in the event someone would configure say Xcode or Qt Creator to do a build without configuring with CMake. The software is then labeled as "Not for Release" since it did come from our official build channels.

So this should fully implement the CMake versioning system that Allan had envisioned. Allan and I talk back and forth on occasion and I told him I would finish implementing this as the final step after the CMake overhaul.