### PR TITLE
Rx pane scroll bar fix

### DIFF
--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -506,6 +506,10 @@ void UI_Constructor::readSettings() {
         m_config.reset_activity()
             ? ""
             : m_settings->value("RXActivity", "").toString());
+    QTimer::singleShot(0, this, [this](){
+        ui->textEditRX->verticalScrollBar()->setValue(
+            ui->textEditRX->verticalScrollBar()->maximum());
+    });
     ui->actionShow_Band_Heartbeats_and_ACKs->setChecked(
         m_settings->value("BandHBActivityVisible", true).toBool());
     m_settings->endGroup();
@@ -1012,6 +1016,11 @@ void UI_Constructor::on_actionSettings_triggered() { openSettings(); }
 
 void UI_Constructor::openSettings(int tab) {
     m_config.select_tab(tab);
+    
+    // Save scroll position before opening settings
+    QScrollBar *bar = ui->textEditRX->verticalScrollBar();
+    const bool wasAtBottom = (bar->value() == bar->maximum());
+    const int savedPos = bar->value();
 
     // things that might change that we need know about
     auto callsign = m_config.my_callsign();
@@ -1072,6 +1081,16 @@ void UI_Constructor::openSettings(int tab) {
 
         m_opCall = m_config.opCall();
     }
+    
+    // Restore scroll position after settings dialog
+    QTimer::singleShot(0, this, [this, wasAtBottom, savedPos](){
+        QScrollBar *bar = ui->textEditRX->verticalScrollBar();
+        if (wasAtBottom) {
+            bar->setValue(bar->maximum());
+        } else {
+            bar->setValue(savedPos);
+        }
+    });
 }
 
 void UI_Constructor::prepareApi() {


### PR DESCRIPTION
Force Rx pane scroll bar to the bottom on program start and save the scroll bar position on settings reload.

This fixes an issue noted on the forum where when the Settings dialog is opened and click OK, the scrollbar in the Rx pane will jump back to a certain position in time. I thought this was coming from reloading the settings in JS8Call.ini but I was wrong. I never did find the actual call site that is triggering this. And it does not happen all the time but I also did not figure out the exact set of parameters that sets it off. It appears to happen when there is a variety of ACK's, maybe a directed or two, possibly mixed in with some MSG's you have gotten? Who knows? I only know that it does happen and it started doing that this afternoon. So this is a good opportunity to see if I can fix it.

Since this is not a bug, it is perfectly normal from Qt's standpoint and maybe they even consider it a "feature", and I could not identify the exact mechanism that causes it, I took the easy way out:
- In UI_Constructor::openSettings() save the scroll bar position before we open any settings
- Let that function run its mysterious witchcraft
- Reload the scroll bar position before the function exits

It works, even though it was not quite the type of "fix" I had envisioned.

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/302