### PR TITLE
QT Stylesheet of default styles

### DIFF
--- a/.github/workflows/misc/JS8Call-default.qss
+++ b/.github/workflows/misc/JS8Call-default.qss
@@ -1,0 +1,355 @@
+/* JS8Call Default Style Sheet */
+
+/* Reset a few things to catch edge cases as reported by Rob Ruchte (Manjaro with Gnome) */
+
+* {
+  font-size: 11pt;
+  background-color: white;
+  color: #242424;
+  selection-background-color: #242424;
+  selection-color: white;
+}
+
+/* Configuration.ui */
+
+QPushButton:checked#test_PTT_button {
+  background-color: red;
+  border-style    : outset;
+  border-width: 1px;
+  border-radius: 5px;
+  border-color: black;
+  min-width: 5em;
+  padding: 3px;
+}
+
+QLabel#tableSelectionBackgroundLabel {
+  background-color: #3498db;
+}
+
+QLabel#labCQ {
+  background-color: #66ff66;
+}
+
+QLabel#primaryHighlightLabel {
+  background-color: #f1c40f;
+}
+
+QLabel#tableForegroundLabel {
+  background-color: white;
+}
+
+QLabel#tableBackgroundLabel {
+  background-color: white;
+}
+
+QLabel#cqMessagesLabel {
+  background-color: #66ff66;
+}
+
+QLabel#labMyCall {
+  background-color: #ff6666;
+}
+
+QLabel#secondaryHighlightLabel {
+  background-color: #ffff66;
+}   
+
+QLabel#rxLabel {
+  background-color: #ffeaa7;
+}
+
+QLabel#txForegroundLabel {
+  background-color: #ffeaa7;
+}
+
+QLabel#rxForegroundLabel {
+  background-color: #ffeaa7;
+}
+
+QLabel#composeLabel {
+  background-color: white;
+}
+
+/* Pill highlighting */
+
+QLabel:pillRecipientLabel {
+  font-weight:bold;
+  background-color: #2980b9;
+  color: #ffffff;
+}
+
+QLabel:pillCommandLabel {
+  font-weight:bold;
+  background-color: #e67e22;
+  color: #ffffff;
+}
+
+Qlabel:pillGroupLabel {
+  font-weight:bold;
+  background-color: #e74c3c;
+  color: #ffffff;
+}
+
+QLabel:pillSenderLabel {
+  font-weight:bold;
+  background-color: #7f8c8d;
+  color: #ffffff;
+}
+
+/* End Pill highlighting */
+
+/* mainwindow.ui */
+
+QFrame#logWidget {
+  background-color: black;
+}
+
+QFrame#frame {
+  background-color: black;
+  color: white;
+}
+
+QPushButton#dialFreqUpButton {
+  background-color:black  ;
+  background-image:url(":/images/artwork/up.png");
+  background-position: center center;
+  background-repeat:no-repeat;
+  border:1px solid;
+  border-radius:2px;
+}
+
+QLabel#labDialFreqOffset {
+  font-size: 14pt;
+  line-height:12pt;
+  color: white;
+}
+
+QFrame#frame_6 {
+  background-color: black;
+}
+
+QLabel#labCallsign {
+  font-size: 14pt;
+  line-height:12pt;
+  color: white;
+}
+
+Qlabel#labUTC {
+  font-size: 14pt;
+  line-height:12pt;
+  color: white;
+}
+
+QFrame:QPushButton#buttonGrid {
+  background-color: lightgray;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QFrame:QPushButton:checked#buttonGrid {
+  background-color: #6699ff;
+  padding:0.25em 0.25em; font-weight:bold;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton#monitorTxButton {
+  background-color:lightgray  ;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#monitorTxButton {
+  background-color:#22FF22;
+}
+
+QPushButton#monitorTxButton[transmitting="true"] {
+  background-color:#FF2222;
+}
+
+QPushButton#monitorButton {
+  background-color:lightgray  ;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#monitorButton {
+  background-color:#22FF22;
+}
+
+QPushButton#logQSOButton {
+  background-color:lightgray  ;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#logQSOButton {  
+  background-color:#22FF22;
+}
+
+QPushButton#tuneButton {
+  background-color:lightgray  ;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#tuneButton {
+  background-color: #6699ff;
+}
+
+QPushButton#modeButton {
+  background-color: #6699ff  ;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#modeButton {
+  background-color: #6699ff;
+}
+
+QPushButton#spotButton {
+  background-color:lightgray;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#spotButton {
+  background-color: #6699ff;
+}
+
+QTextEdit#textEditRx {
+  background-color: #ffeaa7;
+}
+
+/* Custom Widget is defined in JS8_Main/TransmitTextEdit.h */
+
+QTextEdit:TransmitTextEdit#textEditTx {
+  background-color: white;
+  font-size: 11pt;
+}
+
+QTextEdit:TransmitTextEdit:QTextEdit[readOnly="true"] {
+  background: #EEE;
+  font-style: italic;
+}
+
+QTextEdit:TransmitTextEdit:QTextEdit[transmitting="true"] {
+  background: #EEE;
+  font-style: italic;
+}
+
+QPushButton#hbMacroButton {
+  background-color:lightgray;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#hbMacroButton {
+  font-weight:bold;
+  color:black;
+}
+
+QPushButton#cqMacroButton {
+  background-color:lightgray;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#cqMacroButton {
+  font-weight:bold;
+  color:black;
+}
+
+QPushButton#startTxMacroButton {
+  background-color:lightgray;
+  padding:0.25em 0.25em; font-weight:normal;
+  border-style:solid;
+  border-width:0px;
+  border-radius:2px;
+}
+
+QPushButton:checked#startTxMacroButton {
+  background-color: #22FF22;
+  color: #222;
+}
+
+QPushButton#startTxMacroButton[transmitting="true"] {
+  background-color: #FF2222;
+  color: #222;
+}
+
+QWidget#widget_3 {
+  background-color: black;
+}
+
+QPushButton#readFreq {
+  font-family: helvetica;
+  font-size: 9pt;
+  font-weight: bold;
+  background-color: white;
+  color: black;
+  border-style: solid;
+  border-width:0px;
+  border-color: gray;
+  min-width:40px;
+  min-height:30px;
+}
+
+QPushButton#readFreq[state="warning"] {
+  background-color: orange;
+}
+
+QPushButton#readFreq[state="ok"] {
+  background-color: #22FF22;
+}
+
+QFrame#logWidget {
+  background: black;
+}
+
+/* Custom Widget is defined in JS8_Main/AttenuationSlider.h */
+Qslider:AttenuationSlider#outAttenuation {
+  font-size: 10;
+}
+
+/* Custom Widget is defined in JS8_Main/SignalMeter.h */
+/* Meter component, which displays to the right of the scale, as a  */
+/* level gauge with a peak hold indicator. Displays green when the  */
+/* level is good, yellow when it's too low, red when it's too high. */
+
+QWidget:SignalMeter#signal_meter_widget {
+  color: white;
+  font-size: 11pt;
+}
+
+/* MessagePanel.ui */
+
+QTextEdit#messageTextEdit {
+  background-color: #ffeaa7;
+}
+
+/* WideGraph.ui */
+
+QPushButton:checked#autoDriftButton {
+  font-weight:bold;
+  color:black;
+}


### PR DESCRIPTION
Broken off from PR #232.

Task list to be completed
1. Fully add everything style relevant from the ui files (fonts, etc)
2. As well as items buried in the cpp and header files
3. Verify that the QSS agrees with ui files, such that a user can "switch back"

Caveats:
As @Joe-K0OG Joe [found](https://github.com/JS8Call-improved/JS8Call-improved/issues/244#issuecomment-4207350888) out, there are a few things that are defined in the cpp files that are not in the ui files, and currently need fixes to enable access from a stylesheet.

Currently (as far as I've searched) the following have no QSS mapping, see [comment](https://github.com/JS8Call-improved/JS8Call-improved/issues/244#issuecomment-4208139155) 
```
tx_status_label
config_label
mode_label
last_tx_label
auto_tx_label
progressBar
wpm_label
```

