### PR TITLE
Update links for libraries now hosted on js8lib

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -41,12 +41,12 @@ jobs:
 
     - name: Grab build dependeneces
       run: |
-        curl --location --output /tmp/js8lib2.6-MacOS_AppleSilicon_Qt.tar.gz https://github.com/JS8Call-improved/JS8Call-improved/releases/download/lib%2F2.6/js8lib2.6-MacOS_AppleSilicon_Qt.tar.gz
+        curl --location --output /tmp/js8lib3.0-MacOS_AppleSilicon_Qt.tar.gz https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/js8lib3.0-MacOS_AppleSilicon_Qt.tar.gz
         cd /tmp
-        tar zxf /tmp/js8lib2.6-MacOS_AppleSilicon_Qt.tar.gz
+        tar zxf /tmp/js8lib3.0-MacOS_AppleSilicon_Qt.tar.gz
         sudo mv /tmp/js8lib /usr/local/js8lib
 
-        curl --location --output /tmp/ffmpeg_MacOS_arm64.tar.gz https://github.com/JS8Call-improved/JS8Call-improved/releases/download/lib%2F2.6/ffmpeg_MacOS_arm64.tar.gz
+        curl --location --output /tmp/ffmpeg_MacOS_arm64.tar.gz https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/ffmpeg_MacOS_arm64.tar.gz
         tar zxf /tmp/ffmpeg_MacOS_arm64.tar.gz
         sudo mv /tmp/ffmpeg /usr/local/ffmpeg
       

--- a/docs/build_for_Linux.md
+++ b/docs/build_for_Linux.md
@@ -2,7 +2,7 @@
 
 ...and also building Hamlib.
 
-Note: versions of Qt older than 6.5 are deprecated for building JS8Call-improved 2.4 or newer. Use of Qt 6.9.3 is recommended. While other versions of Qt down to 6.5 are possible to use, there is significant risk that unwanted audio or PTT bugs may be injected into your build. The Qt Group is deprecating use of native audio back ends in favor of standardizing on FFmpeg audio, which requires either PulseAudio or PipeWire on linux. Most linux distributions do not ship with Qt 6.9.3 with proper FFmpeg audio support. Instead of using distribution packaged Qt, you can download pre-built Qt 6.9.3 library packages with FFmpeg audio support built-in [here](https://github.com/JS8Call-improved/JS8Call-improved/releases/tag/2.4) for both x86_64 and arm64.
+Note: versions of Qt older than 6.5 are deprecated for building JS8Call-improved 2.4 or newer. Use of Qt 6.9.3 is recommended. While other versions of Qt down to 6.5 are possible to use, there is significant risk that unwanted audio or PTT bugs may be injected into your build. The Qt Group is deprecating use of native audio back ends in favor of standardizing on FFmpeg audio, which requires either PulseAudio or PipeWire on linux. Most linux distributions do not ship with Qt 6.9.3 with proper FFmpeg audio support. Instead of using distribution packaged Qt, you can download pre-built Qt 6.9.3 library packages with FFmpeg audio support built-in [here](https://github.com/JS8Call-improved/js8lib/releases/tag/lib%2F3.0) for both x86_64 and arm64.
 
 Depending on where you install the package (/usr/local/Qt recommended), this will require using `-DCMAKE_PREFIX_PATH=<path_to_your_qt_install>` for build.
 

--- a/docs/build_for_MacOS.md
+++ b/docs/build_for_MacOS.md
@@ -27,7 +27,7 @@ Below are the required libraries and tested versions for a JS8Call-improved buil
 
     If you wish to build the libraries yourself you can clone this [repository](https://github.com/JS8Call-improved/js8lib) and follow the developer instructions. You can check out one of the MacOS branches with `git switch branch-name` and follow the instructions to build your libraries. It's optional to build Qt with the developer library. I recommend building the base libraries and obtaining Qt 6.9.3 with the Online Installer from the Qt Group for Intel builds. For Apple silicon builds you must build the Qt libraries yourself.
     
-    Pre-built libraries without Qt6 can be downloaded [here](https://github.com/JS8Call-improved/JS8Call-improved/releases/tag/lib%2F2.6)
+    Pre-built libraries without Qt6 can be downloaded [here](https://github.com/JS8Call-improved/js8lib/releases/tag/lib%2F3.0)
 
 *   In Terminal create the directory structure to build JS8Call-improved with the following command.
     ```

--- a/docs/build_for_Windows.md
+++ b/docs/build_for_Windows.md
@@ -52,7 +52,7 @@ Windows 10 or 11
 
 * Create a directory called `development` at `C:\development`
 
-* Download the Windows JS8Call-improved development library [here](https://github.com/JS8Call-improved/JS8Call-improved/releases/tag/2.4) and unzip the library inside of the development folder. This will create a folder called `js8lib` which contains the necessary development libraries to build JS8Call-improved
+* Download the Windows JS8Call-improved development library [here](https://github.com/JS8Call-improved/js8lib/releases/tag/lib%2F3.0) and unzip the library inside of the development folder. This will create a folder called `js8lib` which contains the necessary development libraries to build JS8Call-improved
 
 * Next we need to get the JS8Call-improved source code with git. This requires use of the Windows Command shell (installing the Windows PowerShell is recommended). Change to the `C:\development` folder and type `git clone https://github.com/JS8Call-improved/JS8Call-improved.git` This will create a folder called JS8Call-improved which contains the source code.
 

--- a/tools/INSTALL_JS8Call-improved_Debian.sh
+++ b/tools/INSTALL_JS8Call-improved_Debian.sh
@@ -174,9 +174,9 @@ cd ~/development
 if [ ! -d $HOME/.local/lib/Qt ]; then
   mkdir ~/.local/lib
   if [ "${ARCH}" = "aarch64" ]; then
-    wget https://github.com/JS8Call-improved/JS8Call-improved/releases/download/2.4/Qt6.9.3_Linux_aarch64.tar.gz
+    wget https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/Qt6.9.3_Linux_aarch64.tar.gz
   else
-    wget https://github.com/JS8Call-improved/JS8Call-improved/releases/download/2.4/Qt6.9.3_Linux_x86_64.tar.gz
+    wget https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/Qt6.9.3_Linux_x86_64.tar.gz
   fi
 else
   echo "~/.local/lib/Qt already exists......"

--- a/tools/INSTALL_JS8Call-improved_Fedora.sh
+++ b/tools/INSTALL_JS8Call-improved_Fedora.sh
@@ -168,9 +168,9 @@ cd ~/development
 if [ ! -d $HOME/.local/lib/Qt ]; then
   mkdir ~/.local/lib
   if [ "${ARCH}" = "aarch64" ]; then
-    wget https://github.com/JS8Call-improved/JS8Call-improved/releases/download/2.4/Qt6.9.3_Linux_aarch64.tar.gz
+    wget https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/Qt6.9.3_Linux_aarch64.tar.gz
   else
-    wget https://github.com/JS8Call-improved/JS8Call-improved/releases/download/2.4/Qt6.9.3_Linux_x86_64.tar.gz
+    wget https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/Qt6.9.3_Linux_x86_64.tar.gz
   fi
 else
   echo "~/.local/lib/Qt already exists......"


### PR DESCRIPTION
New change for 3.0, libraries and build assets are now hosted on js8lib releases instead of on the main repository releases. This changes the links to where the libraries are hosted. As soon as this is merged so CI builds don't get broken, the build assets 2.6 release on the main repo will be removed.