### PR TITLE
Fix for #298 - APRS CMD not checksumming properly. 

### DIFF
--- a/JS8_Main/Varicode.cpp
+++ b/JS8_Main/Varicode.cpp
@@ -2273,7 +2273,8 @@ Varicode::buildMessageFrames(QString const &mycall, QString const &mygrid,
 
 #if 1
                     bool skipAprsChecksum =
-                        (dirTo.compare("@APRSIS", Qt::CaseInsensitive) == 0);
+                        (dirTo.compare("@APRSIS", Qt::CaseInsensitive) == 0 &&
+                         (dirCmd == " MSG" || dirCmd == " MSG TO:"));
                     int checksumSize =
                         skipAprsChecksum
                             ? 0


### PR DESCRIPTION
This fixes a regression where APRS CMDs don't properly checksum when transmitting. 