### PR TITLE
Waterfall cursor fix for split mode.

### DIFF
--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -1358,6 +1358,7 @@ void UI_Constructor::displayDialFrequency() {
     }
 
     freqOffsetWidget->setValue(audio_frequency);
+    m_wideGraph->setFreq(audio_frequency);
 
     auto const onAir = dial_frequency + audio_frequency;
         frequency_label.setText(QString("Freq: %1").arg(Radio::pretty_frequency_MHz_string(onAir)));


### PR DESCRIPTION
Explanation of issue:
When I added the frequency offset slider I had basically designed it so the frequency offset slider controls the waterfall cursor. At the same time, the waterfall cursor can also control the frequency offset slider. I had hooked it up for HB's, but failed to hook it up for split mode. This causes the frequency slider to display the correct offset, but the waterfall cursor did not move when transmitting in split mode.