### PR TITLE
Fix security vulnerability

### DIFF
--- a/JS8_Main/APRSISClient.cpp
+++ b/JS8_Main/APRSISClient.cpp
@@ -176,10 +176,9 @@ QPair<float, float> APRSISClient::grid2deg(QString locator) {
     foreach (QStringList matched, lats) {
         char x = matched.at(1).at(0).toLatin1();
         char y = matched.at(2).at(0).toLatin1();
-
+        if (i * 2 + 1 >= 22) break;
         valx[i * 2] = x - A;
         valy[i * 2] = y - A;
-
         i++;
         tot++;
     }
@@ -188,9 +187,9 @@ QPair<float, float> APRSISClient::grid2deg(QString locator) {
     foreach (QStringList matched, lons) {
         int x = matched.at(1).toInt();
         int y = matched.at(2).toInt();
+        if (i * 2 + 1 >= 22) break;
         valx[i * 2 + 1] = x;
         valy[i * 2 + 1] = y;
-
         i++;
         tot++;
     }


### PR DESCRIPTION
These were fixed 22-element stack arrays. They get populated by two separate loops over regex matches derived from network input. There was no check that i * 2 or i * 2 + 1 stays within [0, 21]. An attacker can supply an arbitrarily long string and crash JS8Call.

This was reported here:
https://github.com/JS8Call-improved/JS8Call-improved/security/advisories/GHSA-98hp-pjp7-w62x