### PR TITLE
Addresses issue #260 Multiple notification audio connections left open

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ target_sources(
   JS8_Audio/AudioDevice.cpp
   JS8_Audio/BWFFile.cpp
   JS8_Audio/NotificationAudio.cpp
+  JS8_Audio/NotificationSoundOutput.cpp
   JS8_Audio/SoundInput.cpp
   JS8_Audio/SoundOutput.cpp
   JS8_JSC/JSC.cpp

--- a/JS8_Audio/NotificationAudio.cpp
+++ b/JS8_Audio/NotificationAudio.cpp
@@ -19,10 +19,10 @@ Q_DECLARE_LOGGING_CATEGORY(notificationaudio_js8)
  * @return None.
  */
 NotificationAudio::NotificationAudio(QObject *parent)
-    : QObject{parent}, m_stream{new SoundOutput} {
-    connect(m_stream.data(), &SoundOutput::status, this,
+    : QObject{parent}, m_stream{new NotificationSoundOutput} {
+    connect(m_stream.data(), &NotificationSoundOutput::status, this,
             &NotificationAudio::status);
-    connect(m_stream.data(), &SoundOutput::error, this,
+    connect(m_stream.data(), &NotificationSoundOutput::error, this,
             &NotificationAudio::error);
 }
 
@@ -115,17 +115,9 @@ void NotificationAudio::stop() { m_stream->stop(); }
 /******************************************************************************/
 
 void NotificationAudio::playEntry(Cache::const_iterator const it) {
-    if (m_buffer.isOpen())
-        m_buffer.close();
-
     auto const &[format, data] = *it;
-
-    m_buffer.setData(data);
-
-    if (m_buffer.open(QIODevice::ReadOnly)) {
-        m_stream->setDeviceFormat(m_device, format, m_msBuffer);
-        m_stream->restart(&m_buffer);
-    }
+    m_stream->setDevice(m_device, m_msBuffer);
+    m_stream->play(data, format);
 }
 
 /**

--- a/JS8_Audio/NotificationAudio.h
+++ b/JS8_Audio/NotificationAudio.h
@@ -1,6 +1,8 @@
 #ifndef NOTIFICATIONAUDIO_H
 #define NOTIFICATIONAUDIO_H
 
+#include "NotificationSoundOutput.h"
+
 #include <QAudioDevice>
 #include <QBuffer>
 #include <QByteArray>
@@ -32,7 +34,7 @@ class NotificationAudio : public QObject {
     static QByteArray pcm24le_to_int32le(const QByteArray &in);
     static bool upmixMonoToStereoInPlace(QAudioFormat &fmt, QByteArray &data);
 
-    QScopedPointer<SoundOutput> m_stream;
+    QScopedPointer<NotificationSoundOutput> m_stream;
     Cache m_cache;
     QAudioDevice m_device;
     QBuffer m_buffer;

--- a/JS8_Audio/NotificationSoundOutput.cpp
+++ b/JS8_Audio/NotificationSoundOutput.cpp
@@ -1,0 +1,176 @@
+/**
+ * @file NotificationSoundOutput.cpp
+ * @brief Self-contained audio output for notification sounds.
+ *
+ * Designed for fire-and-forget playback of buffered audio data.
+ * Manages its own buffer lifecycle and releases the audio device
+ * automatically when playback completes.
+ */
+
+#include "NotificationSoundOutput.h"
+
+#include <QAudioSink>
+#include <QBuffer>
+
+NotificationSoundOutput::NotificationSoundOutput(QObject *parent)
+    : QObject(parent)
+{
+}
+
+NotificationSoundOutput::~NotificationSoundOutput()
+{
+    if (m_sink) {
+        disconnect(m_sink.get(), nullptr, this, nullptr);
+        m_sink->stop();
+    }
+}
+
+/**
+ * @brief Sets the audio device and buffer size.
+ * @param device The QAudioDevice to use.
+ * @param msBuffer The buffer size in milliseconds.
+ */
+void NotificationSoundOutput::setDevice(QAudioDevice const &device,
+                                        unsigned const msBuffer)
+{
+    m_device = device;
+    m_msBuffer = msBuffer;
+}
+
+/**
+ * @brief Sets the attenuation in dB.
+ * @param a The attenuation value (0 = full volume).
+ */
+void NotificationSoundOutput::setAttenuation(qreal const a)
+{
+    Q_ASSERT(0.0 <= a && a <= 999.0);
+    m_volume = qPow(10.0, -a / 20.0);
+
+    if (m_sink)
+        m_sink->setVolume(m_volume);
+}
+
+/**
+ * @brief Plays audio from the provided data and format.
+ * @param data The raw PCM audio data.
+ * @param format The QAudioFormat describing the data.
+ *
+ * Any currently playing notification is stopped and replaced.
+ */
+void NotificationSoundOutput::play(QByteArray const &data,
+                                   QAudioFormat const &format)
+{
+    if (m_sink) {
+        disconnect(m_sink.get(), nullptr, this, nullptr);
+        m_sink->stop();
+    }
+
+    if (m_buffer) {
+        m_buffer->close();
+        m_buffer.reset();
+    }
+
+    if (m_device.isNull()) {
+        Q_EMIT error(tr("No audio output device configured."));
+        return;
+    }
+
+    if (!format.isValid()) {
+        Q_EMIT error(tr("Requested audio format is not valid."));
+        return;
+    }
+
+    if (!m_device.isFormatSupported(format)) {
+        Q_EMIT error(tr("Requested audio format is not supported on device."));
+        return;
+    }
+
+    if (data.isEmpty()) {
+        Q_EMIT error(tr("Audio data is empty."));
+        return;
+    }
+
+    m_buffer.reset(new QBuffer);
+    m_buffer->setData(data);
+
+    if (!m_buffer->open(QIODevice::ReadOnly)) {
+        m_buffer.reset();
+        Q_EMIT error(tr("Unable to open audio buffer."));
+        return;
+    }
+
+    // Only create a new sink if we don't have one, or if the
+    // format has changed since the last playback.
+    if (!m_sink || m_currentFormat != format) {
+        m_sink.reset(new QAudioSink(m_device, format));
+        m_sink->setVolume(m_volume);
+        m_currentFormat = format;
+
+        if (m_msBuffer > 0) {
+            m_sink->setBufferSize(
+                m_sink->format().bytesForDuration(m_msBuffer));
+        }
+    }
+
+    connect(m_sink.get(), &QAudioSink::stateChanged,
+            this, &NotificationSoundOutput::handleStateChanged);
+
+    m_sink->start(m_buffer.get());
+
+    if (m_sink->error() != QAudio::NoError) {
+        Q_EMIT error(tr("Failed to start audio output."));
+        m_sink->stop();
+        if (m_buffer) {
+            m_buffer->close();
+            m_buffer.reset();
+        }
+    }
+}
+
+/**
+ * @brief Stops playback and releases all resources.
+ */
+void NotificationSoundOutput::stop()
+{
+    release();
+}
+
+// Private
+void NotificationSoundOutput::release()
+{
+    if (m_sink) {
+        disconnect(m_sink.get(), nullptr, this, nullptr);
+        m_sink->stop();
+    }
+
+    if (m_buffer) {
+        m_buffer->close();
+        m_buffer.reset();
+    }
+}
+
+/**
+ * @brief Handles state changes from the QAudioSink.
+ * @param newState The new audio state.
+ */
+void NotificationSoundOutput::handleStateChanged(QAudio::State const newState)
+{
+    switch (newState) {
+    case QAudio::ActiveState:
+        Q_EMIT status(tr("Active"));
+        break;
+
+    case QAudio::SuspendedState:
+        Q_EMIT status(tr("Suspended"));
+        break;
+
+    case QAudio::IdleState:
+    case QAudio::StoppedState:
+        if (m_buffer) {
+            m_buffer->close();
+            m_buffer.reset();
+        }
+        Q_EMIT status(tr("Idle"));
+        break;
+    }
+}

--- a/JS8_Audio/NotificationSoundOutput.h
+++ b/JS8_Audio/NotificationSoundOutput.h
@@ -1,0 +1,46 @@
+/**
+ * @file NotificationSoundOutput.h
+ * @brief Self-contained audio output for notification sounds.
+ */
+
+#pragma once
+
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QAudioSink>
+#include <QBuffer>
+#include <QObject>
+#include <qmath.h>
+
+#include <memory>
+
+class NotificationSoundOutput : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit NotificationSoundOutput(QObject *parent = nullptr);
+    ~NotificationSoundOutput() override;
+
+    void setDevice(QAudioDevice const &device, unsigned msBuffer);
+    void setAttenuation(qreal a);
+    void play(QByteArray const &data, QAudioFormat const &format);
+    void stop();
+
+signals:
+    void status(QString message);
+    void error(QString message);
+
+private slots:
+    void handleStateChanged(QAudio::State newState);
+
+private:
+    void release();
+
+    QAudioDevice                  m_device;
+    std::unique_ptr<QAudioSink>   m_sink;
+    std::unique_ptr<QBuffer>      m_buffer;
+    QAudioFormat                  m_currentFormat;
+    qreal                         m_volume  = 1.0;
+    unsigned                      m_msBuffer = 0;
+};


### PR DESCRIPTION
Refactor notification sound playback to prevent orphaned audio connections when simultaneous notifications sounds are played.