### PR TITLE
displayCallActivity.cpp: fix horizontal text alignment

### DIFF
--- a/JS8_Mainwindow/displayCallActivity.cpp
+++ b/JS8_Mainwindow/displayCallActivity.cpp
@@ -377,12 +377,12 @@ void UI_Constructor::displayCallActivity() {
                 }
 
                 auto logNameItem = new QTableWidgetItem(logDetailName);
-                logNameItem->setTextAlignment(Qt::AlignCenter);
+                logNameItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
                 logNameItem->setToolTip(logDetailName);
                 ui->tableWidgetCalls->setItem(row, col++, logNameItem);
 
                 auto logCommentItem = new QTableWidgetItem(logDetailComment);
-                logCommentItem->setTextAlignment(Qt::AlignCenter);
+                logCommentItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
                 logCommentItem->setToolTip(logDetailComment);
                 ui->tableWidgetCalls->setItem(row, col++, logCommentItem);
 


### PR DESCRIPTION
for "Name" and "Comment" columns in call activity table.

Before:
<img width="743" height="377" alt="Screenshot 2026-07-11 at 13 48 16" src="https://github.com/user-attachments/assets/360fcbfb-7154-4631-b9c7-60c2d22bb8cf" />

After:
<img width="746" height="388" alt="Screenshot 2026-07-11 at 13 59 15" src="https://github.com/user-attachments/assets/ca17a701-68fb-4cb4-b863-f347387579d4" />
