### PR TITLE
TCI Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,6 @@ target_link_libraries(
   Qt::SerialPort
   Qt::WebSockets
   Qt::Widgets
-  Qt::WebSockets
 )
 
 #------------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,16 +260,13 @@ target_sources(
   JS8_Audio/AudioOutputStream.h
   JS8_Audio/AudioInputManager.cpp
   JS8_Audio/AudioOutputDevice.h
-  JS8_Audio/AudioOutputManager.h
   JS8_Audio/AudioOutputManager.cpp
   JS8_Audio/BWFFile.cpp
   JS8_Audio/NotificationAudio.cpp
   JS8_Audio/NotificationSoundOutput.cpp
   JS8_Audio/SoundInput.cpp
   JS8_Audio/SoundOutput.cpp
-  JS8_Audio/TCIAudioInput.h
   JS8_Audio/TCIAudioInput.cpp
-  JS8_Audio/TCIAudioOutput.h
   JS8_Audio/TCIAudioOutput.cpp
   JS8_JSC/JSC.cpp
   JS8_JSC/JSC_checker.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,11 +255,22 @@ target_sources(
   ${TARGET} PRIVATE
   vendor/sqlite3/sqlite3.c
   JS8_Audio/AudioDevice.cpp
+  JS8_Audio/AudioInputDevice.h
+  JS8_Audio/AudioInputSource.h
+  JS8_Audio/AudioOutputStream.h
+  JS8_Audio/AudioInputManager.cpp
+  JS8_Audio/AudioOutputDevice.h
+  JS8_Audio/AudioOutputManager.h
+  JS8_Audio/AudioOutputManager.cpp
   JS8_Audio/BWFFile.cpp
   JS8_Audio/NotificationAudio.cpp
   JS8_Audio/NotificationSoundOutput.cpp
   JS8_Audio/SoundInput.cpp
   JS8_Audio/SoundOutput.cpp
+  JS8_Audio/TCIAudioInput.h
+  JS8_Audio/TCIAudioInput.cpp
+  JS8_Audio/TCIAudioOutput.h
+  JS8_Audio/TCIAudioOutput.cpp
   JS8_JSC/JSC.cpp
   JS8_JSC/JSC_checker.cpp
   JS8_JSC/JSC_list.cpp
@@ -340,12 +351,17 @@ target_sources(
   JS8_Network/NetworkServerLookup.cpp
   JS8_Network/PSKReporter.cpp
   JS8_Network/SpotClient.cpp
+  JS8_Network/TCIClient.cpp
+  JS8_Network/TciProtocolHandler.cpp
+  JS8_Network/TCIStreamFrame.cpp
   JS8_Network/TCPClient.cpp
+  JS8_Network/TCISession.cpp
   JS8_Transceiver/DXLabSuiteCommanderTransceiver.cpp
   JS8_Transceiver/EmulateSplitTransceiver.cpp
   JS8_Transceiver/HamlibTransceiver.cpp
   JS8_Transceiver/HRDTransceiver.cpp
   JS8_Transceiver/PollingTransceiver.cpp
+  JS8_Transceiver/TCITransceiver.cpp
   JS8_Transceiver/Transceiver.cpp
   JS8_Transceiver/TransceiverBase.cpp
   JS8_Transceiver/TransceiverFactory.cpp
@@ -375,6 +391,7 @@ target_link_libraries(
   Qt::Multimedia
   Qt::Network
   Qt::SerialPort
+  Qt::WebSockets
   Qt::Widgets
   Qt::WebSockets
 )

--- a/JS8_Audio/AudioInputDevice.h
+++ b/JS8_Audio/AudioInputDevice.h
@@ -1,0 +1,78 @@
+#ifndef AUDIO_INPUT_DEVICE_HPP_
+#define AUDIO_INPUT_DEVICE_HPP_
+
+#include <QAudioDevice>
+#include <QMetaType>
+#include <QUrl>
+
+class AudioInputDevice {
+public:
+  enum class BackendType {
+    System,
+    TCI
+};
+
+  static AudioInputDevice system(QAudioDevice const &device) {
+    AudioInputDevice d;
+    d.m_backendType = BackendType::System;
+    d.m_systemDevice = device;
+    return d;
+  }
+
+  static AudioInputDevice tci(QUrl const &url) {
+    AudioInputDevice d;
+    d.m_backendType = BackendType::TCI;
+    d.m_tciUrl = url;
+    return d;
+  }
+
+  BackendType backendType() const { return m_backendType; }
+
+  bool isSystemAudio() const {
+    return BackendType::System == m_backendType;
+  }
+
+  bool isTCIAudio() const {
+    return BackendType::TCI == m_backendType;
+  }
+
+  QAudioDevice const &systemDevice() const { return m_systemDevice; }
+  QUrl const &tciUrl() const { return m_tciUrl; }
+
+  QString description() const {
+    if (isTCIAudio()) {
+      return QStringLiteral("TCI Network Audio (%1)")
+          .arg(m_tciUrl.toString());
+    }
+
+    return m_systemDevice.description();
+  }
+
+  bool isNull() const
+  {
+    switch (m_backendType) {
+    case BackendType::System:
+      return m_systemDevice.isNull();
+
+    case BackendType::TCI:
+      return !m_tciUrl.isValid() || m_tciUrl.isEmpty();
+
+    default:
+      return true;
+    }
+  }
+
+  bool isValid() const
+  {
+    return !isNull();
+  }
+
+private:
+  BackendType m_backendType = BackendType::System;
+  QAudioDevice m_systemDevice;
+  QUrl m_tciUrl;
+};
+
+Q_DECLARE_METATYPE(AudioInputDevice)
+
+#endif

--- a/JS8_Audio/AudioInputManager.cpp
+++ b/JS8_Audio/AudioInputManager.cpp
@@ -1,0 +1,103 @@
+#include "AudioInputManager.h"
+
+#include "JS8_Audio/SoundInput.h"
+#include "JS8_Audio/TCIAudioInput.h"
+
+#include <QDebug>
+#include <QThread>
+
+AudioInputManager::AudioInputManager(QObject *parent)
+    : QObject(parent),
+      m_systemInput(new SoundInput(this)),
+      m_tciInput(new TCIAudioInput(this))
+{
+    connect(m_systemInput, &SoundInput::error,
+        this, &AudioInputManager::error);
+
+    connect(m_systemInput, &SoundInput::error,
+            this, &AudioInputManager::systemAudioError);
+
+    connect(m_systemInput, &SoundInput::status,
+            this, &AudioInputManager::status);
+
+    connect(m_tciInput, &TCIAudioInput::error,
+            this, &AudioInputManager::error);
+
+    connect(m_tciInput, &TCIAudioInput::error,
+            this, &AudioInputManager::tciAudioError);
+
+    connect(m_tciInput, &TCIAudioInput::status,
+            this, &AudioInputManager::status);
+}
+
+AudioInputManager::~AudioInputManager()
+{
+    stop();
+}
+
+void AudioInputManager::start(AudioInputDevice const &device,
+                              int framesPerBuffer,
+                              AudioDevice *sink,
+                              AudioDevice::Channel channel)
+{
+    stop();
+
+    m_activeBackend = device.backendType();
+
+    switch (device.backendType()) {
+    case AudioInputDevice::BackendType::System:
+        m_systemInput->start(device.systemDevice(),
+                             framesPerBuffer,
+                             sink,
+                             channel);
+        break;
+
+    case AudioInputDevice::BackendType::TCI:
+        m_tciInput->start(device.tciUrl(),
+                          framesPerBuffer,
+                          sink,
+                          AudioDevice::Mono);
+        break;
+    }
+}
+
+void AudioInputManager::suspend()
+{
+    switch (m_activeBackend) {
+    case AudioInputDevice::BackendType::System:
+        m_systemInput->suspend();
+        break;
+
+    case AudioInputDevice::BackendType::TCI:
+        m_tciInput->suspend();
+        break;
+    }
+}
+
+void AudioInputManager::resume()
+{
+    switch (m_activeBackend) {
+    case AudioInputDevice::BackendType::System:
+        m_systemInput->resume();
+        break;
+
+    case AudioInputDevice::BackendType::TCI:
+        m_tciInput->resume();
+        break;
+    }
+}
+
+void AudioInputManager::stop()
+{
+    if (m_systemInput)
+        m_systemInput->stop();
+
+    if (m_tciInput)
+        m_tciInput->stop();
+}
+
+void AudioInputManager::setTciSession(TCISession *session)
+{
+    if (m_tciInput)
+        m_tciInput->setSession(session);
+}

--- a/JS8_Audio/AudioInputManager.h
+++ b/JS8_Audio/AudioInputManager.h
@@ -1,0 +1,43 @@
+#ifndef AUDIO_INPUT_MANAGER_HPP_
+#define AUDIO_INPUT_MANAGER_HPP_
+
+#include "JS8_Audio/AudioDevice.h"
+#include "JS8_Audio/AudioInputDevice.h"
+#include "JS8_Network/TCISession.h"
+
+#include <QObject>
+
+class SoundInput;
+class TCIAudioInput;
+
+class AudioInputManager final : public QObject {
+  Q_OBJECT
+
+public:
+  explicit AudioInputManager(QObject *parent = nullptr);
+  ~AudioInputManager() override;
+
+  Q_SLOT void start(AudioInputDevice const &device, int framesPerBuffer,
+                    AudioDevice *sink,
+                    AudioDevice::Channel channel = AudioDevice::Mono);
+
+  Q_SLOT void suspend();
+  Q_SLOT void resume();
+  Q_SLOT void stop();
+
+  Q_SLOT void setTciSession(TCISession *session);
+
+  Q_SIGNAL void error(QString message) const;
+  Q_SIGNAL void status(QString message) const;
+
+  Q_SIGNAL void systemAudioError(QString message) const;
+  Q_SIGNAL void tciAudioError(QString message) const;
+
+private:
+  SoundInput *m_systemInput = nullptr;
+  TCIAudioInput *m_tciInput = nullptr;
+  AudioInputDevice::BackendType m_activeBackend =
+      AudioInputDevice::BackendType::System;
+};
+
+#endif

--- a/JS8_Audio/AudioInputSource.h
+++ b/JS8_Audio/AudioInputSource.h
@@ -1,0 +1,28 @@
+#ifndef AUDIO_INPUT_SOURCE_HPP_
+#define AUDIO_INPUT_SOURCE_HPP_
+
+#include <QObject>
+
+#include "JS8_Audio/AudioDevice.h"
+
+class AudioInputSource : public QObject {
+  Q_OBJECT
+
+public:
+  explicit AudioInputSource(QObject *parent = nullptr)
+      : QObject(parent) {}
+
+  ~AudioInputSource() override = default;
+
+public Q_SLOTS:
+  virtual void start(unsigned framesBuffered,
+                     AudioDevice *sink,
+                     AudioDevice::Channel channel) = 0;
+
+  virtual void stop() = 0;
+
+  Q_SIGNALS:
+    void error(QString message);
+};
+
+#endif

--- a/JS8_Audio/AudioOutputDevice.h
+++ b/JS8_Audio/AudioOutputDevice.h
@@ -1,0 +1,78 @@
+#ifndef AUDIO_OUTPUT_DEVICE_HPP_
+#define AUDIO_OUTPUT_DEVICE_HPP_
+
+#include <QAudioDevice>
+#include <QMetaType>
+#include <QUrl>
+
+class AudioOutputDevice {
+public:
+  enum class BackendType {
+    System,
+    TCI
+  };
+
+  static AudioOutputDevice system(QAudioDevice const &device) {
+    AudioOutputDevice d;
+    d.m_backendType = BackendType::System;
+    d.m_systemDevice = device;
+    return d;
+  }
+
+  static AudioOutputDevice tci(QUrl const &url) {
+    AudioOutputDevice d;
+    d.m_backendType = BackendType::TCI;
+    d.m_tciUrl = url;
+    return d;
+  }
+
+  BackendType backendType() const { return m_backendType; }
+
+  bool isSystemAudio() const {
+    return BackendType::System == m_backendType;
+  }
+
+  bool isTCIAudio() const {
+    return BackendType::TCI == m_backendType;
+  }
+
+  QAudioDevice const &systemDevice() const { return m_systemDevice; }
+  QUrl const &tciUrl() const { return m_tciUrl; }
+
+  QString description() const {
+    if (isTCIAudio()) {
+      return QStringLiteral("TCI Network Audio (%1)")
+          .arg(m_tciUrl.toString());
+    }
+
+    return m_systemDevice.description();
+  }
+
+  bool isNull() const
+  {
+    switch (m_backendType) {
+    case BackendType::System:
+      return m_systemDevice.isNull();
+
+    case BackendType::TCI:
+      return !m_tciUrl.isValid() || m_tciUrl.isEmpty();
+
+    default:
+      return true;
+    }
+  }
+
+  bool isValid() const
+  {
+    return !isNull();
+  }
+
+private:
+  BackendType m_backendType = BackendType::System;
+  QAudioDevice m_systemDevice;
+  QUrl m_tciUrl;
+};
+
+Q_DECLARE_METATYPE(AudioOutputDevice)
+
+#endif

--- a/JS8_Audio/AudioOutputManager.cpp
+++ b/JS8_Audio/AudioOutputManager.cpp
@@ -1,0 +1,150 @@
+#include "AudioOutputManager.h"
+
+#include "JS8_Audio/SoundOutput.h"
+#include "JS8_Audio/TCIAudioOutput.h"
+
+#include <QtMath>
+
+AudioOutputManager::AudioOutputManager(QObject *parent)
+    : AudioOutputStream(parent),
+      m_systemOutput(new SoundOutput(this)),
+      m_tciOutput(new TCIAudioOutput(this))
+{
+    connect(m_systemOutput, &SoundOutput::error,
+            this, &AudioOutputManager::error);
+
+    connect(m_systemOutput, &SoundOutput::status,
+            this, &AudioOutputManager::status);
+
+    connect(m_tciOutput, &TCIAudioOutput::error,
+            this, &AudioOutputManager::error);
+
+    connect(m_tciOutput, &TCIAudioOutput::status,
+            this, &AudioOutputManager::status);
+}
+
+AudioOutputManager::~AudioOutputManager()
+{
+    stop();
+}
+
+void AudioOutputManager::setDevice(AudioOutputDevice const &device,
+                                   unsigned channels,
+                                   unsigned msBuffered)
+{
+    stop();
+
+    m_device = device;
+    m_activeBackend = device.backendType();
+    m_channels = channels;
+    m_msBuffered = msBuffered;
+
+    switch (m_activeBackend) {
+    case AudioOutputDevice::BackendType::System:
+        m_systemOutput->setFormat(device.systemDevice(),
+                                  m_channels,
+                                  m_msBuffered);
+        m_systemOutput->setAttenuation(m_attenuationDb);
+        break;
+
+    case AudioOutputDevice::BackendType::TCI:
+        if (!m_tciOutput)
+            m_tciOutput = new TCIAudioOutput(this);
+
+        m_tciOutput->setSession(m_tciSession);
+        m_tciOutput->setUrl(device.tciUrl());
+        m_tciOutput->set_attenuation(m_attenuationDb);
+        break;
+    }
+}
+
+void AudioOutputManager::setTciSession(TCISession *session)
+{
+    m_tciSession = session;
+
+    if (m_tciOutput)
+        m_tciOutput->setSession(session);
+}
+
+AudioOutputStream *AudioOutputManager::activeStream() const
+{
+    switch (m_activeBackend) {
+    case AudioOutputDevice::BackendType::System:
+        return m_systemOutput;
+
+    case AudioOutputDevice::BackendType::TCI:
+        return m_tciOutput;
+    }
+
+    return nullptr;
+}
+
+void AudioOutputManager::restart(QIODevice *source)
+{
+    if (AudioOutputStream *stream = activeStream())
+        stream->restart(source);
+}
+
+void AudioOutputManager::suspend()
+{
+    if (AudioOutputStream *stream = activeStream())
+        stream->suspend();
+}
+
+void AudioOutputManager::resume()
+{
+    if (AudioOutputStream *stream = activeStream())
+        stream->resume();
+}
+
+
+void AudioOutputManager::reset()
+{
+    /*
+     * We could reset only the active stream, but let's reset both to
+     * make quick-abort cleanup deterministic even if the active backend
+     * changed during configuration churn.
+
+    if (AudioOutputStream *stream = activeStream())
+        stream->reset();
+    */
+
+    if (m_systemOutput)
+        m_systemOutput->reset();
+
+    if (m_tciOutput)
+        m_tciOutput->reset();
+}
+
+void AudioOutputManager::stop()
+{
+    if (m_systemOutput)
+        m_systemOutput->stop();
+
+    if (m_tciOutput)
+        m_tciOutput->stop();
+}
+
+void AudioOutputManager::setAttenuation(qreal attenuationDb)
+{
+    // The existing UI path conceptually expresses this as attenuation.
+    // Be tolerant of alternate paths that might pass a negative dB value.
+    m_attenuationDb = qAbs(attenuationDb);
+
+    if (m_systemOutput)
+        m_systemOutput->setAttenuation(m_attenuationDb);
+
+    if (m_tciOutput)
+        m_tciOutput->set_attenuation(m_attenuationDb);
+}
+
+void AudioOutputManager::resetAttenuation()
+{
+    m_attenuationDb = 0.0;
+
+    if (m_systemOutput)
+        m_systemOutput->resetAttenuation();
+
+    if (m_tciOutput)
+        m_tciOutput->reset_attenuation();
+}

--- a/JS8_Audio/AudioOutputManager.h
+++ b/JS8_Audio/AudioOutputManager.h
@@ -1,0 +1,57 @@
+#ifndef AUDIO_OUTPUT_MANAGER_HPP_
+#define AUDIO_OUTPUT_MANAGER_HPP_
+
+#include "JS8_Audio/AudioDevice.h"
+#include "JS8_Audio/AudioOutputDevice.h"
+#include "JS8_Audio/AudioOutputStream.h"
+#include "JS8_Network/TCISession.h"
+
+#include <QObject>
+
+class SoundOutput;
+class TCIAudioOutput;
+
+class AudioOutputManager final : public AudioOutputStream {
+  Q_OBJECT
+
+public:
+  explicit AudioOutputManager(QObject *parent = nullptr);
+  ~AudioOutputManager() override;
+
+  Q_SLOT void setDevice(AudioOutputDevice const &device,
+                        unsigned channels,
+                        unsigned msBuffered = 0u);
+
+  Q_SLOT void restart(QIODevice *source) override;
+  Q_SLOT void suspend() override;
+  Q_SLOT void resume() override;
+  Q_SLOT void reset() override;
+  Q_SLOT void stop() override;
+
+  Q_SLOT void setTciSession(TCISession *session);
+
+  Q_SLOT void setAttenuation(qreal attenuationDb);
+  Q_SLOT void resetAttenuation();
+
+  AudioOutputDevice::BackendType activeBackend() const {
+    return m_activeBackend;
+  }
+
+private:
+  AudioOutputStream *activeStream() const;
+
+  SoundOutput *m_systemOutput = nullptr;
+  TCIAudioOutput *m_tciOutput = nullptr;
+
+  TCISession *m_tciSession = nullptr;
+
+  AudioOutputDevice m_device;
+  AudioOutputDevice::BackendType m_activeBackend =
+      AudioOutputDevice::BackendType::System;
+
+  unsigned m_channels = 1;
+  unsigned m_msBuffered = 0u;
+  qreal m_attenuationDb = 0.0;
+};
+
+#endif

--- a/JS8_Audio/AudioOutputStream.h
+++ b/JS8_Audio/AudioOutputStream.h
@@ -1,0 +1,29 @@
+#ifndef AUDIO_OUTPUT_STREAM_HPP_
+#define AUDIO_OUTPUT_STREAM_HPP_
+
+#include <QObject>
+#include <QIODevice>
+#include <QString>
+
+class AudioOutputStream : public QObject {
+  Q_OBJECT
+
+public:
+  explicit AudioOutputStream(QObject *parent = nullptr)
+      : QObject(parent) {}
+
+  ~AudioOutputStream() override = default;
+
+public Q_SLOTS:
+  virtual void restart(QIODevice *source) = 0;
+  virtual void suspend() = 0;
+  virtual void resume() = 0;
+  virtual void reset() = 0;
+  virtual void stop() = 0;
+
+  Q_SIGNALS:
+    void error(QString message) const;
+  void status(QString message) const;
+};
+
+#endif

--- a/JS8_Audio/SoundOutput.h
+++ b/JS8_Audio/SoundOutput.h
@@ -2,6 +2,8 @@
 #ifndef SOUNDOUT_H__
 #define SOUNDOUT_H__
 
+#include "JS8_Audio/AudioOutputStream.h"
+
 #include <QAudioDevice>
 #include <QAudioFormat>
 #include <QAudioSink>
@@ -10,11 +12,12 @@
 
 // An instance of this sends audio data to a specified soundcard.
 
-class SoundOutput : public QObject {
+class SoundOutput : public AudioOutputStream {
     Q_OBJECT;
 
   public:
-    SoundOutput() = default;
+    explicit SoundOutput(QObject *parent = nullptr)
+    : AudioOutputStream(parent) {}
 
     qreal attenuation() const;
     QAudioFormat format() const;
@@ -24,11 +27,11 @@ class SoundOutput : public QObject {
                    unsigned msBuffered = 0u);
     void setDeviceFormat(QAudioDevice const &device, QAudioFormat const &format,
                          unsigned msBuffered = 0u);
-    void restart(QIODevice *);
-    void suspend();
-    void resume();
-    void reset();
-    void stop();
+    void restart(QIODevice *) override;
+    void suspend() override;
+    void resume() override;
+    void reset() override;
+    void stop() override;
     void setAttenuation(qreal); /* unsigned */
     void resetAttenuation();    /* to zero */
 

--- a/JS8_Audio/TCIAudioInput.cpp
+++ b/JS8_Audio/TCIAudioInput.cpp
@@ -1,0 +1,313 @@
+#include "TCIAudioInput.h"
+
+#include <QLoggingCategory>
+#include <QThread>
+#include <QMetaObject>
+
+#include "moc_TCIAudioInput.cpp"
+
+Q_DECLARE_LOGGING_CATEGORY(tciaudioinput_js8)
+
+TCIAudioInput::TCIAudioInput(QObject *parent)
+    : QObject(parent)
+{
+}
+
+TCIAudioInput::~TCIAudioInput()
+{
+    stop();
+}
+
+void TCIAudioInput::start(QUrl const &url, int framesPerBuffer,
+                          AudioDevice *sink,
+                          AudioDevice::Channel channel)
+{
+    Q_UNUSED(channel);
+
+    stop();
+
+    if (!sink) {
+        Q_EMIT error(tr("No audio sink supplied for TCI input."));
+        return;
+    }
+
+    m_url = url;
+    m_sink = sink;
+    m_framesPerBuffer = framesPerBuffer;
+    m_started = false;
+    m_suspended = false;
+    m_stopping = false;
+
+
+    if (!m_sink) {
+        Q_EMIT error(tr("No audio sink supplied for TCI input."));
+        return;
+    }
+
+    // TCI bridge RX audio is 48 kHz mono signed int16.
+    // Force Mono here. The configured left/right/both channel selector applies
+    // to physical stereo devices, not the network mono stream.
+    if (!m_sink->initialize(QIODevice::WriteOnly, AudioDevice::Mono)) {
+        Q_EMIT error(tr("Failed to initialize TCI audio sink device."));
+        m_sink.clear();
+        return;
+    }
+
+    Q_EMIT status(tr("Connecting"));
+
+    qCInfo(tciaudioinput_js8) << "Connecting TCI audio input:" << url;
+
+    create_client();
+
+    m_session->connectToServer(m_url);
+    m_client->emitReadyIfReady();
+}
+
+void TCIAudioInput::handle_ready()
+{
+    if (m_stopping || m_suspended)
+        return;
+
+    if (!m_sink || !m_client)
+        return;
+
+    if (m_sink)
+        m_sink->reset();
+
+    if (m_suspended) {
+        m_started = false;
+        Q_EMIT status(tr("Suspended"));
+        return;
+    }
+
+    qCInfo(tciaudioinput_js8)
+        << "TCI audio input ready; starting RX stream";
+
+    m_client->configureAudio(48000, 1, 512);
+    m_client->startRxAudio();
+
+    m_started = true;
+
+    Q_EMIT status(tr("Receiving"));
+}
+
+/*
+void TCIAudioInput::handle_rx_audio_frame(QByteArray pcm, int sampleRate)
+{
+    if (!m_started || m_suspended || !m_sink)
+        return;
+
+    if (sampleRate != 48000) {
+        Q_EMIT error(tr("Unsupported TCI audio sample rate: %1 Hz.")
+                         .arg(sampleRate));
+        return;
+    }
+
+    if (pcm.isEmpty())
+        return;
+
+    qint64 const written = m_sink->write(pcm.constData(), pcm.size());
+
+    if (written != pcm.size()) {
+        qCWarning(tciaudioinput_js8)
+            << "Short write to TCI audio sink:"
+            << written
+            << "of"
+            << pcm.size();
+    }
+}
+*/
+void TCIAudioInput::handle_rx_audio_frame(QByteArray pcm, int sampleRate)
+{
+    if (!m_started || m_suspended || !m_sink)
+        return;
+
+    if (sampleRate != 48000) {
+        Q_EMIT error(tr("Unsupported TCI audio sample rate: %1 Hz.")
+                         .arg(sampleRate));
+        return;
+    }
+
+    if (pcm.isEmpty())
+        return;
+
+    qint64 const written = m_sink->write(pcm.constData(), pcm.size());
+
+    if (written != pcm.size()) {
+        qCWarning(tciaudioinput_js8)
+            << "Short write to TCI audio sink:"
+            << written
+            << "of"
+            << pcm.size();
+    }
+}
+
+void TCIAudioInput::setSession(TCISession *session)
+{
+    m_session = session;
+}
+
+void TCIAudioInput::suspend()
+{
+    m_suspended = true;
+
+    if (m_client && m_client->isConnected())
+        m_client->stopRxAudio();
+
+    Q_EMIT status(tr("Suspended"));
+}
+
+void TCIAudioInput::resume()
+{
+    if (m_sink)
+        m_sink->reset();
+
+    m_suspended = false;
+
+    if (m_client && m_client->isConnected() && m_client->isReady()) {
+        m_client->startRxAudio();
+        m_started = true;
+        Q_EMIT status(tr("Receiving"));
+        return;
+    }
+
+    m_started = false;
+
+    if (!m_stopping) {
+        Q_EMIT status(tr("Waiting for TCI connection"));
+
+        if (m_session && m_url.isValid())
+            m_session->connectToServer(m_url);
+
+        return;
+    }
+
+    Q_EMIT status(tr("Stopped"));
+}
+
+void TCIAudioInput::stop()
+{
+    m_stopping = true;
+    m_started = false;
+    m_suspended = false;
+
+    if (m_client && m_client->isConnected())
+        m_client->stopRxAudio();
+
+    destroy_client();
+
+    if (m_sink) {
+        m_sink->close();
+        m_sink.clear();
+    }
+
+    Q_EMIT status(tr("Stopped"));
+}
+
+
+void TCIAudioInput::handle_disconnected()
+{
+    qCInfo(tciaudioinput_js8)
+        << "TCI audio input disconnected"
+        << "stopping =" << m_stopping;
+
+    m_started = false;
+    m_suspended = false;
+
+    if (m_stopping) {
+        Q_EMIT status(tr("Stopped"));
+        return;
+    }
+
+    Q_EMIT status(tr("Disconnected"));
+}
+
+void TCIAudioInput::handle_error(QString message)
+{
+    qCWarning(tciaudioinput_js8)
+        << "TCI audio input error:" << message;
+
+    m_started = false;
+
+    if (m_stopping) {
+        Q_EMIT status(tr("Error"));
+        return;
+    }
+}
+
+void TCIAudioInput::create_client()
+{
+    if (m_client)
+        return;
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                create_client();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (!m_session) {
+        Q_EMIT error(tr("TCI session is not available."));
+        return;
+    }
+
+    m_client = m_session->client();
+
+    qCInfo(tciaudioinput_js8)
+        << "Created TCI audio client"
+        << "client =" << m_client
+        << "clientThread =" << m_client->thread()
+        << "ownerThread =" << thread()
+        << "currentThread =" << QThread::currentThread();
+
+
+    connect(m_client, &TCIClient::ready,
+            this,
+            &TCIAudioInput::handle_ready,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::disconnected,
+            this,
+            &TCIAudioInput::handle_disconnected,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::rxAudioFrame,
+            this,
+            &TCIAudioInput::handle_rx_audio_frame,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::error,
+            this,
+            &TCIAudioInput::handle_error,
+            Qt::QueuedConnection);
+}
+
+
+void TCIAudioInput::destroy_client()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                destroy_client();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (!m_client)
+        return;
+
+    TCIClient *client = m_client;
+    m_client = nullptr;
+
+    disconnect(client, nullptr, this, nullptr);
+
+    client->stopRxAudio();
+}
+
+Q_LOGGING_CATEGORY(tciaudioinput_js8, "tciaudioinput.js8", QtWarningMsg)

--- a/JS8_Audio/TCIAudioInput.h
+++ b/JS8_Audio/TCIAudioInput.h
@@ -1,0 +1,53 @@
+#ifndef TCI_AUDIO_INPUT_HPP_
+#define TCI_AUDIO_INPUT_HPP_
+
+#include "JS8_Audio/AudioDevice.h"
+#include "JS8_Network/TCIClient.h"
+#include "JS8_Network/TCISession.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QTimer>
+#include <QUrl>
+
+class TCIAudioInput final : public QObject {
+  Q_OBJECT
+
+public:
+  explicit TCIAudioInput(QObject *parent = nullptr);
+  ~TCIAudioInput() override;
+
+  Q_SLOT void start(QUrl const &url, int framesPerBuffer,
+                    AudioDevice *sink,
+                    AudioDevice::Channel channel = AudioDevice::Mono);
+
+  Q_SLOT void setSession(TCISession *session);
+  Q_SLOT void suspend();
+  Q_SLOT void resume();
+  Q_SLOT void stop();
+
+  Q_SIGNAL void error(QString message) const;
+  Q_SIGNAL void status(QString message) const;
+
+private Q_SLOTS:
+  void handle_ready();
+  void handle_disconnected();
+  void handle_rx_audio_frame(QByteArray pcm, int sampleRate);
+  void handle_error(QString message);
+
+private:
+  void create_client();
+  void destroy_client();
+
+  TCISession *m_session = nullptr;
+  TCIClient *m_client = nullptr;
+
+  QPointer<AudioDevice> m_sink;
+  QUrl m_url;
+  int m_framesPerBuffer = 0;
+  bool m_started = false;
+  bool m_suspended = false;
+  bool m_stopping = false;
+};
+
+#endif

--- a/JS8_Audio/TCIAudioOutput.cpp
+++ b/JS8_Audio/TCIAudioOutput.cpp
@@ -1,0 +1,502 @@
+#include "TCIAudioOutput.h"
+
+#include <QLoggingCategory>
+#include <QtMath>
+#include <QMetaObject>
+#include <QThread>
+
+#include "moc_TCIAudioOutput.cpp"
+
+Q_DECLARE_LOGGING_CATEGORY(tciaudiooutput_js8)
+
+namespace {
+    void apply_gain_int16(QByteArray &pcm, qreal gain)
+    {
+        if (qFuzzyCompare(gain, 1.0))
+            return;
+
+        auto *samples = reinterpret_cast<qint16 *>(pcm.data());
+        int const count = pcm.size() / int(sizeof(qint16));
+
+        for (int i = 0; i < count; ++i) {
+            int const scaled = qRound(double(samples[i]) * gain);
+            samples[i] = static_cast<qint16>(
+                qBound(-32768, scaled, 32767));
+        }
+    }
+}
+
+TCIAudioOutput::TCIAudioOutput(QObject *parent)
+    : AudioOutputStream(parent)
+{
+}
+
+TCIAudioOutput::~TCIAudioOutput()
+{
+    stop();
+}
+
+void TCIAudioOutput::setUrl(QUrl const &url)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, url]() {
+                setUrl(url);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (m_url == url && m_client)
+        return;
+
+    if (m_client)
+        destroy_client();
+
+    m_url = url;
+
+    if (m_url.isValid()) {
+        create_client();
+
+        if (m_session && m_client) {
+            m_session->connectToServer(m_url);
+            m_client->emitReadyIfReady();
+        }
+    }
+}
+
+void TCIAudioOutput::set_attenuation(qreal attenuation_db)
+{
+    // Some UI paths may represent TX level as "-15 dB".
+    // SoundOutput conceptually wants positive attenuation: 15 dB.
+    attenuation_db = qAbs(attenuation_db);
+
+    attenuation_db = qBound<qreal>(0.0, attenuation_db, 999.0);
+
+    m_volume = qPow(10.0, -attenuation_db / 20.0);
+
+    qCInfo(tciaudiooutput_js8)
+        << "TCI TX attenuation"
+        << attenuation_db
+        << "dB gain =" << m_volume;
+}
+
+void TCIAudioOutput::reset_attenuation()
+{
+    m_volume = 1.0;
+}
+
+void TCIAudioOutput::setSession(TCISession *session)
+{
+    m_session = session;
+}
+
+void TCIAudioOutput::create_client()
+{
+    if (m_client)
+        return;
+
+    if (!m_session) {
+        Q_EMIT error(tr("TCI session is not available."));
+        return;
+    }
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this,
+                                  [this]() { create_client(); },
+                                  Qt::QueuedConnection);
+        return;
+    }
+
+    m_client = m_session->client();
+
+    connect(m_client, &TCIClient::ready,
+            this, &TCIAudioOutput::handle_ready,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::disconnected,
+            this, &TCIAudioOutput::handle_disconnected,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::error,
+            this, &TCIAudioOutput::handle_error,
+            Qt::QueuedConnection);
+
+    auto const ok = connect(m_client, &TCIClient::txChronoRequested,
+                        this, &TCIAudioOutput::handle_tx_chrono_requested,
+                        Qt::QueuedConnection);
+}
+
+void TCIAudioOutput::destroy_client()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this,
+                                  [this]() { destroy_client(); },
+                                  Qt::QueuedConnection);
+        return;
+    }
+
+    if (!m_client)
+        return;
+
+    TCIClient *client = m_client;
+    m_client = nullptr;
+
+    disconnect(client, nullptr, this, nullptr);
+
+    m_tx_audio_started = false;
+
+    client->stopTxAudio();
+}
+
+void TCIAudioOutput::create_pump_timer()
+{
+    if (m_pump_timer)
+        return;
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this,
+                                  [this]() { create_pump_timer(); },
+                                  Qt::QueuedConnection);
+        return;
+    }
+
+    m_pump_timer = new QTimer(this);
+    m_pump_timer->setTimerType(Qt::PreciseTimer);
+
+    connect(m_pump_timer, &QTimer::timeout,
+            this, &TCIAudioOutput::pump_audio);
+}
+
+void TCIAudioOutput::stop_pump_timer()
+{
+    if (m_pump_timer && m_pump_timer->isActive())
+        m_pump_timer->stop();
+}
+
+void TCIAudioOutput::stop_tx_audio_if_active()
+{
+    if (!m_tx_audio_started)
+        return;
+
+    if (m_client && m_client->isConnected())
+        m_client->stopTxAudio();
+
+    m_tx_audio_started = false;
+}
+
+void TCIAudioOutput::reset_tx_state()
+{
+    m_started = false;
+    m_suspended = false;
+    m_tx_audio_started = false;
+
+    m_source.clear();
+    m_buffer.clear();
+
+    m_tx_samples_sent = 0;
+    m_pump_count = 0;
+    m_total_read = 0;
+}
+
+void TCIAudioOutput::restart(QIODevice *source)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, source]() {
+                restart(source);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    stop();
+
+    m_source = source;
+    m_started = true;
+    m_suspended = false;
+    m_stopping = false;
+    m_chrono_mode = false;
+
+    if (!m_client) {
+        if (m_url.isValid())
+            create_client();
+    }
+
+    if (!m_client) {
+        Q_EMIT error(tr("TCI client is not available."));
+        return;
+    }
+
+    if (m_session)
+        m_session->connectToServer(m_url);
+
+    if (m_client)
+        m_client->emitReadyIfReady();
+
+    if (m_client->isConnected()) {
+        handle_ready();
+    }
+}
+
+void TCIAudioOutput::pump_audio()
+{
+    if (!m_started || m_suspended || !m_client || !m_source)
+        return;
+
+    if (m_chrono_mode)
+        return;
+
+    if (!m_client->isConnected() || !m_client->isReady())
+        return;
+
+    if (!m_source->isOpen() || !m_source->isReadable()) {
+        stop();
+        return;
+    }
+
+    constexpr qint64 sample_rate = 48000;
+    constexpr int samples_per_frame = 512;
+    constexpr int bytes_per_sample = int(sizeof(qint16));
+    constexpr int bytes_per_frame = samples_per_frame * bytes_per_sample;
+
+    qint64 const elapsed_ns = m_tx_clock.nsecsElapsed();
+
+    qint64 const samples_should_have_sent =
+        (elapsed_ns * sample_rate) / 1000000000LL;
+
+    qint64 const samples_due =
+        samples_should_have_sent - m_tx_samples_sent;
+
+    if (samples_due < samples_per_frame)
+        return;
+
+    int frames_to_send = int(samples_due / samples_per_frame);
+
+    // Avoid huge catch-up bursts if the event loop stalls.
+    frames_to_send = qMin(frames_to_send, 4);
+
+    for (int frame = 0; frame < frames_to_send; ++frame) {
+        m_buffer.resize(bytes_per_frame);
+
+        qint64 const read = m_source->read(m_buffer.data(), m_buffer.size());
+
+        if (read <= 0) {
+            stop();
+            return;
+        }
+
+        if (read < m_buffer.size()) {
+            std::fill(m_buffer.begin() + read, m_buffer.end(), char(0));
+        }
+
+        apply_gain_int16(m_buffer, m_volume);
+
+        m_client->sendTxAudioMonoInt16(m_buffer);
+
+        // IMPORTANT: this is samples, not bytes.
+        m_tx_samples_sent += samples_per_frame;
+
+        ++m_pump_count;
+        m_total_read += read;
+
+        if (!(m_pump_count % 500)) {
+            qCInfo(tciaudiooutput_js8)
+                << "TCI TX pump"
+                << "pumps =" << m_pump_count
+                << "totalRead =" << m_total_read
+                << "lastRead =" << read
+                << "wanted =" << m_buffer.size()
+                << "sourceOpen =" << (m_source ? m_source->isOpen() : false)
+                << "sourceReadable =" << (m_source ? m_source->isReadable() : false);
+        }
+    }
+}
+
+QByteArray TCIAudioOutput::read_mono_int16_samples(int samples)
+{
+    if (!m_source || !m_source->isOpen() || !m_source->isReadable())
+        return {};
+
+    int const bytesWanted = samples * int(sizeof(qint16));
+
+    QByteArray pcm;
+    pcm.resize(bytesWanted);
+
+    qint64 const read = m_source->read(pcm.data(), pcm.size());
+
+    if (read <= 0)
+        return {};
+
+    if (read < pcm.size())
+        std::fill(pcm.begin() + read, pcm.end(), char(0));
+
+    apply_gain_int16(pcm, m_volume);
+
+    return pcm;
+}
+
+void TCIAudioOutput::suspend()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this,
+                                  [this]() { suspend(); },
+                                  Qt::QueuedConnection);
+        return;
+    }
+
+    if (m_suspended)
+        return;
+
+    m_suspended = true;
+
+    stop_pump_timer();
+
+    Q_EMIT status(tr("Suspended"));
+}
+
+void TCIAudioOutput::resume()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this,
+                                  [this]() { resume(); },
+                                  Qt::QueuedConnection);
+        return;
+    }
+
+    if (!m_suspended)
+        return;
+
+    m_suspended = false;
+
+    if (m_started && m_pump_timer)
+        m_pump_timer->start(2);
+
+    Q_EMIT status(tr("Sending"));
+}
+
+void TCIAudioOutput::reset()
+{
+    stop();
+}
+
+void TCIAudioOutput::stop()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                stop();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    m_stopping = true;
+
+    stop_pump_timer();
+    stop_tx_audio_if_active();
+
+    m_source.clear();
+    m_buffer.clear();
+
+    m_started = false;
+    m_suspended = false;
+    m_chrono_mode = false;
+    m_stopping = false;
+}
+
+void TCIAudioOutput::handle_ready()
+{
+    if (m_stopping)
+        return;
+
+    if (!m_client || !m_source)
+        return;
+
+    qCInfo(tciaudiooutput_js8)
+        << "TCI TX audio ready; starting TX stream";
+
+    // Match bridge protocol expectations.
+    m_client->configureAudio(48000, 1, 512);
+    m_client->startTxAudio();
+
+    m_tx_audio_started = true;
+    m_started = true;
+    m_suspended = false;
+    m_error_reported = false;
+
+    m_tx_clock.restart();
+    m_tx_samples_sent = 0;
+    m_pump_count = 0;
+    m_total_read = 0;
+
+    if (m_pump_timer)
+        m_pump_timer->start(2);
+
+    Q_EMIT status(tr("Sending"));
+}
+
+void TCIAudioOutput::handle_tx_chrono_requested(TciTxAudioPolicy policy)
+{
+    m_chrono_mode = true;
+    stop_pump_timer();
+
+    if (!m_started || m_suspended || !m_client || !m_source)
+        return;
+
+    if (policy.sampleRate != 48000) {
+        Q_EMIT error(tr("Unsupported TCI TX sample rate: %1 Hz.")
+                         .arg(policy.sampleRate));
+        return;
+    }
+
+    int monoSamplesNeeded = policy.samplesPerFrame;
+
+    if (policy.sampleCountMeaning ==
+        TciTxAudioPolicy::SampleCountMeaning::TotalSampleValues) {
+        monoSamplesNeeded = policy.samplesPerFrame / qMax(1, policy.channels);
+    }
+
+    if (monoSamplesNeeded <= 0)
+        return;
+
+    QByteArray const monoInt16 =
+        read_mono_int16_samples(monoSamplesNeeded);
+
+    if (monoInt16.isEmpty()) {
+        stop();
+        return;
+    }
+
+    m_client->sendTxAudio(monoInt16, policy);
+}
+
+void TCIAudioOutput::handle_disconnected()
+{
+    stop_pump_timer();
+
+    reset_tx_state();
+
+    Q_EMIT status(tr("Stopped"));
+}
+
+void TCIAudioOutput::handle_error(QString message)
+{
+    qCWarning(tciaudiooutput_js8)
+        << "TCI audio output error:" << message;
+
+    if (!m_stopping)
+        stop();
+
+    if (m_error_reported)
+        return;
+
+    m_error_reported = true;
+
+    Q_EMIT error(message);
+}
+
+Q_LOGGING_CATEGORY(tciaudiooutput_js8, "tciaudiooutput.js8", QtWarningMsg)

