### PR TITLE
Fix to show status of auto_reply when program is first started.

### DIFF
--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -1443,6 +1443,7 @@ void UI_Constructor::createStatusBar() // createStatusBar
     auto_reply_label.setMinimumSize(QSize{110, 18});
     auto_reply_label.setStyleSheet(statusLabelStyle());
     QString autoReplyState = ui->actionModeAutoreply->isChecked() ? "On" : "Off";
+    auto_reply_label.setText(QString("Auto Reply: %1").arg(autoReplyState));
     statusBar()->addWidget(&auto_reply_label);
 
     statusBar()->addPermanentWidget(&progressBar);


### PR DESCRIPTION
This is a small fix for the Auto Reply label. When the program is first started and automatically enable auto reply on startup is not enabled in the settings, it would show a blank label until the setting was toggled. This fixes that.