### PR TITLE
BUG FIX: processCommandActivity.cpp

### DIFF
--- a/JS8_Mainwindow/processBufferedActivity.cpp
+++ b/JS8_Mainwindow/processBufferedActivity.cpp
@@ -25,17 +25,18 @@ void UI_Constructor::processBufferedActivity() {
         if (!buffer.msgs.isEmpty()) {
             dt = qMax(dt, buffer.msgs.last().utcTimestamp);
         }
+        
+        int ageSecs = dt.secsTo(DriftingDateTime::currentDateTimeUtc());
 
         // if the buffer has messages older than 1 minute, and we still haven't
         // closed it, let's mark it as the last frame
-        if (dt.secsTo(DriftingDateTime::currentDateTimeUtc()) > 60 &&
-            !buffer.msgs.isEmpty()) {
+        if (ageSecs > 60 && !buffer.msgs.isEmpty()) {
             buffer.msgs.last().bits |= Varicode::JS8CallLast;
         }
 
         // but, if the buffer is older than 1.5 minutes, and we still haven't
         // closed it, just remove it and skip
-        if (dt.secsTo(DriftingDateTime::currentDateTimeUtc()) > 90) {
+        if (ageSecs > 90) {
             m_messageBuffer.remove(freq);
             continue;
         }

--- a/JS8_Mainwindow/processCommandActivity.cpp
+++ b/JS8_Mainwindow/processCommandActivity.cpp
@@ -216,29 +216,25 @@ void UI_Constructor::processCommandActivity() {
             // ACKs and SNRs are the most likely source of items to be
             // overwritten (multiple responses at once)... so don't overwrite
             // those (i.e., print each on a new line)
-            bool shouldOverwrite =
-                (!d.cmd.contains(" ACK") &&
-                 !d.cmd.contains(" SNR")); /* && isRecentOffset(d.freq);*/
+            bool shouldOverwrite = (!d.cmd.contains(" ACK") && !d.cmd.contains(" SNR"));
 
             if (shouldOverwrite &&
-                ui->textEditRX->find(d.utcTimestamp.time().toString(),
-                                     QTextDocument::FindBackward)) {
-                // ... maybe we could delete the last line that had this message
-                // on this frequency...
-                c = ui->textEditRX->textCursor();
-                c.movePosition(QTextCursor::StartOfBlock);
-                c.movePosition(QTextCursor::EndOfBlock,
-                               QTextCursor::KeepAnchor);
-                qCDebug(mainwindow_js8) << "should display directed message, "
-                                           "erasing last rx activity line..."
-                                        << c.selectedText().toUpper();
-                c.removeSelectedText();
-                c.deletePreviousChar();
-                c.deletePreviousChar();
-                /*
-                c.deleteChar();
-                c.deleteChar();
-                */
+                ui->textEditRX->find(d.utcTimestamp.time().toString(), QTextDocument::FindBackward)) {
+                auto candidate = ui->textEditRX->textCursor();
+                candidate.select(QTextCursor::BlockUnderCursor);
+                QString selectedText = candidate.selectedText();
+
+                // Only treat this as "the same message being redrawn" if it's
+                // actually from the same sender - otherwise it's a distinct
+                // reply that happens to share a rendered timestamp.
+                if (selectedText.contains(QString("%1:").arg(d.from))) {
+                    c = ui->textEditRX->textCursor();
+                    c.movePosition(QTextCursor::StartOfBlock);
+                    c.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+                    c.removeSelectedText();
+                    c.deletePreviousChar();
+                    c.deletePreviousChar();
+                }
             }
 
             // log it to the display!


### PR DESCRIPTION
Directed replies to group queries can overwrite each other in RX pane (textEditRX)

Context:
When multiple stations reply to a group-addressed query (i.e. "@GROUP QUERY MSGS") within the same second, their replies share an identical rendered timestamp string. The avoid duplicate line logic in processCommandActivity() searched backward for that timestamp string alone and erased whatever block it found, with no check that the found block actually belonged to the same sender. With enough replies landing in one processing tick, each new reply erased the previous different station's line, leaving only the last reply visible in textEditRX (the incoming MSG pane)

Thanks to John W2KI for reporting this bug and testing the fix.

Note: extensive diagnostic logging was added to diagnose this issue. After reviewing the final fix and there was over 70 lines of logging code added to several files, I cleaned that up and left only the final fix in the code. 