--- a/JS8_Audio/TCIAudioOutput.h
+++ b/JS8_Audio/TCIAudioOutput.h
@@ -1,0 +1,76 @@
+#ifndef TCI_AUDIO_OUTPUT_HPP_
+#define TCI_AUDIO_OUTPUT_HPP_
+
+#include "BWFFile.h"
+#include "JS8_Audio/AudioDevice.h"
+#include "JS8_Audio/AudioOutputStream.h"
+#include "JS8_Network/TCIClient.h"
+#include "JS8_Network/TCISession.h"
+
+#include <QElapsedTimer>
+#include <QPointer>
+#include <QTimer>
+#include <QUrl>
+
+class TCIAudioOutput final : public AudioOutputStream {
+  Q_OBJECT
+
+public:
+  explicit TCIAudioOutput(QObject *parent = nullptr);
+  ~TCIAudioOutput() override;
+
+public Q_SLOTS:
+  void restart(QIODevice *source) override;
+  void suspend() override;
+  void resume() override;
+  void reset() override;
+  void stop() override;
+  void set_attenuation(qreal attenuation_db);
+  void reset_attenuation();
+  void handle_tx_chrono_requested(TciTxAudioPolicy policy);
+  void setSession(TCISession *session);
+  void setUrl(QUrl const &url);
+
+
+private Q_SLOTS:
+  void handle_ready();
+  void handle_disconnected();
+  void handle_error(QString message);
+  void pump_audio();
+
+private:
+  void create_client();
+  void destroy_client();
+  void create_pump_timer();
+
+  void stop_pump_timer();
+  QByteArray read_mono_int16_samples(int samples);
+  void stop_tx_audio_if_active();
+  void reset_tx_state();
+
+  TCISession *m_session = nullptr;
+  TCIClient *m_client = nullptr;
+
+  QTimer *m_pump_timer = nullptr;
+
+  QPointer<QIODevice> m_source;
+  QUrl m_url;
+
+  QByteArray m_buffer;
+
+  qreal m_volume = 0.177827941; // -15 dB
+
+  bool m_started = false;
+  bool m_suspended = false;
+  bool m_stopping = false;
+  bool m_tx_audio_started = false;
+  bool m_chrono_mode = false;
+  bool m_error_reported = false;
+
+  QElapsedTimer m_tx_clock;
+  qint64 m_tx_samples_sent = 0;
+  qint64 m_pump_count = 0;
+  qint64 m_total_read = 0;
+};
+
+#endif

