### PR TITLE
- Break confirmThenEnqueueMessage member function out of mainwindow.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ target_sources(
   JS8_Mainwindow/processHeartbeatRateLimit.cpp
   JS8_Mainwindow/processRxActivity.cpp
   JS8_Mainwindow/UI_Constructor.cpp
+  JS8_Mainwindow/confirmThenEnqueueMessage.cpp
   JS8_Mode/DecodedText.cpp
   JS8_Mode/Detector.cpp
   JS8_Mode/FrequencyTracker.cpp

--- a/JS8_Mainwindow/confirmThenEnqueueMessage.cpp
+++ b/JS8_Mainwindow/confirmThenEnqueueMessage.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file confirmThenEnqueueMessage.cpp
+ * @brief Member function of the UI_Constructor class.
+ * Handles autoreply confirmation via both local UI notification and
+ * the network API, ensuring the operator and external clients are
+ * kept in sync on pending autoreply transmissions.
+ * @ingroup API Network Message API
+ */
+
+#include "../JS8_UI/mainwindow.h"
+
+/**
+ * @brief Presents a local confirmation dialog and fires a network confirmation request.
+ *
+ * Called from the decoder thread; all Qt and network operations are marshalled
+ * to the GUI thread via QMetaObject::invokeMethod. A SelfDestructMessageBox is
+ * shown to the local operator while simultaneously sending
+ * STATION.AUTOREPLY_CONFIRM_REQUEST to any connected API clients.
+ *
+ * Whichever resolves first — local operator response or timeout — cancels the
+ * other. On acceptance, enqueueMessage() is called and
+ * STATION.AUTOREPLY_CONFIRM_ACCEPTED is sent. On rejection or timeout,
+ * STATION.AUTOREPLY_CONFIRM_EXPIRED is sent.
+ *
+ * @param timeout  Seconds before the confirmation auto-rejects.
+ * @param priority Transmission priority passed to enqueueMessage().
+ * @param message  The autoreply message text shown to the operator and sent over the API.
+ * @param offset   Frequency offset passed to enqueueMessage().
+ * @param c        Callback passed to enqueueMessage() on acceptance.
+ *
+ * @note Requires @ref PendingConfirmation::box to be present in the struct.
+ * @note API 2.6+
+ */
+void UI_Constructor::confirmThenEnqueueMessage(int timeout, int priority,
+                                               QString message, int offset,
+                                               Callback c) {
+    // CRITICAL: called from decoder thread → QTimer/sendNetworkMessage must run in GUI thread
+    QMetaObject::invokeMethod(this, [this, timeout, priority, message, offset, c]() {
+        int id = m_nextConfirmId++;
+
+        // Timer auto-reject after timeout
+        QTimer *timer = new QTimer(this);
+        timer->setSingleShot(true);
+        connect(timer, &QTimer::timeout, this, [this, id]() {
+            if (m_pendingConfirmations.contains(id)) {
+                auto pc = m_pendingConfirmations.take(id);
+                pc.timer->deleteLater();
+                sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_EXPIRED", "",
+                    {{"_ID", QVariant(-1)},
+                     {"CONFIRM_ID", QVariant(id)},
+                     {"MESSAGE", QVariant(pc.message)}});
+                pc.box->close();
+            }
+        });
+
+        // Local popup — same timeout as the network timer
+        SelfDestructMessageBox *m = new SelfDestructMessageBox(
+            timeout, "Autoreply Confirmation Required",
+            QString("A transmission is queued for autoreply:\n\n%1\n\nWould you "
+                    "like to send this transmission?")
+                .arg(message),
+            QMessageBox::Question, QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No, false, this);
+        m->setWindowModality(Qt::NonModal);
+
+        // Build and insert the PendingConfirmation before any signals can fire
+        PendingConfirmation pc;
+        pc.id       = id;
+        pc.priority = priority;
+        pc.message  = message;
+        pc.offset   = offset;
+        pc.callback = c;
+        pc.timer    = timer;
+        pc.box      = m;
+        m_pendingConfirmations.insert(id, pc);
+
+        // Local operator response
+        connect(m, &SelfDestructMessageBox::finished, this,
+            [this, m, id](int) {
+                m->deleteLater();
+
+                if (!m_pendingConfirmations.contains(id))
+                    return; // already resolved by timer
+
+                auto pc = m_pendingConfirmations.take(id);
+                pc.timer->stop();
+                pc.timer->deleteLater();
+
+                if (m->result() == QMessageBox::Yes) {
+                    enqueueMessage(pc.priority, pc.message, pc.offset, pc.callback);
+                    sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_ACCEPTED", pc.message,
+                        {{"_ID", QVariant(-1)},
+                         {"CONFIRM_ID", QVariant(id)},
+                         {"PRIORITY", QVariant(pc.priority)},
+                         {"OFFSET", QVariant(pc.offset)}});
+                } else {
+                    sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_EXPIRED", "",
+                        {{"_ID", QVariant(-1)},
+                         {"CONFIRM_ID", QVariant(id)},
+                         {"MESSAGE", QVariant(pc.message)}});
+                }
+            });
+
+        // Both show() and the network message go out after the map is populated
+        m->show();
+        timer->start(timeout * 1000);
+
+        sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_REQUEST", message,
+            {{"_ID", QVariant(-1)},
+             {"CONFIRM_ID", QVariant(id)},
+             {"PRIORITY", QVariant(priority)},
+             {"OFFSET", QVariant(offset)},
+             {"TIMEOUT", QVariant(timeout)}});
+    });
+}

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -101,7 +101,10 @@ void copyMessage(QStringView const string, char *const array,
 
 } // namespace
 
