### PR TITLE
Replace UI lockup code that prevented a MSG from being composed with

### DIFF
--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -3421,19 +3421,11 @@ bool UI_Constructor::ensureCreateMessageReady(const QString &text) {
 
     if (!ensureKeyNotStuck(text)) {
         on_stopTxButton_clicked();
-
-        ui->monitorButton->setChecked(false);
-        ui->monitorTxButton->setChecked(false);
-        on_monitorButton_clicked(false);
-        on_monitorTxButton_toggled(false);
-
-        foreach (auto obj, this->children()) {
-            if (obj->isWidgetType()) {
-                auto wid = qobject_cast<QWidget *>(obj);
-                wid->setEnabled(false);
-            }
-        }
-
+        JS8MessageBox::warning_message(
+            this,
+            tr("Message Not Sent"),
+            tr("It appears you may have a stuck key (more than 5 repeated characters). "
+               "Please check your keyboard and try again."));
         return false;
     }
 


### PR DESCRIPTION
with a string that contains a word with more than 5 repeated characters with a warning popup message

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/276