### PR TITLE
Use preprocessor directives to apply platform-specific styles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,14 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/js8call_config.h"
 )
 
+#------------------------------------------------------------------------------#
+# On Linux we allow QSS theme injection
+#------------------------------------------------------------------------------#
+if (UNIX AND NOT APPLE)
+      target_compile_definitions(
+      ${TARGET} PRIVATE USE_QSS_THEMES)
+endif()
+
 target_precompile_headers(
   ${TARGET} PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/js8call_config.h

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "mainwindow.h"
+#include "styles.h"
 
 #include "moc_mainwindow.cpp"
 
@@ -1389,27 +1390,24 @@ void UI_Constructor::createStatusBar() // createStatusBar
 {
     tx_status_label.setAlignment(Qt::AlignCenter);
     tx_status_label.setMinimumSize(QSize{150, 18});
-    tx_status_label.setStyleSheet("QLabel{background-color: #22ff22; color: #000000}");
-    tx_status_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    tx_status_label.setStyleSheet(txStatusLabelStyle(TxStatusAppearance::Receiving));
     statusBar()->addWidget(&tx_status_label);
 
     last_tx_label.setAlignment(Qt::AlignCenter);
     last_tx_label.setMinimumSize(QSize{150, 18});
-    last_tx_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    last_tx_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    last_tx_label.setStyleSheet(statusLabelStyle());
     statusBar()->addWidget(&last_tx_label);
 
     config_label.setAlignment(Qt::AlignCenter);
     config_label.setMinimumSize(QSize{80, 18});
-    config_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    config_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    config_label.setStyleSheet(statusLabelStyle());
     statusBar()->addWidget(&config_label);
     config_label.hide(); // only shown for non-default configuration
 
     mode_label.setAlignment(Qt::AlignCenter);
     mode_label.setMinimumSize(QSize{80, 18});
-    mode_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    mode_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    mode_label.setStyleSheet(statusLabelStyle());
+
     {
         QString modeLabelText;
         switch (m_nSubMode) {
@@ -1438,32 +1436,26 @@ void UI_Constructor::createStatusBar() // createStatusBar
 
     frequency_label.setAlignment(Qt::AlignCenter);
     frequency_label.setMinimumSize(QSize{110, 18});
-    frequency_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    frequency_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    frequency_label.setStyleSheet(statusLabelStyle());
     frequency_label.setText(QString("Freq: %1").arg(Radio::pretty_frequency_MHz_string(dialFrequency() + freq())));
     statusBar()->addWidget(&frequency_label);
     
     auto_reply_label.setAlignment(Qt::AlignCenter);
     auto_reply_label.setMinimumSize(QSize{110, 18});
-    auto_reply_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    auto_reply_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    auto_reply_label.setStyleSheet(statusLabelStyle());
     QString autoReplyState = ui->actionModeAutoreply->isChecked() ? "On" : "Off";
     statusBar()->addWidget(&auto_reply_label);
 
     statusBar()->addPermanentWidget(&progressBar);
     progressBar.setMinimumSize(QSize{100, 18});
-    if (QStyle *fusion = QStyleFactory::create("Fusion")) {
-        progressBar.setStyle(fusion);
-    }
+    const bool small = true;
     const QColor textColor = this->palette().color(QPalette::WindowText);
-    progressBar.setStyleSheet(QString("QProgressBar { color: %1; text-align: center; }")
-                                  .arg(textColor.name()));
+    progressBar.setStyleSheet(progress_bar_stylesheet(textColor, small));
     progressBar.setFormat("%v/%m");
 
     statusBar()->addPermanentWidget(&wpm_label);
     wpm_label.setMinimumSize(QSize{120, 18});
-    wpm_label.setStyleSheet("QLabel{background-color: #6699ff; color: #000000}");
-    wpm_label.setFrameStyle(QFrame::Panel | QFrame::Sunken);
+    wpm_label.setStyleSheet(statusLabelStyle());
     wpm_label.setAlignment(Qt::AlignCenter);
 }
 
@@ -2734,8 +2726,8 @@ void UI_Constructor::guiUpdate() {
         }
 
         if (m_transmitting) {
-            tx_status_label.setStyleSheet(
-                "QLabel{background-color: #ff2222; color:#000}");
+            tx_status_label.setStyleSheet(txStatusLabelStyle(TxStatusAppearance::Transmitting));
+
             if (m_tune) {
                 tx_status_label.setText("Tx: TUNE");
             } else {
@@ -2747,12 +2739,10 @@ void UI_Constructor::guiUpdate() {
             transmitDisplay(true);
         } else if (m_monitoring) {
             if (m_tx_watchdog) {
-                tx_status_label.setStyleSheet(
-                    "QLabel{background-color: #000; color:#fff}");
+                tx_status_label.setStyleSheet(txStatusLabelStyle(TxStatusAppearance::IdleTimeout));
                 tx_status_label.setText("Idle timeout");
             } else {
-                tx_status_label.setStyleSheet(
-                    "QLabel{background-color: #22ff22; color: #000}");
+                tx_status_label.setStyleSheet(txStatusLabelStyle(TxStatusAppearance::Decoding));
                 tx_status_label.setText(m_decoderBusy ? "Decoding"
                                                       : "Receiving");
             }
@@ -6953,8 +6943,9 @@ void UI_Constructor::tx_watchdog(bool triggered) {
         if (m_auto)
             auto_tx_mode(false);
         stopTx();
-        tx_status_label.setStyleSheet(
-            "QLabel{background-color: #000000; color:#ffffff; }");
+        {
+            tx_status_label.setStyleSheet(txStatusLabelStyle(TxStatusAppearance::IdleTimeout));
+        }
         tx_status_label.setText("Idle timeout");
 
         // if the watchdog is triggered...we're no longer active

--- a/JS8_UI/styles.h
+++ b/JS8_UI/styles.h
@@ -1,0 +1,131 @@
+/**
+ * @file styles.h
+ * @brief header file that defines platform specific label, button, widget and dialog
+ * styles used in functions in the UI_Constructor class that assembles the UI and provides
+ * the proper "look and feel" for each desktop platform
+ *
+ * styles.h was added on 11 Apr, 2026 and is intended to eventually become the default
+ * StyleSheet configuration for the JS8Call user interface.
+ */
+
+#pragma once
+#include <QtGlobal>
+#include <QtGui/QGuiApplication>
+#include <QtCore/QOperatingSystemVersion>
+#include <QtCore/QString>
+
+inline QString statusLabelStyle(const QString& bg = "#6699ff",
+                                const QString& fg = "#000000")
+{
+#if defined(USE_QSS_THEMES)
+    // If a global application stylesheet is active, defer to it and don't override.
+    if (qApp && !qApp->styleSheet().isEmpty()) {
+        return QString();
+    }
+#endif
+
+// Status bar label StyleSheet
+#if defined(Q_OS_MACOS)
+    return QStringLiteral(
+        "QLabel{background-color: %1; color: %2; "
+        "border-radius: 8px; padding: 2px 8px; "
+        "border: 1px solid rgba(0,0,0,0.15)}"
+    ).arg(bg, fg);
+#elif defined(Q_OS_WIN)
+    return QStringLiteral(
+        "QLabel{background-color:%1; color:%2; "
+        "border-radius:4px; padding:0px 8px; "
+        "border:1px solid rgba(0,0,0,0.25)}"
+    ).arg(bg, fg);
+#else // Linux/other
+    return QStringLiteral(
+        "QLabel{background-color:%1; color:%2; "
+        "border-radius:2px; padding:1px 6px; "
+        "border:1px inset rgba(0,0,0,0.18)}"
+    ).arg(bg, fg);
+#endif
+}
+
+// We need special handling for tx_status_label since it technically has four states,
+// however, Receiving and Decoding are the presently the same colors. But this allows
+// Decoding to be set differently if we choose to do so
+enum class TxStatusAppearance {
+    Receiving,    // green on black text
+    Transmitting, // red
+    Decoding,     // same as Receiving
+    IdleTimeout   // black bg, white fg
+};
+
+QString txStatusLabelStyle(TxStatusAppearance appearance);
+
+static inline QString makeStyle(const QString& bg, const QString& fg) {
+#if defined(Q_OS_LINUX)
+    return QString(
+        "QLabel{background-color:%1; color:%2; "
+        "border-radius:2px; padding:1px 6px; "
+        "border:1px inset rgba(0,0,0,0.18);}"
+    ).arg(bg, fg);
+#elif defined(Q_OS_WIN)
+    return QString(
+        "QLabel{background-color:%1; color:%2; "
+        "border-radius:4px; padding:0px 8px; "
+        "border:1px solid rgba(0,0,0,0.25);}"
+    ).arg(bg, fg);
+#elif defined(Q_OS_MACOS)
+    return QString(
+        "QLabel{background-color:%1; color:%2; "
+        "border-radius:8px; padding:2px 8px; "
+        "border:1px solid rgba(0,0,0,0.15);}"
+    ).arg(bg, fg);
+#else
+    // Fallback in the event we're compiling on an operating system not
+    // defined in the above i.e. BSD Unix, etc. So style isn't defined here
+    return QString(
+        "QLabel{background-color:%1; color:%2;}"
+    ).arg(bg, fg);
+#endif
+}
+
+inline QString txStatusLabelStyle(TxStatusAppearance appearance) {
+    switch (appearance) {
+    case TxStatusAppearance::Receiving:
+        return makeStyle("#22ff22", "#000000");
+    case TxStatusAppearance::Transmitting:
+        return makeStyle("#ff2222", "#000000");
+    case TxStatusAppearance::Decoding:
+        return makeStyle("#22ff22", "#000000"); // same as Receiving but we can define a different color if we want
+    case TxStatusAppearance::IdleTimeout:
+        return makeStyle("#000000", "#ffffff");
+    default:
+        return QString(); // no style for compiler fallback
+    }
+}
+
+// QProgressBar StyleSheet
+inline QString progress_bar_stylesheet(const QColor& textColor, bool small = false);
+
+inline QString progress_bar_stylesheet(const QColor& textColor, bool small)
+{
+    const QString base = QString(
+        "QProgressBar {"
+        "  border: 0px;"
+        "  background-color: #ffffff;"
+        "  color: %1;"
+        "  text-align: center;"
+        "  padding: 0px;"
+        "  %2"
+        "}"
+        "QProgressBar::chunk {"
+        "  background-color: #a5cdff;"
+        "  border-radius: %3px;"
+        "  %4"
+        "}"
+    );
+
+    // Unified progress bar across all platforms
+    const int height = small ? 10 : 14;        // overall control height
+    const int radius = small ? 3 : 5;          // roundness of the bar ends
+    const QString barDim = QString("min-height:%1px; max-height:%1px; border-radius:%2px;").arg(height).arg(radius);
+    const QString chunkDim = QString("min-height:%1px;").arg(height);
+    return base.arg(textColor.name(), barDim, QString::number(radius), chunkDim);
+}


### PR DESCRIPTION
- allow QSS theme injection on linux for status bar labels
- remove color definitions from labels that are already defined by the preprocessor
- fix progress bar on MacOS 26 which uses a different style from other platforms