### PR TITLE
Switch to Clang 17 compiler for Windows workflow builds

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,46 +1,28 @@
-permissions:
-  contents: read
-  attestations: write
-  id-token: write
-  
 name: CI Build for MacOS 26 Arm64 (M1 and higher)
-run-name: ${{ (github.event.inputs.environment) || (github.event.pull_request.title) || 'CI' }} Build for MacOS M1
+run-name: ${{ github.event.pull_request.title || github.ref_name }} CI Build for MacOS M1
 
-on: 
-  workflow_dispatch: 
+on:
+  push:
   pull_request:
-  workflow_call:
-    inputs:
-      build-type:
-        description: 'Build type (Debug/Release)'
-        required: false
-        type: string
-        default: 'Release'
-      release-ver:
-        description: 'Release Version (v3.0.0)'
-        required: false
-        type: string      
-        default: 'v3.0.0'
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
-  build_macos-latest:
-    runs-on: macOS-26
-    permissions: write-all
+  build_macos-26:
+    runs-on: macos-26
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v6
+    - name: Configure Git line endings
+      run: git config --global core.autocrlf input
 
-    - name: Create our own var with the ImageOS value for cache use
-      id: which-os
-      run: |
-        export ImageOS=$(sw_vers -productVersion)
-        echo "thisos=$ImageOS" >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v4
 
-    - name: Grab build dependeneces
+    - name: Grab build dependencies
       run: |
         curl --location --output /tmp/js8lib3.0-MacOS_AppleSilicon_Qt.tar.gz https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/js8lib3.0-MacOS_AppleSilicon_Qt.tar.gz
         cd /tmp
@@ -50,32 +32,39 @@ jobs:
         curl --location --output /tmp/ffmpeg_MacOS_arm64.tar.gz https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/ffmpeg_MacOS_arm64.tar.gz
         tar zxf /tmp/ffmpeg_MacOS_arm64.tar.gz
         sudo mv /tmp/ffmpeg /usr/local/ffmpeg
-      
-    - name: Build JS8Call
+
+    - name: Configure JS8Call
       run: |
         mkdir -p ./build && cd ./build
-        cmake -DCMAKE_PREFIX_PATH="/usr/local/js8lib" ..
-        make
+        cmake -G Xcode -DCMAKE_PREFIX_PATH="/usr/local/js8lib" ..
+
+    - name: Extract version
+      run: |
+        ver=$(grep "CMAKE_PROJECT_VERSION:STATIC=" build/CMakeCache.txt | cut -d'=' -f2 | tr -d '[:space:]')
+        gitHash=$(git rev-parse --short HEAD)
+
+        if [ "$ver" = "0.0.0" ]; then
+          safeVer=$gitHash
+        else
+          safeVer=$ver
+        fi
+
+        echo "JS8_SAFE_VER=$safeVer" >> $GITHUB_ENV
+        echo "SAFE_VER=$safeVer"
+
+    - name: Build JS8Call
+      run: |
+        cd ./build
+        xcodebuild -scheme JS8Call -configuration Release
 
     - name: Create DMG