-void UI_Constructor(); // explicit member function of the UI_Constructor class
+// explicit member function of the UI_Constructor class
+// this is the forward declaration of the constructor contained in
+// JS8_Mainwindow/UI_Constructor.cpp
+void UI_Constructor();
 
 void UI_Constructor::ensureMessageDock()
 {
@@ -152,18 +155,12 @@ void UI_Constructor::ensureMessageDock()
         });
 }
 
-bool checkVersion(); // JS8_Mainwindow/checkVersion.cpp
-
 void UI_Constructor::checkStartupWarnings() {
     if (m_config.check_for_updates()) {
         checkVersion(false);
     }
     ensureCallsignSet(false);
 }
-
-void initializeDummyData(); // JS8_Mainwindow/initializeDummyData.cpp
-
-void initializeGroupMessage(); // JS8_Mainwindow/initializeGroupMessage.cpp
 
 void UI_Constructor::initialize_fonts() {
     set_application_font(m_config.text_font());
@@ -676,8 +673,6 @@ void UI_Constructor::set_application_font(QFont const &font) {
         widget->updateGeometry();
     }
 }
-
-void dataSink(); // JS8_Mainwindow/dataSink.cpp
 
 void UI_Constructor::showSoundInError(const QString &errorMsg) {
     JS8MessageBox::critical_message(this, tr("Error in Sound Input"), errorMsg);
@@ -2199,8 +2194,6 @@ QDateTime UI_Constructor::nextTransmitCycle() {
     return timestamp;
 }
 
-void processDecodeEvent(); // JS8_Mainwindow/processDecodeEvent.cpp
-
 bool UI_Constructor::hasExistingMessageBufferToMe(int *const pOffset) {
     for (auto const [offset, buffer] : m_messageBuffer.asKeyValueRange()) {
         // if this is a valid buffer and it's to me...
@@ -3317,45 +3310,6 @@ void UI_Constructor::addMessageText(QString text, bool clear,
     ui->extFreeTextMsgEdit->setFocus();
 }
 
-void UI_Constructor::confirmThenEnqueueMessage(int timeout, int priority,
-                                               QString message, int offset,
-                                               Callback c) {
-    // CRITICAL: called from decoder thread → QTimer/sendNetworkMessage must run in GUI thread
-    QMetaObject::invokeMethod(this, [this, timeout, priority, message, offset, c]() {
-        int id = m_nextConfirmId++;
-        PendingConfirmation pc;
-        pc.id = id;
-        pc.priority = priority;
-        pc.message = message;
-        pc.offset = offset;
-        pc.callback = c;
-
-        // Timer auto-reject after timeout
-        pc.timer = new QTimer(this);
-        pc.timer->setSingleShot(true);
-        connect(pc.timer, &QTimer::timeout, this, [this, id]() {
-            if (m_pendingConfirmations.contains(id)) {
-                auto pc = m_pendingConfirmations.take(id);
-                delete pc.timer;
-                sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_EXPIRED", "",
-                    {{"_ID", QVariant(-1)},
-                     {"CONFIRM_ID", QVariant(id)},
-                     {"MESSAGE", QVariant(pc.message)}});
-            }
-        });
-        pc.timer->start(timeout * 1000);
-
-        m_pendingConfirmations.insert(id, pc);
-
-        sendNetworkMessage("STATION.AUTOREPLY_CONFIRM_REQUEST", message,
-            {{"_ID", QVariant(-1)},
-             {"CONFIRM_ID", QVariant(id)},
-             {"PRIORITY", QVariant(priority)},
-             {"OFFSET", QVariant(offset)},
-             {"TIMEOUT", QVariant(timeout)}});
-    });
-}
-
 void UI_Constructor::enqueueMessage(int priority, QString message, int offset,
                                     Callback c) {
     m_txMessageQueue.enqueue(PrioritizedMessage{
@@ -3514,8 +3468,6 @@ QString UI_Constructor::hbBlockingPath() const {
     return QDir::toNativeSeparators(
         m_config.writeable_data_dir().absoluteFilePath("hb_blocking.db3"));
 }
-
-void processHeartbeatRateLimit(const QString &callsign); // JS8_Mainwindow/processHeartbeatRateLimit.cpp
 
 void UI_Constructor::restoreMessage() {
     if (m_lastTxMessage.isEmpty()) {
@@ -4828,8 +4780,6 @@ void UI_Constructor::buildCallActivitySortByMenu(QMenu *menu) {
                      {"Mode Speed (slowest first)", "submode"},
                      {"Mode Speed (fastest first)", "-submode"}});
 }
-
-void buildQueryMenu(); // JS8_Mainwindow/buildQueryMenu.cpp
 
 void UI_Constructor::buildRelayMenu(QMenu *menu) {
     auto now = DriftingDateTime::currentDateTimeUtc();
@@ -6195,8 +6145,6 @@ void UI_Constructor::processIdleActivity() {
     }
 }
 
-void processRxActivity(); // JS8_Mainwindow/processRxActivity.cpp
-
 void UI_Constructor::processCompoundActivity() {
     if (m_messageBuffer.isEmpty()) {
         return;
@@ -6296,10 +6244,6 @@ void UI_Constructor::processCompoundActivity() {
         m_lastClosedMessageBufferOffset = freq;
     }
 }
-
-void processBufferedActivity(); // JS8_Mainwindow/processBufferedActivity.cpp
-
-void processCommandActivity(); // JS8_Mainwindow/processCommandActivity.cpp
 
 QString UI_Constructor::inboxPath() {
     return QDir::toNativeSeparators(
@@ -6719,12 +6663,6 @@ void UI_Constructor::displayActivity(bool force) {
     m_rxDisplayDirty = false;
 }
 
-// updateBandActivity
-void displayBandActivity(); // JS8_Mainwindow/displayBandActivity.cpp
-
-// updateCallActivity
-void displayCallActivity(); // JS8_Mainwindow/displayCallActivity.cpp
-
 void UI_Constructor::emitPTT(bool on) {
     qCDebug(mainwindow_js8) << "Setting PTT to" << (on ? "on" : "off");
 
@@ -6780,8 +6718,6 @@ void UI_Constructor::tcpNetworkMessage(Message const &message) {
 
     networkMessage(message);
 }
-
-void networkMessage(); // JS8_Mainwindow/networkMessage.cpp
 
 bool UI_Constructor::canSendNetworkMessage() {
     return m_config.udpEnabled() || m_config.tcpEnabled();

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -224,7 +224,7 @@ class UI_Constructor : public QMainWindow {
     void showSoundInError(const QString &errorMsg);
     void showSoundOutError(const QString &errorMsg);
     void showStatusMessage(const QString &statusMsg);
-    void dataSink(qint64 frames);
+    void dataSink(qint64 frames); // JS8_Mainwindow/dataSink.cpp
     /**
      * The name `guiUpdate` suggests updating of the views from the models
      * (in MVC terms, but we don't do MVC in this project), animations and
@@ -264,13 +264,13 @@ class UI_Constructor : public QMainWindow {
     void addMessageText(QString text, bool clear = false,
                         bool selectFirstPlaceholder = false);
     void confirmThenEnqueueMessage(int timeout, int priority, QString message,
-                                   int offset, Callback c);
+                                   int offset, Callback c); // JS8_Mainwindow/confirmThenEnqueueMessage.cpp
     void enqueueMessage(int priority, QString message, int offset, Callback c);
     void resetMessage();
     void resetMessageUI();
     void restoreMessage();
-    void initializeDummyData();
-    void initializeGroupMessage();
+    void initializeDummyData(); // JS8_Mainwindow/initializeDummyData.cpp
+    void initializeGroupMessage(); // JS8_Mainwindow/initializeGroupMessage.cpp
     bool ensureCallsignSet(bool alert = true);
     bool ensureKeyNotStuck(QString const &text);
     bool ensureNotIdle();
@@ -284,7 +284,7 @@ class UI_Constructor : public QMainWindow {
     void resetMessageTransmitQueue();
     QPair<QString, int> popMessageFrame();
     void tryNotify(const QString &key);
-    void processDecodeEvent(JS8::Event::Variant const &);
+    void processDecodeEvent(JS8::Event::Variant const &); // JS8_Mainwindow/processDecodeEvent.cpp
 
     void updateCQButtonDisplay();
     void updateHBButtonDisplay();
@@ -397,7 +397,7 @@ class UI_Constructor : public QMainWindow {
                          QList<QPair<QString, QString>> values);
     void buildBandActivitySortByMenu(QMenu *menu);
     void buildCallActivitySortByMenu(QMenu *menu);
-    void buildQueryMenu(QMenu *, QString callsign);
+    void buildQueryMenu(QMenu *, QString callsign); // JS8_Mainwindow/buildQueryMenu.cpp
     QMap<QString, QString> buildMacroValues();
     void buildColumnLabelMap();
     void buildSuggestionsMenu(QMenu *menu, QTextEdit *edit,
@@ -450,14 +450,14 @@ class UI_Constructor : public QMainWindow {
     void emitTones();
     void udpNetworkMessage(Message const &message);
     void tcpNetworkMessage(Message const &message);
-    void networkMessage(Message const &message);
+    void networkMessage(Message const &message); // JS8_Mainwindow/networkMessage.cpp
     bool canSendNetworkMessage();
     void sendNetworkMessage(QString const &type, QString const &message);
     void sendNetworkMessage(QString const &type, QString const &message,
                             const QVariantMap &params);
     void pskReporterError(QString const &);
     void TxAgain();
-    void checkVersion(bool alertOnUpToDate);
+    void checkVersion(bool alertOnUpToDate); // JS8_Mainwindow/checkVersion.cpp
     void checkStartupWarnings();
     void clearCallsignSelected();
     void refreshTextDisplay();
@@ -912,7 +912,7 @@ class UI_Constructor : public QMainWindow {
     QMap<QString, QMap<QString, QSet<QString>>>
         m_heardGraphIncomingBandCache; // band -> heard out
 
-    // Pending autoreply confirmations (TCP-based, remplace Qt dialog en headless)
+    // Pending autoreply confirmations (network API and local UI notification)
     struct PendingConfirmation {
         int id;
         int priority;
@@ -920,6 +920,7 @@ class UI_Constructor : public QMainWindow {
         int offset;
         Callback callback;
         QTimer *timer;
+        SelfDestructMessageBox *box;
     };
     int m_nextConfirmId = 0;
     QMap<int, PendingConfirmation> m_pendingConfirmations;
@@ -1022,12 +1023,12 @@ class UI_Constructor : public QMainWindow {
     void clearOffsetDirected(int offset);
     void processActivity(bool force = false);
     void resetTimeDeltaAverage();
-    void processRxActivity();
+    void processRxActivity(); // JS8_Mainwindow/processRxActivity.cpp
     void processIdleActivity();
     void processCompoundActivity();
-    void processBufferedActivity();
-    void processCommandActivity();
-    void processHeartbeatRateLimit(const QString &callsign);
+    void processBufferedActivity(); // JS8_Mainwindow/processBufferedActivity.cpp
+    void processCommandActivity(); // JS8_Mainwindow/processCommandActivity.cpp
+    void processHeartbeatRateLimit(const QString &callsign); // JS8_Mainwindow/processHeartbeatRateLimit.cpp
     QString inboxPath();
     QString hbBlockingPath() const;
     void refreshInboxCounts();
@@ -1048,8 +1049,8 @@ class UI_Constructor : public QMainWindow {
     void processSpots();
     void processTxQueue();
     void displayActivity(bool force = false);
-    void displayBandActivity();
-    void displayCallActivity();
+    void displayBandActivity(); // JS8_Mainwindow/displayBandActivity.cpp
+    void displayCallActivity(); // JS8_Mainwindow/displayCallActivity.cpp
     void enable_DXCC_entity(bool on);
     void setRig(Frequency = 0); // zero frequency means no change
     QDateTime nextTransmitCycle();


### PR DESCRIPTION
and place it in a separate member function file in JS8_Mainwindow
- Add UI hooks for Auto Reply confirmation back into the function
- Remove redundant member function declarations from mainwindow.cpp that left over after moving the function to separate files, leaving only the function call sites
- Move source file comments to the mainwindow header

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/305