### PR TITLE
Change audio notifications dialog so it uses live UI state

### DIFF
--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -2063,10 +2063,7 @@ void Configuration::impl::initialize_models() {
         buttonLayout->addWidget(testPushButton);
 
         connect(testPushButton, &QPushButton::pressed, this,
-                [this, key, pathLabel]() {
-                    // hack for testing...
-                    notifications_enabled_[key] = true;
-                    notifications_paths_[key] = pathLabel->text();
+                [this, key]() {
                     emit this->self_->test_notify(key);
                 });
 
@@ -5170,6 +5167,21 @@ QString Configuration::impl::dump_devices(QString const& title,
     }
     ts << "\n";
     return s;
+}
+
+QString Configuration::test_notification_path(const QString &key) const {
+    if (!m_->ui_->notifications_check_box->isChecked()) {
+        return "";
+    }
+    // Walk the live table to find the path label for this key
+    for (int i = 0; i < m_->ui_->notifications_table_widget->rowCount(); i++) {
+        auto item = m_->ui_->notifications_table_widget->item(i, 0);
+        if (!item || item->data(Qt::UserRole).toString() != key) continue;
+        auto label = qobject_cast<QLabel *>(
+            m_->ui_->notifications_table_widget->cellWidget(i, 2));
+        if (label) return label->text();
+    }
+    return "";
 }
 
 #if !defined(QT_NO_DEBUG_STREAM)

--- a/JS8_UI/Configuration.h
+++ b/JS8_UI/Configuration.h
@@ -86,6 +86,7 @@ class Configuration final : public QObject {
 
     bool notifications_enabled() const;
     QString notification_path(const QString &key) const;
+    QString test_notification_path(const QString &key) const;
     Q_SIGNAL void test_notify(const QString &key);
 
     // These query methods should be used after a call to exec() to

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -5624,7 +5624,11 @@ void UI_Constructor::postDecode(bool is_new, QString const &) {
 }
 
 void UI_Constructor::tryNotify(QString const &key) {
-    if (auto const path = m_config.notification_path(key); !path.isEmpty()) {
+    // During configuration dialog, use live UI state
+    auto const path = m_config.is_active()
+        ? m_config.test_notification_path(key)
+        : m_config.notification_path(key);
+    if (!path.isEmpty()) {
         emit playNotification(path);
     }
 }


### PR DESCRIPTION
This is a fix for Windows and linux that emulates what MacOS QtGui does for configuration dialog handlers. It forces Windows and linux to use live UI state instead of committed state so changed configurations take effect immediately without the use of an "Apply" button to reload configurations. This allows for the simpler MacOS-style configuration dialog without cluttering up the UI with an extra button.

This is labeled as a simple enhancement for Windows and Linux. It is not a bug since it was coded for the MacOS UI conventions and it worked on Windows/Linux as soon as the OK button is pressed.  There was a "hack" noted to make the Test button work on Windows/Linux by closing the config dialog and reopening it on those platforms to reload the global setting.

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/290