-      run: hdiutil create -volname "JS8Call-improved.dmg" -srcfolder "build/JS8Call.app" -format UDZO "JS8Call-improved.dmg"
-      
-    - name: Attestation (Release Only)
-      if: ${{ inputs.release-ver }}
-      uses: actions/attest-build-provenance@v4
-      with:
-        subject-path: '${{ github.workspace }}/JS8Call-improved.dmg'
-        
-    - name: Upload Artifact (Release build)
-      if: ${{ inputs.release-ver }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: "JS8call-improved_${{ inputs.release-ver }}_${{ runner.arch }}_macos26.dmg"
-        path: /Users/runner/work/JS8Call-improved/JS8Call-improved/JS8Call-improved.dmg
+      run: |
+        echo "DMG version: ${{ env.JS8_SAFE_VER }}"
+        hdiutil create -volname "JS8Call" -srcfolder "build/Release/JS8Call.app" -format UDZO "JS8Call_${{ env.JS8_SAFE_VER }}.dmg"
 
-    - name: Upload Artifact (CI build)
-      if: ${{ !inputs.release-ver }}
+    - name: Upload Artifact
       uses: actions/upload-artifact@v7
       with:
-        name: "JS8call-improved_devel_${{ runner.arch }}_macos26.dmg"
-        path: /Users/runner/work/JS8Call-improved/JS8Call-improved/JS8Call-improved.dmg
+        name: "JS8Call_${{ env.JS8_SAFE_VER }}"
+        path: '${{ github.workspace }}/JS8Call_${{ env.JS8_SAFE_VER }}.dmg'
+        archive: false

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -101,8 +101,9 @@ jobs:
         & 'C:/Program Files (x86)/Inno Setup 6/ISCC.exe' $issArg "/FJS8Call-$safeVer-installer" ../.github/workflows/scripts/ci-windows-installer.iss
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: "JS8Call-${{ env.JS8_SAFE_VER }}-installer"
         path: ./build/JS8Call/JS8Call-*-installer.exe
+        archive: false
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,9 +1,8 @@
-name: CI Build for Windows 10+ x64
-run-name: ${{ github.event.pull_request.title || github.ref_name }} CI Build for Windows 10+ x64
+name: Release Build for Windows 10+ x64
+run-name: ${{ github.ref_name }} Release Build for Windows 10+ x64
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release
@@ -12,6 +11,7 @@ jobs:
   build_windows-2025:
     runs-on: windows-2025
     permissions: write-all
+    environment: Release
 
     steps:
     - name: Configure Git line endings
@@ -90,6 +90,23 @@ jobs:
         cp $env:GITHUB_WORKSPACE\js8lib\dll\*.dll JS8Call\
         cp $env:GITHUB_WORKSPACE\LICENSE JS8Call\
 
+    - name: Get signing certificate
+      shell: pwsh
+      run: |
+        echo "${{ secrets.RELEASE_CODE_SIGNING_PFX_BASE64 }}" > 'D:/a/JS8Call-improved/cert.base64'
+        certutil -decode 'D:/a/JS8Call-improved/cert.base64' 'D:/a/JS8Call-improved/certificate.pfx'
+
+    - name: Sign binaries
+      shell: pwsh
+      env:
+        PFX_CERTIFICATE_PASSWORD: ${{ secrets.RELEASE_PFX_CERTIFICATE_PASSWORD }}
+      run: |
+        $signtool = 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/signtool.exe'
+        $cert     = 'D:/a/JS8Call-improved/certificate.pfx'
+        cd ./build/JS8Call/
+        & $signtool sign /fd SHA256 /v /f $cert /p "$env:PFX_CERTIFICATE_PASSWORD" *.exe
+        & $signtool sign /fd SHA256 /v /f $cert /p "$env:PFX_CERTIFICATE_PASSWORD" *.dll
+
     - name: INNO Setup
       shell: pwsh
       run: |
@@ -100,9 +117,23 @@ jobs:
         cd ./build/
         & 'C:/Program Files (x86)/Inno Setup 6/ISCC.exe' $issArg "/FJS8Call-$safeVer-installer" ../.github/workflows/scripts/ci-windows-installer.iss
 
+    - name: Sign installer
+      shell: pwsh
+      env:
+        PFX_CERTIFICATE_PASSWORD: ${{ secrets.RELEASE_PFX_CERTIFICATE_PASSWORD }}
+      run: |
+        $signtool = 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/signtool.exe'
+        $cert     = 'D:/a/JS8Call-improved/certificate.pfx'
+        cd ./build/JS8Call/
+        & $signtool sign /fd SHA256 /v /f $cert /p "$env:PFX_CERTIFICATE_PASSWORD" JS8Call-*-installer.exe
+
+    - name: Attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: '${{ github.workspace }}/build/JS8Call/*'
+
     - name: Upload Artifact
       uses: actions/upload-artifact@v6
       with:
         name: "JS8Call-${{ env.JS8_SAFE_VER }}-installer"
         path: ./build/JS8Call/JS8Call-*-installer.exe
-

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -133,7 +133,8 @@ jobs:
         subject-path: '${{ github.workspace }}/build/JS8Call/*'
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: "JS8Call-${{ env.JS8_SAFE_VER }}-installer"
         path: ./build/JS8Call/JS8Call-*-installer.exe
+        archive: false

--- a/.github/workflows/scripts/ci-windows-installer.iss
+++ b/.github/workflows/scripts/ci-windows-installer.iss
@@ -1,15 +1,17 @@
 #define MyAppName "JS8Call"
-#define MyAppVersion "3.0.0"
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0"
+#endif
+#pragma message "AppVersion is: " + MyAppVersion
 #define MyAppPublisher "JS8Call-improved"
 #define MyAppURL "https://www.js8call-improved.com/"
 #define MyAppExeName "JS8Call.exe"
 
 [Setup]
-; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 AppId={{B5281957-28FD-4BAE-8D06-FC59898D850E}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
-;AppVerName={#MyAppName} {#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -60,10 +62,10 @@ Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\avformat-61.dll"; 
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\avutil-59.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\D3Dcompiler_47.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libfftw3f-3.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libgcc_s_seh-1.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libhamlib-4.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libstdc++-6.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libc++.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libusb-1.0.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libunwind.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\libwinpthread-1.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\opengl32sw.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\a\JS8Call-improved\JS8Call-improved\build\JS8Call\Qt6Core.dll"; DestDir: "{app}"; Flags: ignoreversion
@@ -84,3 +86,4 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilen
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+


### PR DESCRIPTION
Add Vulkan headers on the runner for Windows build
add CMake versioning to Windows workflow
update Windows workflow path for new optimized library package
update Windows workflow with separate CI and Release scripts

@wmiler, since you are very busy and it would be nice to have the Windows workflow working I thought I could help out with this. I got rid of all the complex CI/Release logic and broke it down into two scripts. The CI one runs as before and does not mess with code signing. It is only for PR's and push actions to make sure the code builds.

The Release one is run manually when we want to create a Release build, otherwise it has no trigger.

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/297