--- a/JS8_Main/MetaDataRegistry.cpp
+++ b/JS8_Main/MetaDataRegistry.cpp
@@ -8,6 +8,7 @@
 #include "FrequencyList.h"
 #include "IARURegions.h"
 #include "JS8_Audio/AudioDevice.h"
+#include "JS8_Network/TciProtocolHandler.h"
 #include "JS8_Transceiver/Transceiver.h"
 #include "JS8_Transceiver/TransceiverFactory.h"
 #include "JS8_UI/Configuration.h"
@@ -47,8 +48,10 @@ void register_types() {
     qRegisterMetaType<FrequencyList_v3::Item>("Item_v3");
     qRegisterMetaType<FrequencyList_v3::FrequencyItems>("FrequencyItems_v3");
 
-    // Audio device
+    // Audio devices
     qRegisterMetaType<AudioDevice::Channel>("AudioDevice::Channel");
+    qRegisterMetaType<AudioInputDevice>("AudioInputDevice");
+    qRegisterMetaType<AudioOutputDevice>("AudioOutputDevice");
 
     // Configuration
     qRegisterMetaType<Configuration::DataMode>("Configuration::DataMode");
@@ -75,6 +78,9 @@ void register_types() {
         "TransceiverFactory::TXAudioSource");
     qRegisterMetaType<TransceiverFactory::SplitMode>(
         "TransceiverFactory::SplitMode");
+
+    // TCI
+    qRegisterMetaType<TciTxAudioPolicy>("TciTxAudioPolicy");
 
     // Waterfall
     qRegisterMetaType<WF::Spectrum>("Spectrum");

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "JS8_Main/MsgNotifyDB.h"
+#include "JS8_Audio/AudioOutputManager.h"
 #include "JS8_UI/mainwindow.h"
 #include "JS8_UI/styles.h"
 
@@ -36,8 +37,8 @@ UI_Constructor::UI_Constructor(QString const &program_info,
       m_lastDialFreq{0},
       m_detector{new Detector{JS8_RX_SAMPLE_RATE, JS8_NTMAX}},
       m_FFTSize{6912 / 2}, // conservative value to avoid buffer overruns
-      m_soundInput{new SoundInput}, m_modulator{new Modulator},
-      m_soundOutput{new SoundOutput}, m_notification{new NotificationAudio},
+      m_audioInput{new AudioInputManager}, m_modulator{new Modulator},
+      m_audioOutput{new AudioOutputManager}, m_notification{new NotificationAudio},
       m_cq_loop{new TxLoop{"CQ calls"}}, m_hb_loop{new TxLoop{"HB calls"}},
       m_decoder{this}, m_secBandChanged{0}, m_freqNominal{0},
       m_freqTxNominal{0}, m_XIT{0}, m_sec0{-1},
@@ -69,7 +70,9 @@ UI_Constructor::UI_Constructor(QString const &program_info,
       m_pskReporter{new PSKReporter{&m_config, program_info}}, // UR
       m_spotClient{new SpotClient{"spot.js8call.com", 50000, program_info}},
       m_aprsClient{new APRSISClient{"rotate.aprs2.net", 14580}},
-      m_aprsInboundRelay{nullptr} {
+      m_tciSession{new TCISession},
+      m_aprsInboundRelay{nullptr}
+    {
     ui->setupUi(this);
     ui->frame->setStyleSheet(logFrameStyle());
     ui->logWidget->setStyleSheet(Styles::LogWidgetStyle);
@@ -102,10 +105,15 @@ UI_Constructor::UI_Constructor(QString const &program_info,
     // start audio thread and hook up slots & signals for shutdown management
     // these objects need to be in the audio thread so that invoking
     // their slots is done in a thread safe way
-    m_soundOutput->moveToThread(&m_audioThread);
+    m_audioOutput->moveToThread(&m_audioThread);
     m_modulator->moveToThread(&m_audioThread);
-    m_soundInput->moveToThread(&m_audioThread);
+    m_audioInput->moveToThread(&m_audioThread);
+    m_tciSession->moveToThread(&m_audioThread);
     m_detector->moveToThread(&m_audioThread);
+
+    m_audioInput->setTciSession(m_tciSession);
+    m_audioOutput->setTciSession(m_tciSession);
+    m_config.set_tci_session(m_tciSession);
 
     // notification audio operates in its own thread at a lower priority
     m_notification->moveToThread(&m_notificationAudioThread);
@@ -214,21 +222,49 @@ UI_Constructor::UI_Constructor(QString const &program_info,
     connect(&m_networkThread, &QThread::finished, m_spotClient,
             &QObject::deleteLater);
 
-    // hook up sound output stream slots & signals and disposal
-    connect(this, &UI_Constructor::initializeAudioOutputStream, m_soundOutput,
-            &SoundOutput::setFormat);
-    connect(m_soundOutput, &SoundOutput::error, this,
+    // hook up audio output stream slots & signals and disposal
+    connect(this, &UI_Constructor::initializeAudioOutputStream, m_audioOutput,
+            &AudioOutputManager::setDevice);
+
+    connect(m_audioOutput, &AudioOutputManager::error, this,
             [this](QString const &errorMsg) {
                 if (m_config.audio_output_device().isNull() || m_config.is_active()) {
                     return; // nothing configured yet, or user is fixing it in Settings
                 }
                 showSoundOutError(errorMsg);
             });
-    connect(m_soundOutput, &SoundOutput::error, &m_config,
+
+    connect(m_audioOutput, &AudioOutputManager::error,
+            this,
+            [this](QString const &message) {
+                Q_UNUSED(message)
+
+                if (!m_transmitting && !m_tune)
+                return;
+
+            qCWarning(mainwindow_js8)
+                << "Aborting transmit because audio output failed:"
+                << message;
+
+            Q_EMIT endTransmitMessage(true);
+
+            if (m_tune)
+                Q_EMIT tune(false);
+
+            stopTx();
+        },
+        Qt::QueuedConnection);
+
+    connect(m_audioOutput, &AudioOutputManager::error, &m_config,
             &Configuration::invalidate_audio_output_device);
-    connect(this, &UI_Constructor::outAttenuationChanged, m_soundOutput,
-            &SoundOutput::setAttenuation);
-    connect(&m_audioThread, &QThread::finished, m_soundOutput,
+
+    connect(this, &UI_Constructor::outAttenuationChanged, m_audioOutput,
+            &AudioOutputManager::setAttenuation);
+
+    connect(this, &UI_Constructor::finished, m_audioOutput,
+            &AudioOutputManager::stop);
+
+    connect(&m_audioThread, &QThread::finished, m_audioOutput,
             &QObject::deleteLater);
 
     connect(this, &UI_Constructor::initializeNotificationAudioOutputStream,
@@ -247,29 +283,40 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             &Modulator::stop);
     connect(this, &UI_Constructor::tune, m_modulator, &Modulator::tune);
     connect(this, &UI_Constructor::sendMessage, m_modulator, &Modulator::start);
+    connect(this, &UI_Constructor::finished, m_modulator,
+          [this]() {
+              m_modulator->stop(true);
+          });
     connect(&m_audioThread, &QThread::finished, m_modulator,
             &QObject::deleteLater);
 
     // hook up the audio input stream signals, slots and disposal
-    connect(this, &UI_Constructor::startAudioInputStream, m_soundInput,
-            &SoundInput::start);
-    connect(this, &UI_Constructor::suspendAudioInputStream, m_soundInput,
-            &SoundInput::suspend);
-    connect(this, &UI_Constructor::resumeAudioInputStream, m_soundInput,
-            &SoundInput::resume);
-    connect(this, &UI_Constructor::finished, m_soundInput, &SoundInput::stop);
-    connect(m_soundInput, &SoundInput::error, this,
+    connect(this, &UI_Constructor::startAudioInputStream, m_audioInput,
+            &AudioInputManager::start);
+    connect(this, &UI_Constructor::suspendAudioInputStream, m_audioInput,
+            &AudioInputManager::suspend);
+
+    connect(this, &UI_Constructor::resumeAudioInputStream, m_audioInput,
+            &AudioInputManager::resume);
+
+    connect(this, &UI_Constructor::finished, m_audioInput,
+            &AudioInputManager::stop);
+
+    connect(m_audioInput, &AudioInputManager::error, this,
         [this](QString const &errorMsg) {
             if (m_config.audio_input_device().isNull() || m_config.is_active()) {
                 return;
             }
             showSoundInError(errorMsg);
         });
-    connect(m_soundInput, &SoundInput::error, &m_config,
+
+    connect(m_audioInput, &AudioInputManager::systemAudioError, &m_config,
             &Configuration::invalidate_audio_input_device);
-    // connect(m_soundInput, &SoundInput::status, this,
+
+    // connect(m_audioInput, &AudioInputManager::status, this,
     // &UI_Constructor::showStatusMessage);
-    connect(&m_audioThread, &QThread::finished, m_soundInput,
+
+    connect(&m_audioThread, &QThread::finished, m_audioInput,
             &QObject::deleteLater);
 
     connect(this, &UI_Constructor::finished, this, &UI_Constructor::close);
@@ -1138,7 +1185,7 @@ UI_Constructor::UI_Constructor(QString const &program_info,
 
         displayActivity(true);
     });
-          
+
     auto blockStation =
         new QAction(QString("Block This Station"), ui->tableWidgetCalls);
     connect(blockStation, &QAction::triggered, this, [this]() {
@@ -1258,7 +1305,7 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             ui->tableWidgetCalls, &QTableWidget::customContextMenuRequested, this,
             [this, logAction, historyAction, localMessageAction, clearAction4,
              clearActionAll, addStation, removeStation, blockStation](QPoint const &point) {
-                
+
             QMenu *menu = new QMenu(ui->tableWidgetCalls);
 
             // clear the selection of the call widget on right click
@@ -1357,7 +1404,7 @@ UI_Constructor::UI_Constructor(QString const &program_info,
                                        ? "Remove This Group"
                                        : "Remove This Station");
             menu->addAction(removeStation);
-            
+
             blockStation->setDisabled(missingCallsign || isAllCall ||
                                       selectedCall.startsWith("@"));
 

--- a/JS8_Mode/Modulator.cpp
+++ b/JS8_Mode/Modulator.cpp
@@ -4,7 +4,7 @@
  */
 #include "Modulator.h"
 #include "JS8Submode.h"
-#include "JS8_Audio/SoundOutput.h"
+#include "JS8_Audio/AudioOutputStream.h"
 #include "JS8_Include/commons.h"
 #include "JS8_Main/DriftingDateTime.h"
 #include "JS8_UI/mainwindow.h"
@@ -36,7 +36,7 @@ constexpr auto MS_PER_SEC = 1000;
  * @param channel
  */
 void Modulator::start(double const frequency, int const submode,
-                      double const txDelay, SoundOutput *const stream,
+                      double const txDelay, AudioOutputStream *const stream,
                       Channel const channel) {
     Q_ASSERT(stream);
 

--- a/JS8_Mode/Modulator.h
+++ b/JS8_Mode/Modulator.h
@@ -6,7 +6,7 @@
 #include <QAudio>
 #include <QPointer>
 
-class SoundOutput;
+class AudioOutputStream;
 
 /**
  * Audio device that generates PCM audio frames that encode a message.
@@ -52,8 +52,8 @@ class Modulator final : public AudioDevice {
 
     // Slots
 
-    Q_SLOT void start(double audioFrequency, int submode, double tx_delay,
-                      SoundOutput *stream, Channel channel);
+  Q_SLOT void start(double audioFrequency, int submode, double tx_delay,
+                AudioOutputStream *stream, Channel channel);
     Q_SLOT void stop(bool quick = false);
     Q_SLOT void tune(bool state = true);
 
@@ -78,7 +78,7 @@ class Modulator final : public AudioDevice {
   private:
     // Data members
 
-    QPointer<SoundOutput> m_stream;
+    QPointer<AudioOutputStream> m_stream;
     std::atomic<State> m_state = State::Idle;
     bool m_quickClose = false;
     bool m_tuning = false;

--- a/JS8_Network/TCIClient.cpp
+++ b/JS8_Network/TCIClient.cpp
@@ -1,0 +1,1007 @@
+#include "TCIClient.h"
+#include "TCIStreamFrame.h"
+
+#include <QDebug>
+#include <QMetaObject>
+#include <QThread>
+#include <QVersionNumber>
+
+#include <QtEndian>
+#include <QtMath>
+
+#include <cmath>
+#include <cstring>
+
+#include <qloggingcategory.h>
+
+Q_DECLARE_LOGGING_CATEGORY(tcinetworking_js8)
+
+namespace
+{
+    qint16 clampFloatToInt16(float sample)
+    {
+        if (!std::isfinite(sample))
+            return 0;
+
+        sample = qBound(-1.0f, sample, 1.0f);
+
+        return static_cast<qint16>(
+            qRound(sample * 32767.0f)
+        );
+    }
+
+    qint16 readInt16Le(char const *p)
+    {
+        return qFromLittleEndian<qint16>(
+            reinterpret_cast<uchar const *>(p)
+        );
+    }
+
+    float readFloat32Le(char const *p)
+    {
+        quint32 const bits = qFromLittleEndian<quint32>(
+            reinterpret_cast<uchar const *>(p)
+        );
+
+        float value = 0.0f;
+        static_assert(sizeof(value) == sizeof(bits));
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
+    }
+
+    QByteArray convertRxAudioToMonoInt16(TCIStream::StreamFrame const &frame)
+    {
+        if (frame.channels != 1 && frame.channels != 2) {
+            qWarning() << "Unsupported TCI RX channel count:"
+                       << frame.channels;
+            return {};
+        }
+
+        if (frame.sampleCount == 0)
+            return {};
+
+        QByteArray out;
+        out.resize(static_cast<qsizetype>(frame.sampleCount) *
+                   qsizetype(sizeof(qint16)));
+
+        auto *dest = reinterpret_cast<qint16 *>(out.data());
+
+        switch (frame.sampleType) {
+        case TCIStream::INT16: {
+            qsizetype const expectedBytes =
+                qsizetype(frame.sampleCount) *
+                qsizetype(frame.channels) *
+                qsizetype(sizeof(qint16));
+
+            if (frame.payload.size() < expectedBytes) {
+                qWarning() << "Short TCI RX int16 payload:"
+                           << frame.payload.size()
+                           << "expected"
+                           << expectedBytes;
+                return {};
+            }
+
+            char const *src = frame.payload.constData();
+
+            for (quint32 i = 0; i < frame.sampleCount; ++i) {
+                if (frame.channels == 1) {
+                    dest[i] = readInt16Le(src);
+                    src += sizeof(qint16);
+                } else {
+                    qint32 const left = readInt16Le(src);
+                    src += sizeof(qint16);
+
+                    qint32 const right = readInt16Le(src);
+                    src += sizeof(qint16);
+
+                    dest[i] = static_cast<qint16>((left + right) / 2);
+                }
+            }
+
+            return out;
+        }
+
+        case TCIStream::FLOAT32: {
+            qsizetype const expectedBytes =
+                qsizetype(frame.sampleCount) *
+                qsizetype(frame.channels) *
+                qsizetype(sizeof(float));
+
+            if (frame.payload.size() < expectedBytes) {
+                qWarning() << "Short TCI RX float32 payload:"
+                           << frame.payload.size()
+                           << "expected"
+                           << expectedBytes;
+                return {};
+            }
+
+            char const *src = frame.payload.constData();
+
+            for (quint32 i = 0; i < frame.sampleCount; ++i) {
+                if (frame.channels == 1) {
+                    float const sample = readFloat32Le(src);
+                    src += sizeof(float);
+
+                    dest[i] = clampFloatToInt16(sample);
+                } else {
+                    float const left = readFloat32Le(src);
+                    src += sizeof(float);
+
+                    float const right = readFloat32Le(src);
+                    src += sizeof(float);
+
+                    dest[i] = clampFloatToInt16((left + right) * 0.5f);
+                }
+            }
+
+            return out;
+        }
+
+        default:
+            qWarning() << "Unsupported TCI RX sample type:"
+                       << frame.sampleType;
+            return {};
+        }
+    }
+
+void appendFloat32Le(QByteArray &out, float value)
+    {
+        quint32 bits = 0;
+        static_assert(sizeof(bits) == sizeof(value));
+        std::memcpy(&bits, &value, sizeof(bits));
+
+        bits = qToLittleEndian(bits);
+
+        out.append(reinterpret_cast<char const *>(&bits), sizeof(bits));
+    }
+
+    float int16ToFloat(qint16 sample)
+    {
+        return qBound(-1.0f, float(sample) / 32768.0f, 1.0f);
+    }
+
+    QByteArray convertMonoInt16ToFloat32(QByteArray const &monoInt16,
+                                     int outputChannels)
+    {
+        if (outputChannels < 1)
+            return {};
+
+        int const inputSamples =
+            monoInt16.size() / int(sizeof(qint16));
+
+        auto const *src =
+            reinterpret_cast<qint16 const *>(monoInt16.constData());
+
+        QByteArray out;
+        out.reserve(inputSamples * outputChannels * int(sizeof(float)));
+
+        for (int i = 0; i < inputSamples; ++i) {
+            float const sample = int16ToFloat(qFromLittleEndian<qint16>(
+                reinterpret_cast<uchar const *>(&src[i])));
+
+            for (int ch = 0; ch < outputChannels; ++ch)
+                appendFloat32Le(out, sample);
+        }
+
+        return out;
+    }
+
+    quint32 txHeaderSampleCount(TciTxAudioPolicy const &policy,
+                            int monoInputSamples)
+    {
+        if (policy.sampleCountMeaning ==
+            TciTxAudioPolicy::SampleCountMeaning::TotalSampleValues) {
+            return quint32(monoInputSamples * policy.channels);
+            }
+
+        return quint32(monoInputSamples);
+    }
+}
+
+TCIClient::TCIClient(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void TCIClient::createSocket()
+{
+    if (socket_)
+        return;
+
+    socket_ = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+
+    connect(socket_, &QWebSocket::connected,
+            this, &TCIClient::onConnected);
+
+    connect(socket_, &QWebSocket::disconnected,
+            this, &TCIClient::onDisconnected);
+
+    connect(socket_, &QWebSocket::textMessageReceived,
+            this, &TCIClient::onTextMessageReceived);
+
+    connect(socket_, &QWebSocket::binaryMessageReceived,
+            this, &TCIClient::onBinaryMessageReceived);
+
+    connect(socket_,
+            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::errorOccurred),
+            this,
+            &TCIClient::onErrorOccurred);
+}
+
+void TCIClient::destroySocket()
+{
+    if (!socket_)
+        return;
+
+    QWebSocket *socket = socket_;
+    socket_ = nullptr;
+
+    bool disconnected = socket->disconnect(this);
+    Q_UNUSED(disconnected);
+
+    socket->deleteLater();
+}
+
+void TCIClient::connectToServer(QUrl const &url)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, url]() {
+                connectToServer(url);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (url_ == url && (connected_ || connecting_)) {
+        qCInfo(tcinetworking_js8) << "TCI connection already active or pending:"
+                << "client=" << this
+                << "url=" << url;
+
+        emitReadyIfReady();
+        return;
+    }
+
+    connected_ = false;
+    connecting_ = true;
+    ready_ = false;
+    url_ = url;
+
+    resetProtocolState();
+
+    destroySocket();
+    createSocket();
+
+    qCInfo(tcinetworking_js8) << "Opening TCI connection:"
+            << "client=" << this
+            << "url=" << url;
+
+    socket_->open(url);
+}
+
+void TCIClient::disconnectFromServer()
+{
+    if (thread() != QThread::currentThread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                disconnectFromServer();
+            },
+            Qt::QueuedConnection
+        );
+        return;
+    }
+
+    if (socket_)
+        socket_->close();
+}
+
+bool TCIClient::isConnected() const
+{
+    return connected_;
+}
+
+bool TCIClient::isReady() const
+{
+    return ready_;
+}
+
+void TCIClient::setFrequency(qint64 hz)
+{
+    sendText(QStringLiteral("vfo:0,0,%1;").arg(hz));
+}
+
+void TCIClient::queryFrequency()
+{
+    sendText("vfo;");
+}
+
+void TCIClient::setTxFrequency(qint64 hz)
+{
+    sendText(QStringLiteral("vfo:0,1,%1;").arg(hz));
+}
+
+void TCIClient::queryTxFrequency()
+{
+    sendText("vfo:0,1;");
+}
+
+void TCIClient::setSplit(bool enabled)
+{
+    sendText(QStringLiteral("split_enable:0,%1;")
+                 .arg(enabled ? "true" : "false"));
+}
+
+void TCIClient::querySplit()
+{
+    sendText("split_enable:0;");
+}
+
+void TCIClient::setMode(const QString &mode)
+{
+    sendText(QStringLiteral("modulation:0,0,%1;").arg(mode.trimmed().toLower()));
+}
+
+void TCIClient::queryMode()
+{
+    sendText("modulation;");
+}
+
+void TCIClient::setPtt(bool enabled)
+{
+    sendText(QStringLiteral("trx:0,%1;").arg(enabled ? "true" : "false"));
+}
+
+void TCIClient::queryPtt()
+{
+    sendText("trx;");
+}
+
+void TCIClient::configureAudio(int sampleRate, int channels, int samplesPerFrame)
+{
+    audio_sample_rate_ = sampleRate;
+    audio_channels_ = channels;
+    audio_samples_per_frame_ = samplesPerFrame;
+
+    sendText("audio_stream_sample_type:int16;");
+    sendText(QStringLiteral("audio_stream_channels:%1;").arg(audio_channels_));
+    sendText(QStringLiteral("audio_stream_samples:%1;").arg(audio_samples_per_frame_));
+    sendText(QStringLiteral("audio_samplerate:%1;").arg(audio_sample_rate_));
+}
+
+void TCIClient::startRxAudio()
+{
+    sendText("audio_start:0;");
+}
+
+void TCIClient::stopRxAudio()
+{
+    sendText("audio_stop:0;");
+}
+
+void TCIClient::startTxAudio()
+{
+    sendText("tx_audio_start:0;");
+}
+
+void TCIClient::stopTxAudio()
+{
+    sendText("tx_audio_stop:0;");
+}
+
+void TCIClient::sendTxAudio(QByteArray const &monoInt16Pcm,
+                            TciTxAudioPolicy const &policy)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, monoInt16Pcm, policy]() {
+                sendTxAudio(monoInt16Pcm, policy);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (!socket_ || socket_->state() != QAbstractSocket::ConnectedState)
+        return;
+
+    if (monoInt16Pcm.isEmpty())
+        return;
+
+    if (monoInt16Pcm.size() % qsizetype(sizeof(qint16))) {
+        qWarning() << "Ignoring unaligned TCI TX PCM block:"
+                   << monoInt16Pcm.size();
+        return;
+    }
+
+    int const monoInputSamples =
+        monoInt16Pcm.size() / int(sizeof(qint16));
+
+    QByteArray payload;
+    quint32 headerSampleCount = 0;
+
+    switch (policy.sampleType) {
+    case TCIStream::INT16:
+        if (policy.channels != 1) {
+            qWarning() << "Unsupported TCI TX int16 channel count:"
+                       << policy.channels;
+            return;
+        }
+
+        payload = monoInt16Pcm;
+        headerSampleCount =
+            txHeaderSampleCount(policy, monoInputSamples);
+        break;
+
+    case TCIStream::FLOAT32:
+        payload =
+            convertMonoInt16ToFloat32(monoInt16Pcm, policy.channels);
+
+        if (payload.isEmpty())
+            return;
+
+        headerSampleCount =
+            txHeaderSampleCount(policy, monoInputSamples);
+        break;
+
+    default:
+        qWarning() << "Unsupported TCI TX sample type:"
+                   << policy.sampleType;
+        return;
+    }
+
+    QByteArray const frame =
+        TCIStream::makeTxAudioFrameWithSampleCount(
+            payload,
+            headerSampleCount,
+            0,
+            quint32(policy.sampleRate),
+            quint32(policy.sampleType),
+            quint32(policy.channels));
+
+    if (frame.size() <= 64) {
+        qWarning() << "Refusing to send empty TCI TX audio frame:"
+                   << "payloadBytes=" << payload.size()
+                   << "frameBytes=" << frame.size();
+        return;
+    }
+
+    if (!canSend())
+        return;
+
+    qCInfo(tcinetworking_js8).noquote()
+    << "TCI TX binary:"
+    << "stream=" << tciStreamTypeName(TCIStream::TX_AUDIO_STREAM)
+    << "receiver=" << 0
+    << "rate=" << policy.sampleRate
+    << "type=" << tciSampleTypeName(policy.sampleType)
+    << "sampleCount=" << headerSampleCount
+    << "channels=" << policy.channels
+    << "payloadBytes=" << payload.size()
+    << "messageBytes=" << frame.size()
+    << "sampleCountMeaning="
+    << tciSampleCountMeaningName(policy.sampleCountMeaning);
+
+    socket_->sendBinaryMessage(frame);
+}
+
+void TCIClient::sendTxAudioMonoInt16(QByteArray const &pcm)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, pcm]() {
+                sendTxAudioMonoInt16(pcm);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (!socket_ || socket_->state() != QAbstractSocket::ConnectedState)
+        return;
+
+    if (pcm.isEmpty())
+        return;
+
+    if (pcm.size() % qsizetype(sizeof(qint16))) {
+        qWarning() << "Ignoring unaligned TCI TX audio PCM block:"
+                   << pcm.size();
+        return;
+    }
+
+    QByteArray const frame =
+        TCIStream::makeTxAudioFrame(pcm,
+                                    0,     // receiver
+                                    48000, // sample rate
+                                    TCIStream::INT16,
+                                    1);    // mono
+
+    if (!canSend())
+        return;
+
+    socket_->sendBinaryMessage(frame);
+}
+
+void TCIClient::onConnected()
+{
+    connected_ = true;
+    connecting_ = false;
+
+    qCInfo(tcinetworking_js8) << "Connected to TCI server"
+            << "client=" << this;
+
+    Q_EMIT connected();
+}
+
+void TCIClient::onDisconnected()
+{
+    connected_ = false;
+    connecting_ = false;
+    ready_ = false;
+
+    qCInfo(tcinetworking_js8) << "Disconnected from TCI server"
+            << "client=" << this;
+
+    destroySocket();
+
+    Q_EMIT disconnected();
+}
+
+void TCIClient::onTextMessageReceived(const QString &message)
+{
+    qCInfo(tcinetworking_js8).noquote() << "TCI RX text:" << message;
+    parseTextMessage(message);
+
+    ensureProtocolHandler();
+
+    const QString name = commandName(message);
+    const QStringList args = commandArgs(message);
+
+    if (protocol_handler_)
+        protocol_handler_->handleTextCommand(name,
+                                             args,
+                                             server_info_,
+                                             capabilities_);
+
+    if (name == "protocol")
+        selectProtocolHandler();
+
+    if (!server_info_logged_ &&
+        !server_info_.programName.isEmpty() &&
+        !server_info_.protocolVersion.isEmpty()) {
+        logServerInfo();
+        server_info_logged_ = true;
+        }
+
+    logCapabilities();
+    logTxPolicy();
+}
+
+void TCIClient::onBinaryMessageReceived(QByteArray const &message)
+{
+    TCIStream::StreamFrame const frame = TCIStream::parseFrame(message);
+
+    if (!frame.valid) {
+        qWarning() << "Invalid TCI binary frame:" << message.size();
+        return;
+    }
+
+    if (frame.streamType != TCIStream::RX_AUDIO_STREAM)
+        logBinaryFrame(QStringLiteral("RX"), frame, message.size());
+
+    ensureProtocolHandler();
+
+    if (protocol_handler_)
+        protocol_handler_->handleBinaryFrame(frame, capabilities_);
+
+    if (frame.streamType == TCIStream::TX_CHRONO) {
+        logCapabilities();
+        logTxPolicy();
+
+        if (protocol_handler_) {
+            TciTxAudioPolicy const policy =
+                protocol_handler_->deriveTxAudioPolicy(server_info_, capabilities_);
+
+            Q_EMIT txChronoRequested(policy);
+        }
+
+        return;
+    }
+
+    if (frame.streamType != TCIStream::RX_AUDIO_STREAM) {
+        qCInfo(tcinetworking_js8) << "Ignoring non-RX TCI stream type:"
+                << tciStreamTypeName(frame.streamType);
+        return;
+    }
+
+    if (frame.sampleRate != 48000) {
+        qWarning() << "Unsupported TCI RX sample rate:" << frame.sampleRate;
+        return;
+    }
+
+    QByteArray const monoInt16 =
+    convertRxAudioToMonoInt16(frame);
+
+    if (monoInt16.isEmpty())
+        return;
+
+    qsizetype const expected_bytes =
+        static_cast<qsizetype>(frame.sampleCount) * 2;
+
+    if (frame.payload.size() < expected_bytes) {
+        qWarning() << "Short TCI RX audio payload:"
+                   << frame.payload.size()
+                   << "expected"
+                   << expected_bytes;
+        return;
+    }
+
+    Q_EMIT rxAudioFrame(monoInt16,
+                        static_cast<int>(frame.sampleRate));
+}
+
+void TCIClient::onErrorOccurred(QAbstractSocket::SocketError socketError)
+{
+    QString const message =
+        socket_ ? socket_->errorString()
+                : tr("Unknown TCI socket error.");
+
+    if (socketError == QAbstractSocket::RemoteHostClosedError) {
+        qInfo() << "TCI socket closed by remote host:"
+                << message;
+
+        Q_EMIT error(tr("TCI disconnected"));
+
+        return;
+    }
+
+    qWarning() << "TCI socket error:" << message;
+    Q_EMIT error(message);
+}
+
+void TCIClient::resetProtocolState()
+{
+    server_info_ = {};
+    capabilities_ = {};
+    protocol_handler_.reset();
+    protocol_generation_ = TciProtocolGeneration::Unknown;
+
+    server_info_logged_ = false;
+    policy_logged_ = false;
+}
+
+void TCIClient::ensureProtocolHandler()
+{
+    if (protocol_handler_)
+        return;
+
+    protocol_handler_ = std::make_unique<TciProtocolUnknownHandler>();
+    protocol_generation_ = TciProtocolGeneration::Unknown;
+}
+
+void TCIClient::selectProtocolHandler()
+{
+    QVersionNumber const version =
+        QVersionNumber::fromString(server_info_.protocolVersion);
+
+    TciProtocolGeneration next_generation =
+        TciProtocolGeneration::Unknown;
+
+    if (!version.isNull()) {
+        QVersionNumber const modern_boundary(1, 10);
+
+        if (version < modern_boundary)
+            next_generation = TciProtocolGeneration::LegacyV1;
+        else if (version.majorVersion() <= 2)
+            next_generation = TciProtocolGeneration::V2;
+        else
+            next_generation = TciProtocolGeneration::Unknown;
+    }
+
+    if (protocol_handler_ && protocol_generation_ == next_generation)
+        return;
+
+    switch (next_generation) {
+    case TciProtocolGeneration::LegacyV1:
+        protocol_handler_ = std::make_unique<TciProtocolLegacyV1Handler>();
+        break;
+
+    case TciProtocolGeneration::V2:
+        protocol_handler_ = std::make_unique<TciProtocolV2Handler>();
+        break;
+
+    case TciProtocolGeneration::Unknown:
+        protocol_handler_ = std::make_unique<TciProtocolUnknownHandler>();
+        break;
+    }
+
+    protocol_generation_ = next_generation;
+    policy_logged_ = false;
+
+    qCInfo(tcinetworking_js8).noquote()
+        << "TCI protocol handler selected:"
+        << tciGenerationName(protocol_generation_)
+        << "program=" << server_info_.programName
+        << "version=" << server_info_.protocolVersion;
+}
+
+void TCIClient::emitReadyIfReady()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                emitReadyIfReady();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (ready_)
+        Q_EMIT ready();
+}
+
+void TCIClient::logServerInfo() const
+{
+    qCInfo(tcinetworking_js8).noquote()
+        << "TCI server info:"
+        << "program=" << server_info_.programName
+        << "protocol=" << server_info_.protocolVersion
+        << "device=" << server_info_.device;
+}
+
+void TCIClient::logCapabilities() const
+{
+    qCInfo(tcinetworking_js8).noquote()
+        << "TCI capabilities:"
+        << "ready=" << capabilities_.readySeen
+        << "start=" << capabilities_.startSeen
+        << "receiveOnlySeen=" << capabilities_.receiveOnlySeen
+        << "receiveOnly=" << capabilities_.receiveOnly
+        << "txEnableSeen=" << capabilities_.txEnableSeen
+        << "txEnabled=" << capabilities_.txEnabled
+        << "txChronoSeen=" << capabilities_.txChronoSeen
+        << "textAudioType="
+        << (capabilities_.textAudio.sampleTypeSeen
+                ? tciSampleTypeName(capabilities_.textAudio.sampleType)
+                : QStringLiteral("unknown"))
+        << "textAudioChannels="
+        << (capabilities_.textAudio.channelsSeen
+                ? QString::number(capabilities_.textAudio.channels)
+                : QStringLiteral("unknown"))
+        << "textAudioSamples="
+        << (capabilities_.textAudio.samplesSeen
+                ? QString::number(capabilities_.textAudio.samplesPerFrame)
+                : QStringLiteral("unknown"))
+        << "textAudioRate="
+        << (capabilities_.textAudio.sampleRateSeen
+                ? QString::number(capabilities_.textAudio.sampleRate)
+                : QStringLiteral("unknown"))
+        << "rxAudioType="
+        << (capabilities_.rxAudio.sampleTypeSeen
+                ? tciSampleTypeName(capabilities_.rxAudio.sampleType)
+                : QStringLiteral("unknown"))
+        << "rxAudioChannels="
+        << (capabilities_.rxAudio.channelsSeen
+                ? QString::number(capabilities_.rxAudio.channels)
+                : QStringLiteral("unknown"))
+        << "rxAudioSamples="
+        << (capabilities_.rxAudio.samplesSeen
+                ? QString::number(capabilities_.rxAudio.samplesPerFrame)
+                : QStringLiteral("unknown"))
+        << "rxAudioRate="
+        << (capabilities_.rxAudio.sampleRateSeen
+                ? QString::number(capabilities_.rxAudio.sampleRate)
+                : QStringLiteral("unknown"))
+        << "txChronoType="
+        << (capabilities_.txChronoAudio.sampleTypeSeen
+                ? tciSampleTypeName(capabilities_.txChronoAudio.sampleType)
+                : QStringLiteral("unknown"))
+        << "txChronoChannels="
+        << (capabilities_.txChronoAudio.channelsSeen
+                ? QString::number(capabilities_.txChronoAudio.channels)
+                : QStringLiteral("unknown"))
+        << "txChronoSamples="
+        << (capabilities_.txChronoAudio.samplesSeen
+                ? QString::number(capabilities_.txChronoAudio.samplesPerFrame)
+                : QStringLiteral("unknown"))
+        << "txChronoRate="
+        << (capabilities_.txChronoAudio.sampleRateSeen
+                ? QString::number(capabilities_.txChronoAudio.sampleRate)
+                : QStringLiteral("unknown"));
+}
+
+void TCIClient::logTxPolicy()
+{
+    if (!protocol_handler_)
+        return;
+
+    TciTxAudioPolicy const policy =
+        protocol_handler_->deriveTxAudioPolicy(server_info_, capabilities_);
+
+    /*
+     * Log repeatedly until something meaningful has been observed. After that,
+     * only log when the policy is first derived after handler selection.
+     */
+    if (policy_logged_)
+        return;
+
+    qCInfo(tcinetworking_js8).noquote()
+        << "TCI derived TX policy:"
+        << "handler=" << tciGenerationName(protocol_generation_)
+        << "timing=" << tciTxTimingName(policy.timing)
+        << "sampleType=" << tciSampleTypeName(policy.sampleType)
+        << "channels=" << policy.channels
+        << "samplesPerFrame=" << policy.samplesPerFrame
+        << "sampleRate=" << policy.sampleRate
+        << "sampleCountMeaning="
+        << tciSampleCountMeaningName(policy.sampleCountMeaning);
+
+    policy_logged_ = true;
+}
+
+void TCIClient::logBinaryFrame(QString const &direction,
+                               TCIStream::StreamFrame const &frame,
+                               qsizetype messageBytes) const
+{
+    qCInfo(tcinetworking_js8).noquote()
+        << "TCI" << direction << "binary:"
+        << "stream=" << tciStreamTypeName(frame.streamType)
+        << "receiver=" << frame.receiver
+        << "rate=" << frame.sampleRate
+        << "type=" << tciSampleTypeName(frame.sampleType)
+        << "sampleCount=" << frame.sampleCount
+        << "channels=" << frame.channels
+        << "payloadBytes=" << frame.payload.size()
+        << "messageBytes=" << messageBytes;
+}
+
+void TCIClient::sendText(QString const &message)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, message]() {
+                sendText(message);
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (!canSend())
+        return;
+
+    socket_->sendTextMessage(message);
+}
+
+bool TCIClient::canSend() const
+{
+    return socket_
+        && socket_->state() == QAbstractSocket::ConnectedState;
+}
+
+void TCIClient::parseTextMessage(const QString &message)
+{
+    const QString name = commandName(message);
+    const QStringList args = commandArgs(message);
+
+    if (name == "ready") {
+        if (!ready_) {
+            ready_ = true;
+            emit ready();
+        }
+
+        return;
+    }
+
+    if (name == "vfo" || name == "dds") {
+        if (args.size() >= 3) {
+            bool channelOk = false;
+            const int channel = args.at(1).toInt(&channelOk);
+
+            bool freqOk = false;
+            const qint64 hz = args.at(2).toLongLong(&freqOk);
+
+            if (freqOk) {
+                if (channelOk && channel == 1)
+                    emit txFrequencyChanged(hz);
+                else
+                    emit frequencyChanged(hz);
+            }
+        }
+
+        return;
+    }
+
+    if (name == "split_enable") {
+        if (args.size() >= 2) {
+            const QString value = args.at(1).trimmed().toLower();
+
+            emit splitChanged(
+                value == "true" ||
+                value == "1" ||
+                value == "on" ||
+                value == "tx"
+            );
+        }
+
+        return;
+    }
+
+    if (name == "modulation" || name == "mode") {
+        if (args.size() >= 3)
+            emit modeChanged(args.at(2).trimmed().toUpper());
+
+        return;
+    }
+
+    if (name == "trx" || name == "ptt") {
+        if (args.size() >= 2) {
+            const QString value = args.last().trimmed().toLower();
+
+            emit pttChanged(
+                value == "true" ||
+                value == "1" ||
+                value == "on" ||
+                value == "tx"
+            );
+        }
+
+        return;
+    }
+}
+
+QString TCIClient::commandName(const QString &message)
+{
+    QString s = message.trimmed();
+
+    if (s.endsWith(';'))
+        s.chop(1);
+
+    const int colon = s.indexOf(':');
+
+    if (colon < 0)
+        return s.trimmed().toLower();
+
+    return s.left(colon).trimmed().toLower();
+}
+
+QStringList TCIClient::commandArgs(const QString &message)
+{
+    QString s = message.trimmed();
+
+    if (s.endsWith(';'))
+        s.chop(1);
+
+    const int colon = s.indexOf(':');
+
+    if (colon < 0)
+        return {};
+
+    const QString argString = s.mid(colon + 1).trimmed();
+
+    if (argString.isEmpty())
+        return {};
+
+    QStringList out;
+
+    const auto parts = argString.split(',', Qt::KeepEmptyParts);
+
+    for (const QString &part : parts)
+        out << part.trimmed();
+
+    return out;
+}
+
+QString TCIClient::semicolon(QString message)
+{
+    message = message.trimmed();
+
+    if (!message.endsWith(';'))
+        message.append(';');
+
+    return message;
+}
+
+Q_LOGGING_CATEGORY(tcinetworking_js8, "tcinetworking.js8", QtWarningMsg)

--- a/JS8_Network/TCIClient.h
+++ b/JS8_Network/TCIClient.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "TciProtocolHandler.h"
+
+#include <QObject>
+#include <QUrl>
+#include <QWebSocket>
+
+#include <memory>
+
+class TCIClient final : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit TCIClient(QObject *parent = nullptr);
+
+  void connectToServer(const QUrl &url);
+  void disconnectFromServer();
+
+  bool isConnected() const;
+  bool isReady() const;
+
+  void setFrequency(qint64 hz);
+  void queryFrequency();
+
+  void setTxFrequency(qint64 hz);
+  void queryTxFrequency();
+
+  void setSplit(bool enabled);
+  void querySplit();
+
+  void setMode(const QString &mode);
+  void queryMode();
+
+  void setPtt(bool enabled);
+  void queryPtt();
+
+  void configureAudio(int sampleRate = 48000,
+                    int channels = 1,
+                    int samplesPerFrame = 512);
+
+  void startRxAudio();
+  void stopRxAudio();
+
+  void startTxAudio();
+  void stopTxAudio();
+
+  void sendTxAudio(QByteArray const &monoInt16Pcm,
+                 TciTxAudioPolicy const &policy);
+
+  void sendTxAudioMonoInt16(QByteArray const &pcm);
+
+  bool isConnecting() const { return connecting_; }
+  QUrl connectionUrl() const { return url_; }
+
+  Q_SLOT void emitReadyIfReady();
+
+signals:
+  void connected();
+  void disconnected();
+  void ready();
+  void error(QString message);
+
+  void frequencyChanged(qint64 hz);
+  void txFrequencyChanged(qint64 hz);
+  void splitChanged(bool enabled);
+  void modeChanged(QString mode);
+  void pttChanged(bool enabled);
+  void txChronoRequested(TciTxAudioPolicy policy);
+
+  void rxAudioFrame(QByteArray monoInt16Pcm, int sampleRate);
+
+private slots:
+  void onConnected();
+  void onDisconnected();
+  void onTextMessageReceived(const QString &message);
+  void onBinaryMessageReceived(QByteArray const &message);
+  void onErrorOccurred(QAbstractSocket::SocketError error);
+
+private:
+  void createSocket();
+  void destroySocket();
+
+  void sendText(QString const &message);
+  bool canSend() const;
+  void parseTextMessage(const QString &message);
+
+  static QString commandName(const QString &message);
+  static QStringList commandArgs(const QString &message);
+  static QString semicolon(QString message);
+
+private:
+  void resetProtocolState();
+  void ensureProtocolHandler();
+  void selectProtocolHandler();
+  void logServerInfo() const;
+  void logCapabilities() const;
+  void logTxPolicy();
+  void logBinaryFrame(QString const &direction,
+                      TCIStream::StreamFrame const &frame,
+                      qsizetype messageBytes) const;
+
+  QWebSocket *socket_ = nullptr;
+
+  bool connected_ = false;
+  bool ready_ = false;
+
+  int audio_sample_rate_ = 48000;
+  int audio_channels_ = 1;
+  int audio_samples_per_frame_ = 512;
+
+  TciServerInfo server_info_;
+  TciCapabilities capabilities_;
+  std::unique_ptr<TciProtocolHandler> protocol_handler_;
+  TciProtocolGeneration protocol_generation_ = TciProtocolGeneration::Unknown;
+
+  QUrl url_;
+  bool connecting_ = false;
+
+  bool server_info_logged_ = false;
+  bool policy_logged_ = false;
+};

--- a/JS8_Network/TCISession.cpp
+++ b/JS8_Network/TCISession.cpp
@@ -1,0 +1,51 @@
+#include "TCISession.h"
+
+#include <QDebug>
+#include <QMetaObject>
+#include <QThread>
+
+TCISession::TCISession(QObject *parent)
+    : QObject(parent),
+      m_client(new TCIClient(this))
+{
+}
+
+void TCISession::connectToServer(QUrl const &url)
+{
+  if (QThread::currentThread() != thread()) {
+    QMetaObject::invokeMethod(
+        this,
+        [this, url]() {
+            connectToServer(url);
+        },
+        Qt::QueuedConnection);
+    return;
+  }
+
+  if (m_url == url && m_client && (m_client->isConnected() || m_client->isConnecting())) {
+    m_client->emitReadyIfReady();
+    return;
+  }
+
+  m_url = url;
+
+  m_client->connectToServer(url);
+}
+
+void TCISession::disconnectFromServer()
+{
+  if (QThread::currentThread() != thread()) {
+    QMetaObject::invokeMethod(
+        this,
+        [this]() {
+            disconnectFromServer();
+        },
+        Qt::QueuedConnection);
+    return;
+  }
+
+  if (!m_client)
+    return;
+
+  m_client->disconnectFromServer();
+}

--- a/JS8_Network/TCISession.h
+++ b/JS8_Network/TCISession.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "TCIClient.h"
+
+#include <QObject>
+#include <QUrl>
+
+class TCISession final : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit TCISession(QObject *parent = nullptr);
+
+  TCIClient *client() const { return m_client; }
+
+  Q_SLOT void connectToServer(QUrl const &url);
+  Q_SLOT void disconnectFromServer();
+
+  QUrl url() const { return m_url; }
+
+private:
+  TCIClient *m_client = nullptr;
+  QUrl m_url;
+};

--- a/JS8_Network/TCIStreamFrame.cpp
+++ b/JS8_Network/TCIStreamFrame.cpp
@@ -1,0 +1,176 @@
+#include "TCIStreamFrame.h"
+
+#include <QDebug>
+
+namespace
+{
+    constexpr int TCI_STREAM_HEADER_UINT32_COUNT = 16;
+    constexpr int TCI_STREAM_HEADER_BYTES = TCI_STREAM_HEADER_UINT32_COUNT * 4;
+
+    quint32 read_u32_le(QByteArray const &in, int offset)
+    {
+        auto b0 = static_cast<quint32>(static_cast<unsigned char>(in.at(offset)));
+        auto b1 = static_cast<quint32>(static_cast<unsigned char>(in.at(offset + 1)));
+        auto b2 = static_cast<quint32>(static_cast<unsigned char>(in.at(offset + 2)));
+        auto b3 = static_cast<quint32>(static_cast<unsigned char>(in.at(offset + 3)));
+
+        return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+    }
+
+    void append_u32_le(QByteArray &out, quint32 value)
+    {
+        out.append(static_cast<char>(value & 0xff));
+        out.append(static_cast<char>((value >> 8) & 0xff));
+        out.append(static_cast<char>((value >> 16) & 0xff));
+        out.append(static_cast<char>((value >> 24) & 0xff));
+    }
+
+    int bytes_per_sample(quint32 sample_type)
+    {
+        switch (sample_type) {
+        case TCIStream::INT16:
+            return 2;
+        case TCIStream::INT24:
+            return 3;
+        case TCIStream::INT32:
+        case TCIStream::FLOAT32:
+            return 4;
+        default:
+            return 0;
+        }
+    }
+}
+
+namespace TCIStream
+{
+    StreamFrame parseFrame(QByteArray const &frame)
+    {
+        StreamFrame result;
+
+        if (frame.size() < TCI_STREAM_HEADER_BYTES) {
+            return result;
+        }
+
+        result.receiver = read_u32_le(frame, 0);
+        result.sampleRate = read_u32_le(frame, 4);
+        result.sampleType = read_u32_le(frame, 8);
+        result.codec = read_u32_le(frame, 12);
+        result.crc = read_u32_le(frame, 16);
+        result.sampleCount = read_u32_le(frame, 20);
+        result.streamType = read_u32_le(frame, 24);
+        result.channels = read_u32_le(frame, 28);
+        result.payload = frame.mid(TCI_STREAM_HEADER_BYTES);
+
+        int const bps = bytes_per_sample(result.sampleType);
+
+        if (bps <= 0) {
+            return result;
+        }
+
+        /*
+         * TX_CHRONO is a timing/request frame. Some servers send it as a
+         * 64-byte header-only frame. Do not require audio payload for it.
+         */
+        if (result.streamType == TX_CHRONO) {
+            result.valid = true;
+            return result;
+        }
+
+        /*
+         * Other non-audio stream types may also be metadata/control-like for
+         * our purposes. Parse the header and leave payload interpretation to
+         * the caller.
+         */
+        if (result.streamType != RX_AUDIO_STREAM &&
+            result.streamType != TX_AUDIO_STREAM &&
+            result.streamType != IQ_STREAM &&
+            result.streamType != LINEOUT_STREAM) {
+            result.valid = true;
+            return result;
+            }
+
+        if (result.channels == 0) {
+            return result;
+        }
+
+        qsizetype const expected_min =
+            static_cast<qsizetype>(result.sampleCount) *
+            static_cast<qsizetype>(result.channels) *
+            static_cast<qsizetype>(bps);
+
+        if (result.payload.size() < expected_min) {
+            qWarning() << "Short TCI stream payload:"
+                       << "streamType=" << result.streamType
+                       << "sampleRate=" << result.sampleRate
+                       << "sampleType=" << result.sampleType
+                       << "sampleCount=" << result.sampleCount
+                       << "channels=" << result.channels
+                       << "payloadBytes=" << result.payload.size()
+                       << "expectedBytes=" << expected_min;
+            return result;
+        }
+
+        result.valid = true;
+        return result;
+    }
+
+    QByteArray makeTxAudioFrame(QByteArray const &pcm,
+                                quint32 receiver,
+                                quint32 sampleRate,
+                                quint32 sampleType,
+                                quint32 channels)
+    {
+        int const bps = bytes_per_sample(sampleType);
+
+        quint32 const sample_count =
+            bps > 0 && channels > 0
+                ? static_cast<quint32>(pcm.size() / bps / channels)
+                : 0;
+
+        QByteArray frame;
+        frame.reserve(TCI_STREAM_HEADER_BYTES + pcm.size());
+
+        append_u32_le(frame, receiver);
+        append_u32_le(frame, sampleRate);
+        append_u32_le(frame, sampleType);
+        append_u32_le(frame, 0); // codec
+        append_u32_le(frame, 0); // crc
+        append_u32_le(frame, sample_count);
+        append_u32_le(frame, TX_AUDIO_STREAM);
+        append_u32_le(frame, channels);
+
+        for (int i = 0; i < 8; ++i) {
+            append_u32_le(frame, 0);
+        }
+
+        frame.append(pcm);
+        return frame;
+    }
+
+QByteArray makeTxAudioFrameWithSampleCount(QByteArray const &pcm,
+                            quint32 sampleCount,
+                            quint32 receiver,
+                            quint32 sampleRate,
+                            quint32 sampleType,
+                            quint32 channels)
+    {
+        QByteArray frame;
+        frame.reserve(TCI_STREAM_HEADER_BYTES + pcm.size());
+
+        append_u32_le(frame, receiver);
+        append_u32_le(frame, sampleRate);
+        append_u32_le(frame, sampleType);
+        append_u32_le(frame, 0); // codec
+        append_u32_le(frame, 0); // crc
+        append_u32_le(frame, sampleCount);
+        append_u32_le(frame, TX_AUDIO_STREAM);
+        append_u32_le(frame, channels);
+
+        for (int i = 0; i < 8; ++i) {
+            append_u32_le(frame, 0);
+        }
+
+        frame.append(pcm);
+        return frame;
+    }
+}

--- a/JS8_Network/TCIStreamFrame.h
+++ b/JS8_Network/TCIStreamFrame.h
@@ -1,0 +1,58 @@
+#ifndef TCI_STREAM_FRAME_HPP_
+#define TCI_STREAM_FRAME_HPP_
+
+#include <QByteArray>
+#include <QtGlobal>
+
+namespace TCIStream
+{
+enum StreamType : quint32
+{
+  IQ_STREAM = 0,
+  RX_AUDIO_STREAM = 1,
+  TX_AUDIO_STREAM = 2,
+  TX_CHRONO = 3,
+  LINEOUT_STREAM = 4
+};
+
+enum SampleType : quint32
+{
+  INT16 = 0,
+  INT24 = 1,
+  INT32 = 2,
+  FLOAT32 = 3
+};
+
+struct StreamFrame
+{
+  bool valid = false;
+
+  quint32 receiver = 0;
+  quint32 sampleRate = 0;
+  quint32 sampleType = INT16;
+  quint32 codec = 0;
+  quint32 crc = 0;
+  quint32 sampleCount = 0;
+  quint32 streamType = RX_AUDIO_STREAM;
+  quint32 channels = 1;
+
+  QByteArray payload;
+};
+
+StreamFrame parseFrame(QByteArray const &frame);
+
+QByteArray makeTxAudioFrame(QByteArray const &pcm,
+                            quint32 receiver = 0,
+                            quint32 sampleRate = 48000,
+                            quint32 sampleType = INT16,
+                            quint32 channels = 1);
+
+QByteArray makeTxAudioFrameWithSampleCount(QByteArray const &payload,
+                                           quint32 sampleCount,
+                                           quint32 receiver = 0,
+                                           quint32 sampleRate = 48000,
+                                           quint32 sampleType = INT16,
+                                           quint32 channels = 1);
+}
+
+#endif

--- a/JS8_Network/TciProtocolHandler.cpp
+++ b/JS8_Network/TciProtocolHandler.cpp
@@ -1,0 +1,419 @@
+#include "TciProtocolHandler.h"
+
+#include <QDebug>
+
+namespace
+{
+    bool parse_bool(QString const &value)
+    {
+        QString const v = value.trimmed().toLower();
+
+        return v == "true" ||
+               v == "1" ||
+               v == "on" ||
+               v == "yes" ||
+               v == "tx";
+    }
+
+    bool parse_int(QString const &value, int &out)
+    {
+        bool ok = false;
+        int const parsed = value.trimmed().toInt(&ok);
+
+        if (!ok)
+            return false;
+
+        out = parsed;
+        return true;
+    }
+
+    bool parse_sample_type(QString const &value,
+                           TCIStream::SampleType &out)
+    {
+        QString const v = value.trimmed().toLower();
+
+        if (v == "int16" || v == "i16" || v == "0") {
+            out = TCIStream::INT16;
+            return true;
+        }
+
+        if (v == "int24" || v == "i24" || v == "1") {
+            out = TCIStream::INT24;
+            return true;
+        }
+
+        if (v == "int32" || v == "i32" || v == "2") {
+            out = TCIStream::INT32;
+            return true;
+        }
+
+        if (v == "float32" || v == "float" || v == "f32" || v == "3") {
+            out = TCIStream::FLOAT32;
+            return true;
+        }
+
+        return false;
+    }
+
+    void observe_text_audio_command(QString const &name,
+                                    QStringList const &args,
+                                    TciCapabilities &capabilities)
+    {
+        if (args.isEmpty())
+            return;
+
+        QString const value = args.last();
+
+        if (name == "audio_stream_sample_type") {
+            TCIStream::SampleType sampleType = TCIStream::INT16;
+
+            if (parse_sample_type(value, sampleType)) {
+                capabilities.textAudio.sampleType = sampleType;
+                capabilities.textAudio.sampleTypeSeen = true;
+            }
+
+            return;
+        }
+
+        if (name == "audio_stream_channels") {
+            int channels = 0;
+
+            if (parse_int(value, channels) && channels > 0) {
+                capabilities.textAudio.channels = channels;
+                capabilities.textAudio.channelsSeen = true;
+            }
+
+            return;
+        }
+
+        if (name == "audio_stream_samples") {
+            int samples = 0;
+
+            if (parse_int(value, samples) && samples > 0) {
+                capabilities.textAudio.samplesPerFrame = samples;
+                capabilities.textAudio.samplesSeen = true;
+            }
+
+            return;
+        }
+
+        if (name == "audio_samplerate" || name == "audio_sample_rate") {
+            int sampleRate = 0;
+
+            if (parse_int(value, sampleRate) && sampleRate > 0) {
+                capabilities.textAudio.sampleRate = sampleRate;
+                capabilities.textAudio.sampleRateSeen = true;
+            }
+
+            return;
+        }
+    }
+
+    void handle_common_text_command(QString const &name,
+                                    QStringList const &args,
+                                    TciServerInfo &serverInfo,
+                                    TciCapabilities &capabilities)
+    {
+        if (name == "protocol") {
+            if (args.size() >= 1)
+                serverInfo.programName = args.at(0).trimmed();
+
+            if (args.size() >= 2)
+                serverInfo.protocolVersion = args.at(1).trimmed();
+
+            return;
+        }
+
+        if (name == "device") {
+            if (!args.isEmpty())
+                serverInfo.device = args.last().trimmed();
+
+            return;
+        }
+
+        if (name == "ready") {
+            capabilities.readySeen = true;
+            return;
+        }
+
+        if (name == "start") {
+            capabilities.startSeen = true;
+            return;
+        }
+
+        if (name == "receive_only") {
+            if (!args.isEmpty()) {
+                capabilities.receiveOnlySeen = true;
+                capabilities.receiveOnly = parse_bool(args.last());
+            }
+
+            return;
+        }
+
+        if (name == "tx_enable") {
+            if (!args.isEmpty()) {
+                capabilities.txEnableSeen = true;
+                capabilities.txEnabled = parse_bool(args.last());
+            }
+
+            return;
+        }
+
+        observe_text_audio_command(name, args, capabilities);
+    }
+
+void handle_common_binary_frame(TCIStream::StreamFrame const &frame,
+                            TciCapabilities &capabilities)
+    {
+        if (frame.streamType == TCIStream::TX_CHRONO) {
+            capabilities.txChronoSeen = true;
+
+            capabilities.txChronoAudio.sampleType =
+                static_cast<TCIStream::SampleType>(frame.sampleType);
+            capabilities.txChronoAudio.sampleTypeSeen = true;
+
+            capabilities.txChronoAudio.channels =
+                static_cast<int>(frame.channels);
+            capabilities.txChronoAudio.channelsSeen = frame.channels > 0;
+
+            capabilities.txChronoAudio.samplesPerFrame =
+                static_cast<int>(frame.sampleCount);
+            capabilities.txChronoAudio.samplesSeen = frame.sampleCount > 0;
+
+            capabilities.txChronoAudio.sampleRate =
+                static_cast<int>(frame.sampleRate);
+            capabilities.txChronoAudio.sampleRateSeen = frame.sampleRate > 0;
+
+            return;
+        }
+
+        if (frame.streamType == TCIStream::RX_AUDIO_STREAM) {
+            capabilities.rxAudio.sampleType =
+                static_cast<TCIStream::SampleType>(frame.sampleType);
+            capabilities.rxAudio.sampleTypeSeen = true;
+
+            capabilities.rxAudio.channels =
+                static_cast<int>(frame.channels);
+            capabilities.rxAudio.channelsSeen = frame.channels > 0;
+
+            capabilities.rxAudio.samplesPerFrame =
+                static_cast<int>(frame.sampleCount);
+            capabilities.rxAudio.samplesSeen = frame.sampleCount > 0;
+
+            capabilities.rxAudio.sampleRate =
+                static_cast<int>(frame.sampleRate);
+            capabilities.rxAudio.sampleRateSeen = frame.sampleRate > 0;
+        }
+    }
+
+    TciTxAudioPolicy default_push_int16_policy()
+    {
+        TciTxAudioPolicy policy;
+        policy.timing = TciTxAudioPolicy::Timing::ClientPaced;
+        policy.sampleRate = 48000;
+        policy.channels = 1;
+        policy.sampleType = TCIStream::INT16;
+        policy.samplesPerFrame = 512;
+        policy.sampleCountMeaning =
+            TciTxAudioPolicy::SampleCountMeaning::FramesPerChannel;
+        return policy;
+    }
+
+    TciTxAudioPolicy chrono_policy_from_observed_audio(TciCapabilities const &capabilities)
+    {
+        TciTxAudioPolicy policy = default_push_int16_policy();
+
+        policy.timing = TciTxAudioPolicy::Timing::ChronoDriven;
+
+        if (capabilities.txChronoAudio.sampleRateSeen)
+            policy.sampleRate = capabilities.txChronoAudio.sampleRate;
+        else if (capabilities.textAudio.sampleRateSeen)
+            policy.sampleRate = capabilities.textAudio.sampleRate;
+        else if (capabilities.rxAudio.sampleRateSeen)
+            policy.sampleRate = capabilities.rxAudio.sampleRate;
+
+        if (capabilities.txChronoAudio.samplesSeen)
+            policy.samplesPerFrame = capabilities.txChronoAudio.samplesPerFrame;
+        else if (capabilities.textAudio.samplesSeen)
+            policy.samplesPerFrame = capabilities.textAudio.samplesPerFrame;
+        else if (capabilities.rxAudio.samplesSeen)
+            policy.samplesPerFrame = capabilities.rxAudio.samplesPerFrame;
+
+        if (capabilities.txChronoAudio.sampleTypeSeen)
+            policy.sampleType = capabilities.txChronoAudio.sampleType;
+        else if (capabilities.textAudio.sampleTypeSeen)
+            policy.sampleType = capabilities.textAudio.sampleType;
+        else if (capabilities.rxAudio.sampleTypeSeen)
+            policy.sampleType = capabilities.rxAudio.sampleType;
+
+        if (capabilities.txChronoAudio.channelsSeen)
+            policy.channels = capabilities.txChronoAudio.channels;
+        else if (capabilities.textAudio.channelsSeen)
+            policy.channels = capabilities.textAudio.channels;
+        else if (capabilities.rxAudio.channelsSeen)
+            policy.channels = capabilities.rxAudio.channels;
+
+        return policy;
+    }
+}
+
+void TciProtocolLegacyV1Handler::handleTextCommand(QString const &name,
+                                                   QStringList const &args,
+                                                   TciServerInfo &serverInfo,
+                                                   TciCapabilities &capabilities)
+{
+    handle_common_text_command(name, args, serverInfo, capabilities);
+}
+
+void TciProtocolLegacyV1Handler::handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                                                   TciCapabilities &capabilities)
+{
+    handle_common_binary_frame(frame, capabilities);
+}
+
+TciTxAudioPolicy TciProtocolLegacyV1Handler::deriveTxAudioPolicy(
+    TciServerInfo const &serverInfo,
+    TciCapabilities const &capabilities) const
+{
+    Q_UNUSED(serverInfo);
+
+    if (!capabilities.txChronoSeen)
+        return default_push_int16_policy();
+
+    TciTxAudioPolicy policy = chrono_policy_from_observed_audio(capabilities);
+
+    policy.sampleCountMeaning =
+        TciTxAudioPolicy::SampleCountMeaning::TotalSampleValues;
+
+    return policy;
+}
+
+void TciProtocolV2Handler::handleTextCommand(QString const &name,
+                                             QStringList const &args,
+                                             TciServerInfo &serverInfo,
+                                             TciCapabilities &capabilities)
+{
+    handle_common_text_command(name, args, serverInfo, capabilities);
+}
+
+void TciProtocolV2Handler::handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                                             TciCapabilities &capabilities)
+{
+    handle_common_binary_frame(frame, capabilities);
+}
+
+TciTxAudioPolicy TciProtocolV2Handler::deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                                           TciCapabilities const &capabilities) const
+{
+    Q_UNUSED(serverInfo);
+
+    if (!capabilities.txChronoSeen)
+        return default_push_int16_policy();
+
+    TciTxAudioPolicy policy = chrono_policy_from_observed_audio(capabilities);
+    policy.sampleCountMeaning =
+        TciTxAudioPolicy::SampleCountMeaning::FramesPerChannel;
+
+    return policy;
+}
+
+void TciProtocolUnknownHandler::handleTextCommand(QString const &name,
+                                                  QStringList const &args,
+                                                  TciServerInfo &serverInfo,
+                                                  TciCapabilities &capabilities)
+{
+    handle_common_text_command(name, args, serverInfo, capabilities);
+}
+
+void TciProtocolUnknownHandler::handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                                                  TciCapabilities &capabilities)
+{
+    handle_common_binary_frame(frame, capabilities);
+}
+
+TciTxAudioPolicy TciProtocolUnknownHandler::deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                                                TciCapabilities const &capabilities) const
+{
+    Q_UNUSED(serverInfo);
+    Q_UNUSED(capabilities);
+
+    /*
+     * Unknown future protocols should not silently get new TX behavior.
+     * For this observe-only pass, leave the existing client-paced path alone.
+     */
+    return default_push_int16_policy();
+}
+
+QString tciSampleTypeName(quint32 sampleType)
+{
+    switch (sampleType) {
+    case TCIStream::INT16:
+        return QStringLiteral("int16");
+    case TCIStream::INT24:
+        return QStringLiteral("int24");
+    case TCIStream::INT32:
+        return QStringLiteral("int32");
+    case TCIStream::FLOAT32:
+        return QStringLiteral("float32");
+    default:
+        return QStringLiteral("unknown(%1)").arg(sampleType);
+    }
+}
+
+QString tciStreamTypeName(quint32 streamType)
+{
+    switch (streamType) {
+    case TCIStream::IQ_STREAM:
+        return QStringLiteral("IQ_STREAM");
+    case TCIStream::RX_AUDIO_STREAM:
+        return QStringLiteral("RX_AUDIO_STREAM");
+    case TCIStream::TX_AUDIO_STREAM:
+        return QStringLiteral("TX_AUDIO_STREAM");
+    case TCIStream::TX_CHRONO:
+        return QStringLiteral("TX_CHRONO");
+    case TCIStream::LINEOUT_STREAM:
+        return QStringLiteral("LINEOUT_STREAM");
+    default:
+        return QStringLiteral("unknown(%1)").arg(streamType);
+    }
+}
+
+QString tciGenerationName(TciProtocolGeneration generation)
+{
+    switch (generation) {
+    case TciProtocolGeneration::LegacyV1:
+        return QStringLiteral("legacy-v1");
+    case TciProtocolGeneration::V2:
+        return QStringLiteral("v2");
+    case TciProtocolGeneration::Unknown:
+        return QStringLiteral("unknown");
+    }
+
+    return QStringLiteral("unknown");
+}
+
+QString tciTxTimingName(TciTxAudioPolicy::Timing timing)
+{
+    switch (timing) {
+    case TciTxAudioPolicy::Timing::ClientPaced:
+        return QStringLiteral("client-paced");
+    case TciTxAudioPolicy::Timing::ChronoDriven:
+        return QStringLiteral("chrono-driven");
+    }
+
+    return QStringLiteral("unknown");
+}
+
+QString tciSampleCountMeaningName(TciTxAudioPolicy::SampleCountMeaning meaning)
+{
+    switch (meaning) {
+    case TciTxAudioPolicy::SampleCountMeaning::FramesPerChannel:
+        return QStringLiteral("frames-per-channel");
+    case TciTxAudioPolicy::SampleCountMeaning::TotalSampleValues:
+        return QStringLiteral("total-sample-values");
+    case TciTxAudioPolicy::SampleCountMeaning::Unknown:
+        return QStringLiteral("unknown");
+    }
+
+    return QStringLiteral("unknown");
+}

--- a/JS8_Network/TciProtocolHandler.h
+++ b/JS8_Network/TciProtocolHandler.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "TCIStreamFrame.h"
+
+#include <QMetaType>
+#include <QString>
+#include <QStringList>
+
+struct TciServerInfo
+{
+    QString programName;
+    QString protocolVersion;
+    QString device;
+};
+
+struct TciObservedAudio
+{
+    bool sampleTypeSeen = false;
+    bool channelsSeen = false;
+    bool samplesSeen = false;
+    bool sampleRateSeen = false;
+
+    TCIStream::SampleType sampleType = TCIStream::INT16;
+    int channels = 1;
+    int samplesPerFrame = 512;
+    int sampleRate = 48000;
+};
+
+struct TciCapabilities
+{
+    bool readySeen = false;
+    bool startSeen = false;
+    bool receiveOnlySeen = false;
+    bool receiveOnly = false;
+
+    bool txEnableSeen = false;
+    bool txEnabled = false;
+
+    bool txChronoSeen = false;
+
+    TciObservedAudio textAudio;
+    TciObservedAudio rxAudio;
+    TciObservedAudio txChronoAudio;
+};
+
+enum class TciProtocolGeneration
+{
+    LegacyV1,  // protocol version < 1.10
+    V2,        // protocol version >= 1.10 through 2.x
+    Unknown
+};
+
+struct TciTxAudioPolicy
+{
+    enum class Timing
+    {
+        ClientPaced,
+        ChronoDriven
+    };
+
+    enum class SampleCountMeaning
+    {
+        FramesPerChannel,
+        TotalSampleValues,
+        Unknown
+    };
+
+    Timing timing = Timing::ClientPaced;
+    int sampleRate = 48000;
+    int channels = 1;
+    TCIStream::SampleType sampleType = TCIStream::INT16;
+    int samplesPerFrame = 512;
+
+    SampleCountMeaning sampleCountMeaning =
+        SampleCountMeaning::FramesPerChannel;
+};
+
+Q_DECLARE_METATYPE(TciTxAudioPolicy)
+
+class TciProtocolHandler
+{
+public:
+    virtual ~TciProtocolHandler() = default;
+
+    virtual TciProtocolGeneration generation() const = 0;
+
+    virtual void handleTextCommand(QString const &name,
+                                   QStringList const &args,
+                                   TciServerInfo &serverInfo,
+                                   TciCapabilities &capabilities) = 0;
+
+    virtual void handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                                   TciCapabilities &capabilities) = 0;
+
+    virtual TciTxAudioPolicy deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                                 TciCapabilities const &capabilities) const = 0;
+};
+
+class TciProtocolLegacyV1Handler final : public TciProtocolHandler
+{
+public:
+    TciProtocolGeneration generation() const override
+    {
+        return TciProtocolGeneration::LegacyV1;
+    }
+
+    void handleTextCommand(QString const &name,
+                           QStringList const &args,
+                           TciServerInfo &serverInfo,
+                           TciCapabilities &capabilities) override;
+
+    void handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                           TciCapabilities &capabilities) override;
+
+    TciTxAudioPolicy deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                         TciCapabilities const &capabilities) const override;
+};
+
+class TciProtocolV2Handler final : public TciProtocolHandler
+{
+public:
+    TciProtocolGeneration generation() const override
+    {
+        return TciProtocolGeneration::V2;
+    }
+
+    void handleTextCommand(QString const &name,
+                           QStringList const &args,
+                           TciServerInfo &serverInfo,
+                           TciCapabilities &capabilities) override;
+
+    void handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                           TciCapabilities &capabilities) override;
+
+    TciTxAudioPolicy deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                         TciCapabilities const &capabilities) const override;
+};
+
+class TciProtocolUnknownHandler final : public TciProtocolHandler
+{
+public:
+    TciProtocolGeneration generation() const override
+    {
+        return TciProtocolGeneration::Unknown;
+    }
+
+    void handleTextCommand(QString const &name,
+                           QStringList const &args,
+                           TciServerInfo &serverInfo,
+                           TciCapabilities &capabilities) override;
+
+    void handleBinaryFrame(TCIStream::StreamFrame const &frame,
+                           TciCapabilities &capabilities) override;
+
+    TciTxAudioPolicy deriveTxAudioPolicy(TciServerInfo const &serverInfo,
+                                         TciCapabilities const &capabilities) const override;
+};
+
+QString tciSampleTypeName(quint32 sampleType);
+QString tciStreamTypeName(quint32 streamType);
+QString tciGenerationName(TciProtocolGeneration generation);
+QString tciTxTimingName(TciTxAudioPolicy::Timing timing);
+QString tciSampleCountMeaningName(TciTxAudioPolicy::SampleCountMeaning meaning);

--- a/JS8_Transceiver/TCITransceiver.cpp
+++ b/JS8_Transceiver/TCITransceiver.cpp
@@ -1,0 +1,612 @@
+/**
+ * @file TCITransceiver.cpp
+ * @brief TCI transceiver implementation
+ *
+ * This class adapts JS8Call's Transceiver/PollingTransceiver interface to the
+ * TCIClient WebSocket CAT client.
+ */
+
+#include "TCITransceiver.h"
+
+#include "JS8_Network/TCIClient.h"
+
+#include <QEventLoop>
+#include <QtGlobal>
+#include <QLoggingCategory>
+#include <QThread>
+#include <QTimer>
+
+#include "moc_TCITransceiver.cpp"
+
+Q_DECLARE_LOGGING_CATEGORY(tcitransceiver_js8)
+
+QString const TCITransceiver::transceiver_name_{"TCI"};
+
+TCITransceiver::TCITransceiver(TransceiverFactory::ParameterPack const &params,
+                               TCISession *session,
+                               QObject *parent)
+    : PollingTransceiver{params.poll_interval, parent},
+      m_session{session}
+{
+    m_url = QUrl(params.network_port);
+
+    if (!m_url.isValid() || m_url.scheme().isEmpty()) {
+        m_url = QUrl(QStringLiteral("ws://%1").arg(params.network_port));
+    }
+
+    qWarning() << "TCITransceiver ctor entry"
+              << "this=" << this
+              << "session=" << m_session;
+
+    if (!m_session) {
+        throw error{tr("TCI session is not available.")};
+    }
+
+    m_client = m_session->client();
+
+    qWarning() << "TCITransceiver ctor client"
+               << "this=" << this
+               << "session=" << m_session
+               << "client=" << m_client;
+
+    if (!m_client) {
+        throw error{tr("TCI client is not available.")};
+    }
+
+    connect(m_client, &TCIClient::frequencyChanged,
+            this, &TCITransceiver::handle_frequency_changed);
+
+    connect(m_client, &TCIClient::txFrequencyChanged,
+        this, &TCITransceiver::handle_tx_frequency_changed);
+
+    connect(m_client, &TCIClient::splitChanged,
+            this, &TCITransceiver::handle_split_changed);
+
+    connect(m_client, &TCIClient::modeChanged,
+            this, &TCITransceiver::handle_mode_changed);
+
+    connect(m_client, &TCIClient::pttChanged,
+            this, &TCITransceiver::handle_ptt_changed);
+
+    connect(m_client, &TCIClient::rxAudioFrame,
+        this, &TCITransceiver::handle_rx_audio_frame);
+
+    connect(m_client, &TCIClient::ready,
+        this, &TCITransceiver::handle_ready,
+        Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::disconnected,
+            this, &TCITransceiver::handle_disconnected,
+            Qt::QueuedConnection);
+
+    connect(m_client, &TCIClient::error,
+            this, &TCITransceiver::handle_error,
+            Qt::QueuedConnection);
+}
+
+QUrl TCITransceiver::make_url(TransceiverFactory::ParameterPack const &params) const
+{
+    QString endpoint = params.network_port.trimmed();
+
+    if (endpoint.isEmpty()) {
+        endpoint = QStringLiteral("127.0.0.1:40001");
+    }
+
+    if (endpoint.startsWith(QStringLiteral("ws://"), Qt::CaseInsensitive) ||
+        endpoint.startsWith(QStringLiteral("wss://"), Qt::CaseInsensitive)) {
+        return QUrl{endpoint};
+    }
+
+    // Accept either "host:port" or just "host".
+    QString host = endpoint;
+    quint16 port = 40001;
+
+    const int colon = endpoint.lastIndexOf(':');
+
+    if (colon > 0 && colon < endpoint.size() - 1) {
+        bool ok = false;
+        const auto parsed = endpoint.mid(colon + 1).toUShort(&ok);
+
+        if (ok && parsed > 0) {
+            host = endpoint.left(colon);
+            port = parsed;
+        }
+    }
+
+    return QUrl{QStringLiteral("ws://%1:%2").arg(host).arg(port)};
+}
+
+int TCITransceiver::do_start()
+{
+    TRACE_CAT("TCITransceiver", "opening" << m_url);
+
+    if (!m_session) {
+        throw error{tr("TCI session is not available.")};
+    }
+
+    if (!m_client) {
+        m_client = m_session->client();
+    }
+
+    if (!m_client) {
+        throw error{tr("TCI client is not available.")};
+    }
+
+    ready_ = false;
+    started_ = false;
+    stopping_ = false;
+    should_reconnect_ = true;
+    reconnect_attempt_ = 0;
+
+    create_reconnect_timer();
+    cancel_reconnect();
+
+    QEventLoop wait_loop;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+
+    auto ready_connection =
+        connect(m_client, &TCIClient::ready,
+                &wait_loop, &QEventLoop::quit,
+                Qt::QueuedConnection);
+
+    auto error_connection =
+        connect(m_client, &TCIClient::error,
+                &wait_loop, &QEventLoop::quit,
+                Qt::QueuedConnection);
+
+    auto timeout_connection =
+        connect(&timeout, &QTimer::timeout,
+                &wait_loop, &QEventLoop::quit);
+
+    m_session->connectToServer(m_url);
+    m_client->emitReadyIfReady();
+
+    timeout.start(5000);
+    wait_loop.exec();
+
+    disconnect(ready_connection);
+    disconnect(error_connection);
+    disconnect(timeout_connection);
+
+    if (!ready_ && m_client->isReady()) {
+        ready_ = true;
+    }
+
+    if (!ready_) {
+        throw error{
+            tr("TCI connection failed or timed out: %1")
+                .arg(m_url.toString())
+        };
+    }
+
+    started_ = true;
+
+    m_client->queryFrequency();
+    m_client->queryTxFrequency();
+    m_client->querySplit();
+    m_client->queryMode();
+    m_client->queryPtt();
+
+    m_client->configureAudio(48000, 1, 512);
+    m_client->startRxAudio();
+
+    rx_audio_frames_ = 0;
+    rx_audio_bytes_ = 0;
+    rx_audio_sample_rate_ = 0;
+
+    poll();
+
+    TRACE_CAT("TCITransceiver", "started" << state());
+
+    return 0;
+}
+
+void TCITransceiver::do_stop()
+{
+    TRACE_CAT("TCITransceiver", "stopping" << state());
+
+    stopping_ = true;
+    should_reconnect_ = false;
+    cancel_reconnect();
+
+    if (m_client && m_client->isConnected()) {
+        // Defensive cleanup only. TCITransceiver does not own m_client.
+        m_client->stopRxAudio();
+        m_client->setPtt(false);
+    }
+
+    started_ = false;
+    ready_ = false;
+}
+
+void TCITransceiver::do_frequency(Frequency f, MODE m, bool no_ignore)
+{
+    Q_UNUSED(no_ignore);
+
+    TRACE_CAT("TCITransceiver", "set frequency" << f << "mode" << m);
+
+    if (!m_client || !m_client->isConnected())
+        return;
+
+    m_client->setFrequency(static_cast<qint64>(f));
+    update_rx_frequency(f);
+
+    if (UNK != m) {
+        m_client->setMode(map_mode(m));
+        update_mode(m);
+    }
+}
+
+void TCITransceiver::do_tx_frequency(Frequency tx, MODE mode, bool no_ignore)
+{
+    Q_UNUSED(no_ignore);
+
+    TRACE_CAT("TCITransceiver", "set TX frequency" << tx << "mode" << mode);
+
+    if (!m_client || !m_client->isConnected())
+        return;
+
+    if (tx) {
+        m_client->setTxFrequency(static_cast<qint64>(tx));
+
+        if (UNK != mode) {
+            m_client->setMode(map_mode(mode));
+            update_mode(mode);
+        }
+
+        m_client->setSplit(true);
+
+        update_other_frequency(tx);
+        update_split(true);
+    } else {
+        m_client->setSplit(false);
+
+        update_other_frequency(0);
+        update_split(false);
+    }
+}
+
+void TCITransceiver::do_mode(MODE mode)
+{
+    TRACE_CAT("TCITransceiver", "set mode" << mode);
+
+    if (!m_client || !m_client->isConnected())
+        return;
+
+    m_client->setMode(map_mode(mode));
+    update_mode(mode);
+}
+
+void TCITransceiver::do_ptt(bool on)
+{
+    TRACE_CAT("TCITransceiver", "set PTT" << on);
+
+    if (!m_client || !m_client->isConnected())
+        return;
+
+    m_client->setPtt(on);
+
+    // Optimistically update local state. The TCI server should also echo or
+    // broadcast trx state; if transmit is denied by tci-bridge, the subsequent
+    // trx:false update will correct us.
+    update_PTT(on);
+}
+
+void TCITransceiver::poll()
+{
+    if (!m_client || !m_client->isConnected())
+        return;
+
+    TRACE_CAT_POLL("TCITransceiver", "poll");
+
+    m_client->queryFrequency();
+    m_client->queryTxFrequency();
+    m_client->queryMode();
+    m_client->querySplit();
+    m_client->queryPtt();
+}
+
+void TCITransceiver::handle_ready()
+{
+    TRACE_CAT("TCITransceiver", "ready");
+
+    cancel_reconnect();
+    reconnect_attempt_ = 0;
+
+    ready_ = true;
+    started_ = true;
+
+    m_client->queryFrequency();
+    m_client->queryTxFrequency();
+    m_client->queryMode();
+    m_client->querySplit();
+    m_client->queryPtt();
+
+    poll();
+}
+
+void TCITransceiver::handle_frequency_changed(qint64 hz)
+{
+    TRACE_CAT_POLL("TCITransceiver", "frequency changed" << hz);
+
+    if (hz <= 0)
+        return;
+
+    applying_remote_state_ = true;
+    update_rx_frequency(static_cast<Frequency>(hz));
+    applying_remote_state_ = false;
+}
+
+void TCITransceiver::handle_tx_frequency_changed(qint64 hz)
+{
+    TRACE_CAT_POLL("TCITransceiver", "TX frequency changed" << hz);
+
+    if (hz <= 0)
+        return;
+
+    applying_remote_state_ = true;
+    update_other_frequency(static_cast<Frequency>(hz));
+    applying_remote_state_ = false;
+}
+
+void TCITransceiver::handle_split_changed(bool enabled)
+{
+    TRACE_CAT_POLL("TCITransceiver", "split changed" << enabled);
+
+    applying_remote_state_ = true;
+    update_split(enabled);
+    applying_remote_state_ = false;
+}
+
+void TCITransceiver::handle_mode_changed(QString mode)
+{
+    TRACE_CAT_POLL("TCITransceiver", "mode changed" << mode);
+
+    const MODE mapped = map_mode(mode);
+
+    if (UNK == mapped)
+        return;
+
+    applying_remote_state_ = true;
+    update_mode(mapped);
+    applying_remote_state_ = false;
+}
+
+void TCITransceiver::handle_ptt_changed(bool on)
+{
+    TRACE_CAT_POLL("TCITransceiver", "PTT changed" << on);
+
+    applying_remote_state_ = true;
+    update_PTT(on);
+    applying_remote_state_ = false;
+}
+
+void TCITransceiver::handle_rx_audio_frame(QByteArray pcm, int sampleRate)
+{
+    rx_audio_frames_++;
+    rx_audio_bytes_ += pcm.size();
+    rx_audio_sample_rate_ = sampleRate;
+
+    if (!(rx_audio_frames_ % 50)) {
+        TRACE_CAT_POLL("TCITransceiver",
+                       "RX audio frames =" << rx_audio_frames_
+                                           << "bytes =" << rx_audio_bytes_
+                                           << "last frame =" << pcm.size()
+                                           << "sample rate =" << sampleRate);
+    }
+
+    // Phase 1: diagnostic only.
+    // Next step: feed pcm into JS8Call's existing decoder/audio-input path.
+}
+
+void TCITransceiver::schedule_reconnect()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                schedule_reconnect();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    create_reconnect_timer();
+
+    if (!reconnect_timer_)
+        return;
+
+    if (reconnect_timer_->isActive())
+        return;
+
+    if (!should_reconnect_ || stopping_)
+        return;
+
+    ++reconnect_attempt_;
+
+    int const delay_ms = qMin(10000, 500 * reconnect_attempt_);
+
+    TRACE_CAT("TCITransceiver",
+              "scheduling reconnect in"
+                  << delay_ms
+                  << "ms attempt"
+                  << reconnect_attempt_
+                  << "timerThread" << reconnect_timer_->thread()
+                  << "ownerThread" << thread()
+                  << "currentThread" << QThread::currentThread());
+
+    reconnect_timer_->start(delay_ms);
+}
+
+void TCITransceiver::create_reconnect_timer()
+{
+    if (reconnect_timer_)
+        return;
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                create_reconnect_timer();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    reconnect_timer_ = new QTimer(this);
+    reconnect_timer_->setSingleShot(true);
+
+    TRACE_CAT("TCITransceiver",
+              "created reconnect timer"
+                  << reconnect_timer_
+                  << "timerThread" << reconnect_timer_->thread()
+                  << "ownerThread" << thread()
+                  << "currentThread" << QThread::currentThread());
+
+    connect(reconnect_timer_, &QTimer::timeout,
+        this,
+        [this]() {
+            if (!should_reconnect_ || stopping_)
+                return;
+
+            TRACE_CAT("TCITransceiver",
+                      "attempting reconnect"
+                          << reconnect_attempt_
+                          << m_url
+                          << "thread" << QThread::currentThread()
+                          << "objectThread" << thread());
+
+            if (m_session)
+                m_session->connectToServer(m_url);
+        });
+}
+
+void TCITransceiver::cancel_reconnect()
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                cancel_reconnect();
+            },
+            Qt::QueuedConnection);
+        return;
+    }
+
+    if (reconnect_timer_ && reconnect_timer_->isActive())
+        reconnect_timer_->stop();
+}
+
+void TCITransceiver::handle_disconnected()
+{
+    TRACE_CAT("TCITransceiver",
+              "disconnected"
+                  << "stopping" << stopping_
+                  << "shouldReconnect" << should_reconnect_);
+
+    ready_ = false;
+    started_ = false;
+
+    if (stopping_ || !should_reconnect_)
+        return;
+
+    schedule_reconnect();
+}
+
+void TCITransceiver::handle_error(QString message)
+{
+    TRACE_CAT("TCITransceiver", "error" << message);
+
+    if (stopping_ || !should_reconnect_)
+        return;
+
+    ready_ = false;
+    started_ = false;
+
+    schedule_reconnect();
+}
+
+Transceiver::MODE TCITransceiver::map_mode(QString const &mode) const
+{
+    const QString m = mode.trimmed().toUpper();
+
+    if (m == "AM")
+        return AM;
+
+    if (m == "CW")
+        return CW;
+
+    if (m == "CWR" || m == "CW_R")
+        return CW_R;
+
+    if (m == "USB")
+        return USB;
+
+    if (m == "LSB")
+        return LSB;
+
+    if (m == "RTTY" || m == "FSK")
+        return FSK;
+
+    if (m == "RTTYR" || m == "FSK_R")
+        return FSK_R;
+
+    if (m == "DIGL" || m == "DIG_L" || m == "PKTLSB")
+        return DIG_L;
+
+    if (m == "DIGU" || m == "DIG_U" || m == "PKTUSB")
+        return DIG_U;
+
+    if (m == "FM")
+        return FM;
+
+    if (m == "DIGFM" || m == "DIG_FM" || m == "PKTFM")
+        return DIG_FM;
+
+    return UNK;
+}
+
+QString TCITransceiver::map_mode(Transceiver::MODE mode) const
+{
+    switch (mode) {
+    case AM:
+        return QStringLiteral("am");
+
+    case CW:
+        return QStringLiteral("cw");
+
+    case CW_R:
+        return QStringLiteral("cwr");
+
+    case USB:
+        return QStringLiteral("usb");
+
+    case LSB:
+        return QStringLiteral("lsb");
+
+    case FSK:
+        return QStringLiteral("rtty");
+
+    case FSK_R:
+        return QStringLiteral("rttyr");
+
+    case DIG_L:
+        return QStringLiteral("digl");
+
+    case DIG_U:
+        return QStringLiteral("digu");
+
+    case FM:
+        return QStringLiteral("fm");
+
+    case DIG_FM:
+        return QStringLiteral("digfm");
+
+    case UNK:
+    default:
+        return QStringLiteral("usb");
+    }
+}
+
+Q_LOGGING_CATEGORY(tcitransceiver_js8, "tcitransceiver.js8", QtWarningMsg)

