### PR TITLE
Remove obsolete Qt version checks

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Fetch js8lib
       shell: pwsh
       run: |
-        curl -L -o js8lib.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/js8lib3.0.1_Win64.zip"
+        curl -L -o js8lib.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F3.0/js8lib3.0_Win64.zip"
         Expand-Archive js8lib.zip -DestinationPath .
 
     - name: Setup build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ cmake_dependent_option(
 find_package(Boost 1.77 REQUIRED)
 find_package(FFTW3      REQUIRED COMPONENTS single threads)
 find_package(Hamlib     REQUIRED)
-find_package(Qt6    6.5 REQUIRED COMPONENTS Multimedia Network SerialPort Widgets)
+find_package(Qt6  6.9.3 REQUIRED COMPONENTS Multimedia Network SerialPort Widgets)
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${FFTW3_INCLUDE_DIRS})

--- a/JS8_Main/IARURegions.h
+++ b/JS8_Main/IARURegions.h
@@ -65,11 +65,6 @@ class IARURegions final : public QAbstractListModel {
 // Qt boilerplate  to make the IARURegions::region  enumeration a type
 // that can  be streamed and  queued as a  signal argument as  well as
 // showing the human readable string when output to debug streams.
-#if QT_VERSION < 0x050500
-// Qt 5.5 introduces the Q_ENUM macro which automatically registers
-// the meta-type
-Q_DECLARE_METATYPE(IARURegions::Region);
-#endif
 
 #if !defined(QT_NO_DEBUG_STREAM)
 ENUM_QDEBUG_OPS_DECL(IARURegions, Region);

--- a/JS8_Main/Modes.h
+++ b/JS8_Main/Modes.h
@@ -64,12 +64,6 @@ class Modes final : public QAbstractListModel {
 // Qt boilerplate to make the Modes::Mode enumeration a type that can
 // be streamed and queued as a signal argument as well as showing the
 // human readable string when output to debug streams.
-#if QT_VERSION < 0x050500
-// Qt 5.5 introduces the Q_ENUM macro which automatically registers
-// the meta-type
-Q_DECLARE_METATYPE(Modes::Mode);
-#endif
-
 #if !defined(QT_NO_DEBUG_STREAM)
 ENUM_QDEBUG_OPS_DECL(Modes, Mode);
 #endif

--- a/JS8_Main/RadioMetaType.cpp
+++ b/JS8_Main/RadioMetaType.cpp
@@ -14,12 +14,5 @@ void register_types() {
     qRegisterMetaType<Radio::Frequency>("Frequency");
     qRegisterMetaType<Radio::FrequencyDelta>("FrequencyDelta");
     qRegisterMetaType<Radio::Frequencies>("Frequencies");
-
-    // This is required to preserve v1.5 "frequencies" setting for
-    // backwards compatibility, without it the setting gets trashed
-    // by later versions.
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    qRegisterMetaTypeStreamOperators<Radio::Frequencies>("Frequencies");
-#endif
 }
 } // namespace Radio

--- a/JS8_Main/Varicode.cpp
+++ b/JS8_Main/Varicode.cpp
@@ -1279,11 +1279,7 @@ bool isValidCompoundCallsign(QStringView callsign) {
     }
 
     if (callsign.length() > 2 && QRegularExpression("[0-9][A-Z]|[A-Z][0-9]")
-#if (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
-                                     .match(callsign)
-#else
                                      .matchView(callsign)
-#endif
                                      .hasMatch()) {
         return true;
     }

--- a/JS8_Main/main.cpp
+++ b/JS8_Main/main.cpp
@@ -37,11 +37,6 @@
 #include <stdexcept>
 #include <string>
 
-#if QT_VERSION >= 0x050200
-#include <QCommandLineOption>
-#include <QCommandLineParser>
-#endif
-
 Q_DECLARE_LOGGING_CATEGORY(main_js8)
 
 namespace {
@@ -94,7 +89,6 @@ int main(int argc, char *argv[]) {
         // Apply platform-specific styles from styles.h
         a.setStyleSheet(buttonStyle());
 
-#if QT_VERSION >= 0x050200
         QCommandLineParser parser;
         parser.setApplicationDescription("\n" PROJECT_SUMMARY_DESCRIPTION);
         auto help_option = parser.addHelpOption();
@@ -203,7 +197,6 @@ int main(int argc, char *argv[]) {
                 throw std::runtime_error{"Failed to access lock file"};
             }
         }
-#endif
 
 #if WSJT_QDEBUG_TO_FILE
         // Open a trace file

--- a/JS8_Main/qt_helpers.h
+++ b/JS8_Main/qt_helpers.h
@@ -46,30 +46,9 @@
             mo.enumerator(mo.indexOfEnumerator(#ENUM)).valueToKey(m)};         \
     }
 
-#if QT_VERSION >= 0x050500
-
-// Qt 5.5 now has Q_ENUM which registers enumns better
+// Q_ENUM registers enums with the meta-object system
 #define ENUM_QDEBUG_OPS_DECL(CLASS, ENUM)
 #define ENUM_QDEBUG_OPS_IMPL(CLASS, ENUM)
-
-#else
-
-#define Q_ENUM(E)
-
-#include <QDebug>
-
-class QVariant;
-
-#define ENUM_QDEBUG_OPS_DECL(CLASS, ENUM)                                      \
-    QDebug operator<<(QDebug, CLASS::ENUM const &);
-
-#define ENUM_QDEBUG_OPS_IMPL(CLASS, ENUM)                                      \
-    QDebug operator<<(QDebug d, CLASS::ENUM const &m) {                        \
-        auto const &mo = CLASS::staticMetaObject;                              \
-        return d << mo.enumerator(mo.indexOfEnumerator(#ENUM)).valueToKey(m);  \
-    }
-
-#endif
 
 inline void throw_qstring(QString const &qs) {
     throw std::runtime_error{qs.toLocal8Bit().constData()};
@@ -97,23 +76,11 @@ template <class T> class VPtr {
 Q_DECLARE_METATYPE(QHostAddress);
 
 inline bool is_broadcast_address(QHostAddress const &host_addr) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     return host_addr.isBroadcast();
-#else
-    bool ok;
-    return host_addr.toIPv4Address(&ok) == 0xffffffffu && ok;
-#endif
 }
 
 inline bool is_multicast_address(QHostAddress const &host_addr) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     return host_addr.isMulticast();
-#else
-    bool ok;
-    return (((host_addr.toIPv4Address(&ok) & 0xf0000000u) == 0xe0000000u) &&
-            ok) ||
-           host_addr.toIPv6Address()[0] == 0xff;
-#endif
 }
 
 #endif

--- a/JS8_Transceiver/HamlibTransceiver.cpp
+++ b/JS8_Transceiver/HamlibTransceiver.cpp
@@ -250,11 +250,7 @@ HamlibTransceiver::HamlibTransceiver(
         // user defined Hamlib settings
         //
         auto settings_file_name = QStandardPaths::locate(
-#if QT_VERSION >= 0x050500
-            QStandardPaths::AppConfigLocation
-#else
-            QStandardPaths::ConfigLocation
-#endif
+                    QStandardPaths::AppConfigLocation
             ,
             "hamlib_settings.json");
         if (!settings_file_name.isEmpty()) {

--- a/JS8_Transceiver/Transceiver.h
+++ b/JS8_Transceiver/Transceiver.h
@@ -158,9 +158,6 @@ class Transceiver : public QObject {
 };
 
 Q_DECLARE_METATYPE(Transceiver::TransceiverState);
-#if QT_VERSION < 0x050500
-Q_DECLARE_METATYPE(Transceiver::MODE);
-#endif
 
 #if !defined(QT_NO_DEBUG_STREAM)
 ENUM_QDEBUG_OPS_DECL(Transceiver, MODE);

--- a/JS8_Transceiver/TransceiverFactory.h
+++ b/JS8_Transceiver/TransceiverFactory.h
@@ -163,15 +163,6 @@ inline bool operator!=(TransceiverFactory::ParameterPack const &lhs,
 // boilerplate routines to make enum types useable and debuggable in
 // Qt
 //
-#if QT_VERSION < 0x050500
-Q_DECLARE_METATYPE(TransceiverFactory::DataBits);
-Q_DECLARE_METATYPE(TransceiverFactory::StopBits);
-Q_DECLARE_METATYPE(TransceiverFactory::Handshake);
-Q_DECLARE_METATYPE(TransceiverFactory::PTTMethod);
-Q_DECLARE_METATYPE(TransceiverFactory::TXAudioSource);
-Q_DECLARE_METATYPE(TransceiverFactory::SplitMode);
-#endif
-
 #if !defined(QT_NO_DEBUG_STREAM)
 ENUM_QDEBUG_OPS_DECL(TransceiverFactory, DataBits);
 ENUM_QDEBUG_OPS_DECL(TransceiverFactory, StopBits);

--- a/JS8_UDP/NetworkMessage.cpp
+++ b/JS8_UDP/NetworkMessage.cpp
@@ -31,16 +31,12 @@ void Builder::common_initialization(Type type, QString const &id,
     if (schema <= 1) {
         setVersion(QDataStream::Qt_5_0); // Qt schema version
     }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
     else if (schema <= 2) {
         setVersion(QDataStream::Qt_5_2); // Qt schema version
     }
-#endif
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
     else if (schema <= 3) {
         setVersion(QDataStream::Qt_5_4); // Qt schema version
     }
-#endif
     else {
         throw std::runtime_error{"Unrecognized message schema"};
     }
@@ -68,16 +64,12 @@ class Reader::impl {
         if (schema_ <= 1) {
             parent->setVersion(QDataStream::Qt_5_0);
         }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
         else if (schema_ <= 2) {
             parent->setVersion(QDataStream::Qt_5_2);
         }
-#endif
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
         else if (schema_ <= 3) {
             parent->setVersion(QDataStream::Qt_5_4);
         }
-#endif
         quint32 type;
         *parent >> type >> id_;
         if (type >= maximum_message_type_) {

--- a/JS8_UDP/NetworkMessage.h
+++ b/JS8_UDP/NetworkMessage.h
@@ -571,16 +571,9 @@ class Builder : public QDataStream {
   public:
     static quint32 constexpr magic{0xadbccbda}; // never change this
 
-    // increment this if a newer Qt schema is required and add decode
-    // logic to the Builder and Reader class implementations
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    // increment this when the log schema changes; add decode logic to
+    // Builder and Reader class implementations
     static quint32 constexpr schema_number{3};
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
-    static quint32 constexpr schema_number{2};
-#else
-    // Schema 1 (Qt_5_0) is broken
-#error "Qt version 5.2 or greater required"
-#endif
 
     explicit Builder(QIODevice *, Type, QString const &id, quint32 schema);
     explicit Builder(QByteArray *, Type, QString const &id, quint32 schema);

--- a/JS8_UDP/WSJTXMessageClient.cpp
+++ b/JS8_UDP/WSJTXMessageClient.cpp
@@ -162,13 +162,8 @@ void WSJTXMessageClient::impl::set_server(
     if (server_.isNull() && server_name.size()) // DNS lookup required
     {
         // queue a host address lookup
-#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
-        dns_lookup_id_ = QHostInfo::lookupHost(
-            server_name, this, &WSJTXMessageClient::impl::host_info_results);
-#else
-        dns_lookup_id_ = QHostInfo::lookupHost(
-            server_name, this, SLOT(host_info_results(QHostInfo)));
-#endif
+        dns_lookup_id_ = QHostInfo::lookupHost(server_name, this, &WSJTXMessageClient::impl::host_info_results);
+
     } else {
         start();
     }
@@ -455,13 +450,7 @@ WSJTXMessageClient::WSJTXMessageClient(
     QStringList const &network_interface_names, int TTL, QObject *self)
     : QObject{self}, m_{id, version, revision, server_port, TTL, this} {
     connect(&*m_
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-            ,
-            static_cast<void (impl::*)(impl::SocketError)>(&impl::error),
-            [this](impl::SocketError e)
-#else
-           , &impl::errorOccurred, [this] (impl::SocketError e)
-#endif
+        , &impl::errorOccurred, [this] (impl::SocketError e)
             {
 #if defined(Q_OS_WIN)
                 if (e != impl::NetworkError &&

--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -3554,12 +3554,8 @@ void Configuration::impl::on_notifications_check_box_toggled(bool checked) {
 }
 
 void Configuration::impl::on_font_push_button_clicked() {
-    next_font_ = QFontDialog::getFont(0, next_font_, this, tr("Font Chooser")
-#if QT_VERSION >= 0x050201
-                                                               ,
-                                      QFontDialog::DontUseNativeDialog
-#endif
-    );
+    next_font_ = QFontDialog::getFont(0, next_font_, this, tr("Font Chooser"),
+                                      QFontDialog::DontUseNativeDialog);
     ui_->font_push_button->setText(QString("Application Font (%1 %2)")
                                        .arg(next_font_.family())
                                        .arg(next_font_.pointSize()));
@@ -3585,12 +3581,8 @@ void Configuration::impl::on_style_push_button_clicked() {
 
 void Configuration::impl::on_tableFontButton_clicked() {
     next_table_font_ =
-        QFontDialog::getFont(0, next_table_font_, this, tr("Font Chooser")
-#if QT_VERSION >= 0x050201
-                                                            ,
-                             QFontDialog::DontUseNativeDialog
-#endif
-        );
+        QFontDialog::getFont(0, next_table_font_, this, tr("Font Chooser"),
+                             QFontDialog::DontUseNativeDialog);
 
     ui_->tableFontButton->setText(QString("Font (%1 %2)")
                                       .arg(next_table_font_.family())
@@ -3783,12 +3775,8 @@ void Configuration::impl::on_rxForegroundButton_clicked() {
 
 void Configuration::impl::on_rxFontButton_clicked() {
     next_rx_text_font_ =
-        QFontDialog::getFont(0, next_rx_text_font_, this, tr("Font Chooser")
-#if QT_VERSION >= 0x050201
-                                                              ,
-                             QFontDialog::DontUseNativeDialog
-#endif
-        );
+        QFontDialog::getFont(0, next_rx_text_font_, this, tr("Font Chooser"),
+                             QFontDialog::DontUseNativeDialog);
     ui_->rxFontButton->setText(QString("Font (%1 %2)")
                                    .arg(next_rx_text_font_.family())
                                    .arg(next_rx_text_font_.pointSize()));
@@ -3835,13 +3823,9 @@ void Configuration::impl::on_txForegroundButton_clicked() {
 }
 
 void Configuration::impl::on_txFontButton_clicked() {
-    next_tx_text_font_ =
-        QFontDialog::getFont(0, next_tx_text_font_, this, tr("Font Chooser")
-#if QT_VERSION >= 0x050201
-                                                              ,
-                             QFontDialog::DontUseNativeDialog
-#endif
-        );
+    next_tx_text_font_ = QFontDialog::getFont(
+        0, next_tx_text_font_, this, tr("Font Chooser"),
+        QFontDialog::DontUseNativeDialog);
 
     ui_->txFontButton->setText(QString("Font (%1 %2)")
                                    .arg(next_tx_text_font_.family())
@@ -3850,12 +3834,8 @@ void Configuration::impl::on_txFontButton_clicked() {
 
 void Configuration::impl::on_composeFontButton_clicked() {
     next_compose_text_font_ = QFontDialog::getFont(
-        0, next_compose_text_font_, this, tr("Font Chooser")
-#if QT_VERSION >= 0x050201
-                                              ,
-        QFontDialog::DontUseNativeDialog
-#endif
-    );
+        0, next_compose_text_font_, this, tr("Font Chooser"),
+        QFontDialog::DontUseNativeDialog);
     ui_->composeFontButton->setText(
         QString("Font (%1 %2)")
             .arg(next_compose_text_font_.family())

--- a/JS8_UI/Configuration.h
+++ b/JS8_UI/Configuration.h
@@ -431,10 +431,6 @@ class Configuration final : public QObject {
     pimpl<impl> m_;
 };
 
-#if QT_VERSION < 0x050500
-Q_DECLARE_METATYPE(Configuration::DataMode);
-#endif
-
 #if !defined(QT_NO_DEBUG_STREAM)
 ENUM_QDEBUG_OPS_DECL(Configuration, DataMode);
 #endif

--- a/JS8_UI/LogQSO.cpp
+++ b/JS8_UI/LogQSO.cpp
@@ -133,18 +133,9 @@ void LogQSO::resetAdditionalFields() {
     if (!m_additionalFieldsControls.isEmpty()) {
         auto layout =
             static_cast<QFormLayout *>(ui->additionalFields->layout());
-
-#if QT_VERSION >= 0x050800
         for (int i = 0, count = layout->rowCount(); i < count; i++) {
             layout->removeRow(0);
         }
-#else
-        QLayoutItem *child;
-        while ((child = layout->takeAt(0)) != 0) {
-            delete child;
-        }
-#endif
-
         m_additionalFieldsControls.clear();
     }
 

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -101,6 +101,7 @@
 #include <QStandardPaths>
 #include <QStringBuilder>
 #include <QStyleFactory>
+#include <QtCore/QtGlobal>
 #include <QTableWidget>
 #include <QTextEdit>
 #include <QThread>
@@ -130,6 +131,10 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 3)
+#error "Qt >= 6.9.3 is required to build JS8Call. Please upgrade your Qt toolchain."
+#endif
 
 Q_DECLARE_LOGGING_CATEGORY(mainwindow_js8)
 

--- a/JS8_Widgets/LazyFillComboBox.h
+++ b/JS8_Widgets/LazyFillComboBox.h
@@ -19,7 +19,6 @@ class LazyFillComboBox : public QComboBox {
 
     explicit LazyFillComboBox(QWidget *parent = nullptr) : QComboBox{parent} {}
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     void showPopup() override {
         Q_EMIT about_to_show_popup();
         QComboBox::showPopup();
@@ -29,17 +28,6 @@ class LazyFillComboBox : public QComboBox {
         QComboBox::hidePopup();
         Q_EMIT popup_hidden();
     }
-#else
-    void mousePressEvent(QMouseEvent *e) override {
-        Q_EMIT about_to_show_popup();
-        QComboBox::mousePressEvent(e);
-    }
-
-    void mouseReleaseEvent(QMouseEvent *e) override {
-        QComboBox::mouseReleaseEvent(e);
-        Q_EMIT popup_hidden();
-    }
-#endif
 };
 
 #endif


### PR DESCRIPTION
This is a general code cleanup that removes all obsolete Qt version checks. And wires in two sources of truth for Qt version; configure time and compile time in the event somebody tries to override the configure time setting.

We are NOT supporting distro-packaged JS8Call builds where maintainers are building JS8Call against Qt6.8.1 because that's what's packaged in Debian trixie, and modifying code to get it to work. They are inventing their own support issues with that one, especially after an email exchange I had with Christoph Berg, head of the Debian Hamradio Maintainer's. When we move to Qt 6.11 to take advantage of the new callback-based audio API in QtMultimedia, bypassing the need for a QIODevice, they are going to find out why we code for and require a specific version of Qt for our builds.

This was a literal mess, most of which I suspect came from WSJT-x. I was surprised to see it in the (relatively) new WSJTXMessageClient.cpp, which was obviously copied from WSJT-x code.