### PR TITLE
fix CQ notification in call activity pane

### DIFF
--- a/JS8_Mainwindow/processCommandActivity.cpp
+++ b/JS8_Mainwindow/processCommandActivity.cpp
@@ -737,7 +737,22 @@ void UI_Constructor::processCommandActivity() {
 
         // PROCESS CQ
         else if (d.cmd == " CQ") {
-            qCDebug(mainwindow_js8) << "skipping incoming cq" << d.text;
+            CallDetail cd = {};
+            cd.bits = d.bits;
+            cd.call = d.from;
+            cd.dial = d.dial;
+            cd.offset = d.offset;
+            cd.grid = d.grid;
+            cd.snr = d.snr;
+            cd.tdrift = d.tdrift;
+            cd.submode = d.submode;
+            cd.utcTimestamp = d.utcTimestamp;
+            cd.cqTimestamp = d.utcTimestamp.isValid()
+                                 ? d.utcTimestamp
+                                 : DriftingDateTime::currentDateTimeUtc();
+
+            logCallActivity(cd, true);
+            logHeardGraph(d.from, d.to);
             continue;
         }
 


### PR DESCRIPTION
This fixes an issue that I thought worked, but was brought up on the forum here:
https://js8call.groups.io/g/main/topic/119349038?p=Created,,,20,1,0,0

When a CQ comes in it's supposed to display the little telephone and make the table row turn green. It does not do that, but it does now. This was broken in 2.2.0 and never caught until now.

<img width="750" height="143" alt="Screenshot 2026-05-16 at 21 07 31" src="https://github.com/user-attachments/assets/91fc01ce-960b-4459-ab06-d8bc08e9e033" />