--- a/JS8_Transceiver/TCITransceiver.h
+++ b/JS8_Transceiver/TCITransceiver.h
@@ -1,0 +1,79 @@
+#ifndef TCI_TRANSCEIVER_HPP_
+#define TCI_TRANSCEIVER_HPP_
+
+#include "JS8_Network/TCISession.h"
+
+#include "PollingTransceiver.h"
+#include "TransceiverFactory.h"
+
+#include <QScopedPointer>
+#include <QString>
+#include <QTimer>
+#include <QUrl>
+
+class TCIClient;
+class TCISession;
+
+
+class TCITransceiver final : public PollingTransceiver {
+  Q_OBJECT
+
+public:
+  static QString const transceiver_name_;
+
+  // Reuse ParameterPack for now so the factory/settings path can be wired
+  // similarly to network-style CAT backends.
+  explicit TCITransceiver(TransceiverFactory::ParameterPack const &,
+                          TCISession *session,
+                          QObject *parent = nullptr);
+
+private:
+  int do_start() override;
+  void do_stop() override;
+
+  void do_frequency(Frequency, MODE, bool no_ignore) override;
+  void do_tx_frequency(Frequency, MODE, bool no_ignore) override;
+  void do_mode(MODE) override;
+  void do_ptt(bool) override;
+
+  void poll() override;
+
+  QUrl make_url(TransceiverFactory::ParameterPack const &) const;
+
+  Transceiver::MODE map_mode(QString const &) const;
+  QString map_mode(Transceiver::MODE) const;
+
+  void handle_ready();
+  void handle_frequency_changed(qint64);
+  void handle_tx_frequency_changed(qint64);
+  void handle_split_changed(bool);
+  void handle_mode_changed(QString);
+  void handle_ptt_changed(bool);
+  void handle_rx_audio_frame(QByteArray, int sampleRate);
+  void handle_disconnected();
+  void handle_error(QString);
+
+private:
+  void create_reconnect_timer();
+  void schedule_reconnect();
+  void cancel_reconnect();
+
+  TCISession *m_session = nullptr;
+  TCIClient *m_client = nullptr;
+  QUrl m_url;
+
+  bool started_ = false;
+  bool ready_ = false;
+  bool applying_remote_state_ = false;
+
+  qint64 rx_audio_frames_ = 0;
+  qint64 rx_audio_bytes_ = 0;
+  int rx_audio_sample_rate_ = 0;
+
+  QTimer *reconnect_timer_ = nullptr;
+  bool should_reconnect_ = false;
+  bool stopping_ = false;
+  int reconnect_attempt_ = 0;
+};
+
+#endif

--- a/JS8_Transceiver/TransceiverFactory.cpp
+++ b/JS8_Transceiver/TransceiverFactory.cpp
@@ -8,6 +8,7 @@
 #include "EmulateSplitTransceiver.h"
 #include "HRDTransceiver.h"
 #include "HamlibTransceiver.h"
+#include "TCITransceiver.h"
 
 #include <QMetaType>
 
@@ -25,14 +26,27 @@ enum // supported non-hamlib radio interfaces
     NonHamlibBaseId = 9899,
     CommanderId,
     HRDId,
+    TCIId,
 };
 }
 
-TransceiverFactory::TransceiverFactory() {
+TransceiverFactory::TransceiverFactory(TCISession *tci_session)
+    : tci_session_{tci_session}
+{
     HamlibTransceiver::register_transceivers(&transceivers_);
     DXLabSuiteCommanderTransceiver::register_transceivers(&transceivers_,
                                                           CommanderId);
     HRDTransceiver::register_transceivers(&transceivers_, HRDId);
+
+    transceivers_[TCITransceiver::transceiver_name_] =
+        Capabilities{
+            TCIId,                 // model_number
+            Capabilities::network, //port_type
+            true,                  // has_CAT_PTT
+            false,                 // has_CAT_PTT_mic_data
+            false,                 // has_CAT_indirect_serial_PTT
+            false                  // asynchronous (PollingTransceiver for now)
+        };
 }
 
 TransceiverFactory::~TransceiverFactory() {
@@ -67,9 +81,20 @@ bool TransceiverFactory::has_asynchronous_CAT(QString const &name) const {
     return supported_transceivers()[name].asynchronous_;
 }
 
+void TransceiverFactory::set_tci_session(TCISession *session)
+{
+    tci_session_ = session;
+}
+
 std::unique_ptr<Transceiver>
 TransceiverFactory::create(ParameterPack const &params,
                            QThread *target_thread) {
+    qWarning() << "TransceiverFactory TCI create"
+           << "factory=" << this
+           << "tci_session=" << tci_session_
+           << "target_thread=" << target_thread
+           << "network_port=" << params.network_port;
+
     std::unique_ptr<Transceiver> result;
     switch (supported_transceivers()[params.rig_name].model_number_) {
     case CommanderId: {
@@ -112,6 +137,19 @@ TransceiverFactory::create(ParameterPack const &params,
             std::move(basic_transceiver), params.network_port,
             PTT_method_CAT == params.ptt_type, params.audio_source,
             params.poll_interval});
+        if (target_thread) {
+            result->moveToThread(target_thread);
+        }
+    } break;
+
+    case TCIId: {
+        if (!tci_session_) {
+            throw error{
+                tr("TCI session is not available. TCI cannot be tested from this context.")
+            };
+        }
+
+        result.reset(new TCITransceiver{params, tci_session_});
         if (target_thread) {
             result->moveToThread(target_thread);
         }

--- a/JS8_Transceiver/TransceiverFactory.h
+++ b/JS8_Transceiver/TransceiverFactory.h
@@ -2,6 +2,7 @@
 #define TRANSCEIVER_FACTORY_HPP__
 
 #include "JS8_Main/qt_helpers.h"
+#include "JS8_Network/TCISession.h"
 #include "Transceiver.h"
 
 #include <QMap>
@@ -79,7 +80,7 @@ class TransceiverFactory : public QObject {
     enum SplitMode { split_mode_none, split_mode_rig, split_mode_emulate };
     Q_ENUM(SplitMode)
 
-    TransceiverFactory();
+    explicit TransceiverFactory(TCISession *tci_session = nullptr);
     ~TransceiverFactory();
 
     static char const
@@ -89,6 +90,8 @@ class TransceiverFactory : public QObject {
     // fetch all supported rigs as a list of name and model id
     //
     Transceivers const &supported_transceivers() const;
+
+    void set_tci_session(TCISession *session);
 
     // supported model queries
     Capabilities::PortType
@@ -149,8 +152,19 @@ class TransceiverFactory : public QObject {
     std::unique_ptr<Transceiver> create(ParameterPack const &,
                                         QThread *target_thread = nullptr);
 
+  protected:
+    //
+    // Error exception which is thrown to signal unexpected errors.
+    //
+    struct error : public std::runtime_error {
+        explicit error(char const *const msg) : std::runtime_error(msg) {}
+        explicit error(QString const &msg)
+            : std::runtime_error(msg.toStdString()) {}
+    };
+
   private:
     Transceivers transceivers_;
+    TCISession *tci_session_ = nullptr;
 };
 
 inline bool operator!=(TransceiverFactory::ParameterPack const &lhs,

--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -203,6 +203,8 @@
 
 #include "moc_Configuration.cpp"
 
+#include <hamlib/rig.h>
+
 namespace {
 const QRegularExpression message_alphabet{"[^\\x00-\\x1F]*"};
 
@@ -460,6 +462,7 @@ class Configuration::impl final : public QDialog {
                (rig_params_.split_mode != TransceiverFactory::split_mode_none);
     }
     void set_cached_mode();
+
     bool open_rig(bool force = false);
     // bool set_mode ();
     void close_rig();
@@ -802,15 +805,51 @@ void Configuration::select_tab(int index) {
 }
 int Configuration::exec() { return m_->exec(); }
 bool Configuration::is_active() const { return m_->isVisible(); }
+bool Configuration::is_tci_rig_selected() const
+{
+    /*
+     * Literal is ugly here, but do we want to include TCITransceiver
+     * just so we can
+     * return rig_name() == TCITransceiver::transceiver_name_;
+     */
+    return rig_name() == QStringLiteral("TCI");
+}
+QUrl Configuration::tci_url() const
+{
+    QString endpoint = m_->rig_params_.network_port.trimmed();
 
-QAudioDevice const &Configuration::audio_input_device() const {
-    return m_->audio_input_device_;
+    if (endpoint.isEmpty())
+        endpoint = QStringLiteral("127.0.0.1:40001");
+
+    if (endpoint.startsWith(QStringLiteral("ws://"), Qt::CaseInsensitive) ||
+        endpoint.startsWith(QStringLiteral("wss://"), Qt::CaseInsensitive)) {
+        return QUrl(endpoint);
+        }
+
+    return QUrl(QStringLiteral("ws://%1").arg(endpoint));
+}
+void Configuration::set_tci_session(TCISession *session)
+{
+    m_->transceiver_factory_.set_tci_session(session);
+}
+AudioInputDevice Configuration::audio_input_device() const
+{
+    if (is_tci_rig_selected()) {
+        return AudioInputDevice::tci(tci_url());
+    }
+
+    return AudioInputDevice::system(m_->audio_input_device_);
 }
 AudioDevice::Channel Configuration::audio_input_channel() const {
     return m_->audio_input_channel_;
 }
-QAudioDevice const &Configuration::audio_output_device() const {
-    return m_->audio_output_device_;
+AudioOutputDevice Configuration::audio_output_device() const
+{
+    if (is_tci_rig_selected()) {
+        return AudioOutputDevice::tci(tci_url());
+    }
+
+    return AudioOutputDevice::system(m_->audio_output_device_);
 }
 AudioDevice::Channel Configuration::audio_output_channel() const {
     return m_->audio_output_channel_;

--- a/JS8_UI/Configuration.h
+++ b/JS8_UI/Configuration.h
@@ -2,6 +2,8 @@
 #define CONFIGURATION_HPP_
 
 #include "JS8_Audio/AudioDevice.h"
+#include "JS8_Audio/AudioInputDevice.h"
+#include "JS8_Audio/AudioOutputDevice.h"
 #include "JS8_Include/pimpl_h.h"
 #include "JS8_Main/IARURegions.h"
 #include "JS8_Main/Radio.h"
@@ -25,6 +27,7 @@ class FrequencyList_v3;
 class StationList;
 class QStringListModel;
 class QHostAddress;
+class TCISession;
 
 //
 // Class Configuration
@@ -80,9 +83,9 @@ class Configuration final : public QObject {
     QDir temp_dir() const;
     QDir writeable_data_dir() const;
 
-    QAudioDevice const &audio_input_device() const;
+    AudioInputDevice audio_input_device() const;
     AudioDevice::Channel audio_input_channel() const;
-    QAudioDevice const &audio_output_device() const;
+    AudioOutputDevice audio_output_device() const;
     AudioDevice::Channel audio_output_channel() const;
     QAudioDevice const &notification_audio_output_device() const;
 
@@ -162,6 +165,8 @@ class Configuration final : public QObject {
     int watchdog() const;
     bool TX_messages() const;
     bool split_mode() const;
+    bool is_tci_rig_selected() const;
+    QUrl tci_url() const;
     QString opCall() const;
     QString ptt_command() const;
     QString aprs_server_name() const;
@@ -297,6 +302,8 @@ class Configuration final : public QObject {
 
     // check if a real rig is configured
     bool is_dummy_rig() const;
+
+    void set_tci_session(TCISession *session);
 
     // Frequency resolution of the rig
     //

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -7,6 +7,7 @@
 
 #include "mainwindow.h"
 
+#include "JS8_Audio/TCIAudioOutput.h"
 #include "moc_mainwindow.cpp"
 
 // TODO: Move to member:
@@ -2815,8 +2816,13 @@ void UI_Constructor::startTx() {
 void UI_Constructor::transmit() {
     if (m_modulator->isIdle()) {
         qDebug(mainwindow_js8) << "Asking the modulator to emit audio.";
-        Q_EMIT sendMessage(freq() + m_XIT, m_nSubMode, m_TxDelay, m_soundOutput,
-                           m_config.audio_output_channel());
+
+        AudioOutputStream *stream = m_audioOutput;
+        AudioDevice::Channel channel = m_config.audio_output_channel();
+
+        Q_EMIT sendMessage(freq() + m_XIT, m_nSubMode, m_TxDelay, stream,
+                           channel);
+
         ui->signal_meter_widget->setValue(0, 0);
     } else {
         qDebug(mainwindow_js8) << "Not asking the modulator to emit audio as "

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -3,9 +3,12 @@
 #define MAINWINDOW_H
 
 #include "JS8_Audio/AudioDevice.h"
+#include "JS8_Audio/AudioInputDevice.h"
+#include "JS8_Audio/AudioInputManager.h"
+#include "JS8_Audio/AudioOutputDevice.h"
+#include "JS8_Audio/AudioOutputManager.h"
 #include "JS8_Audio/NotificationAudio.h"
 #include "JS8_Audio/SoundInput.h"
-#include "JS8_Audio/SoundOutput.h"
 #include "JS8_Include/EventFilter.h"
 #include "JS8_Include/commons.h"
 #include "JS8_Include/qpriorityqueue.h"
@@ -45,6 +48,7 @@
 #include "JS8_Network/NetworkAccessManager.h"
 #include "JS8_Network/PSKReporter.h"
 #include "JS8_Network/SpotClient.h"
+#include "JS8_Network/TCISession.h"
 #include "JS8_Network/TCPClient.h"
 #include "JS8_Transceiver/Transceiver.h"
 #include "JS8_Transceiver/TransceiverFactory.h"
@@ -52,8 +56,8 @@
 #include "JS8_UDP/WSJTXMessageMapper.h"
 #include "JS8_UI/About.h"
 #include "JS8_UI/Configuration.h"
-#include "JS8_UI/WideGraph.h"
 #include "JS8_UI/MessagePanel.h"
+#include "JS8_UI/WideGraph.h"
 #include "LogQSO.h"
 #include "MessageReplyDialog.h"
 #include "styles.h"
@@ -173,7 +177,6 @@ class Transceiver;
 class MessageClient;
 class QTime;
 class HelpTextWindow;
-class SoundOutput;
 class Modulator;
 class SoundInput;
 class Detector;
@@ -511,12 +514,13 @@ class UI_Constructor : public QMainWindow {
     Q_SIGNAL void playNotification(const QString &name);
     Q_SIGNAL void initializeNotificationAudioOutputStream(const QAudioDevice &,
                                                           unsigned) const;
-    Q_SIGNAL void initializeAudioOutputStream(QAudioDevice, unsigned channels,
-                                              unsigned msBuffered) const;
+    Q_SIGNAL void initializeAudioOutputStream(AudioOutputDevice const &,
+                                          unsigned channels,
+                                          unsigned msBuffered) const;
     Q_SIGNAL void stopAudioOutputStream() const;
-    Q_SIGNAL void startAudioInputStream(QAudioDevice const &,
-                                        int framesPerBuffer, AudioDevice *sink,
-                                        AudioDevice::Channel) const;
+    Q_SIGNAL void startAudioInputStream(AudioInputDevice const &, int framesPerBuffer,
+                                       AudioDevice *sink,
+                                       AudioDevice::Channel channel) const;
     Q_SIGNAL void suspendAudioInputStream() const;
     Q_SIGNAL void resumeAudioInputStream() const;
     Q_SIGNAL void startDetector(AudioDevice::Channel) const;
@@ -526,8 +530,9 @@ class UI_Constructor : public QMainWindow {
     Q_SIGNAL void transmitFrequency(double) const;
     Q_SIGNAL void endTransmitMessage(bool quick = false) const;
     Q_SIGNAL void tune(bool = true) const;
-    Q_SIGNAL void sendMessage(double frequency, int submode, double txDelay,
-                              SoundOutput *, AudioDevice::Channel) const;
+    Q_SIGNAL void sendMessage(double audioFrequency, int submode, double txDelay,
+                 AudioOutputStream *stream,
+                 AudioDevice::Channel channel);
     Q_SIGNAL void outAttenuationChanged(qreal) const;
     Q_SIGNAL void toggleShorthand() const;
     Q_SIGNAL void submodeChanged(Varicode::SubmodeType) const;
@@ -595,9 +600,9 @@ class UI_Constructor : public QMainWindow {
 
     Detector *m_detector;
     unsigned m_FFTSize;
-    SoundInput *m_soundInput;
+    AudioInputManager *m_audioInput;
     Modulator *m_modulator;
-    SoundOutput *m_soundOutput;
+    AudioOutputManager *m_audioOutput;
     NotificationAudio *m_notification;
 
     // Configuration might one day offer to send a txDelayChanged signal.
@@ -981,6 +986,7 @@ class UI_Constructor : public QMainWindow {
     PSKReporter *m_pskReporter;
     SpotClient *m_spotClient;
     APRSISClient *m_aprsClient;
+    TCISession *m_tciSession = nullptr;
     AprsInboundRelay *m_aprsInboundRelay;
     QVariantHash m_pwrBandTxMemory; // Remembers power level by band
     QVariantHash


### PR DESCRIPTION
Addresses issue #294
Add TCI integration using new transceiver and audio devices Add TCI rig type
Refactored audio I/O to support different audio backend types

I do not have a TCI-capable radio, so in order to implement these changes, I built a simple software bridge that uses rigctld and QT audio to provide a TCI interface for pretty much any radio you can connect to your computer. You can use this to test the changes if you also do not have a TCI-enabled radio like Hermes, SunSDR, etc.

https://github.com/rruchte/tci-bridge

While the bridge works well, we really need this PR to be thoroughly tested by someone with access to one of these radios before merging. I've tagged this WIP assuming that there may be some adjustment required based on that real-world testing.