### PR TITLE
Add QtWebSockets as required Qt component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ cmake_dependent_option(
 find_package(Boost 1.77 REQUIRED)
 find_package(FFTW3      REQUIRED COMPONENTS single threads)
 find_package(Hamlib     REQUIRED)
-find_package(Qt6  6.11  REQUIRED COMPONENTS Multimedia Network SerialPort Widgets)
+find_package(Qt6   6.11 REQUIRED COMPONENTS Multimedia Network SerialPort Widgets WebSockets)
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${FFTW3_INCLUDE_DIRS})
@@ -362,6 +362,7 @@ target_link_libraries(
   Qt::Network
   Qt::SerialPort
   Qt::Widgets
+  Qt::WebSockets
 )
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
This is a non-breaking change that adds QtWebSockets as a required Qt component for the WIP TCI audio backend. Our Qt6.11.1 packages are built with this module. But I believe this was an oversight on my part, failing to require it for the build configuration and failing to tell the linker to link it with the binary as shown below. Including it in the Qt package will get your project to build, but it likely won't work unless it's properly linked.

It would be recommended for anybody who has tested the WIP TCI project to rebase that PR on master, let the workflows build new binaries and test it again to see if it works now.

> ###### Checking bundle linking and library versions ######
> ============================================================================================
> JS8Call.app/Contents/MacOS/JS8Call:
> 	@rpath/libhamlib.4.dylib (compatibility version 5.0.0, current version 5.7.0)
> 	@rpath/QtMultimedia.framework/Versions/A/QtMultimedia (compatibility version 6.0.0, current version 6.11.1)
> 	@rpath/QtSerialPort.framework/Versions/A/QtSerialPort (compatibility version 6.0.0, current version 6.11.1)
> 	@rpath/QtWidgets.framework/Versions/A/QtWidgets (compatibility version 6.0.0, current version 6.11.1)
> 	**@rpath/QtWebSockets.framework/Versions/A/QtWebSockets (compatibility version 6.0.0, current version 6.11.1)**
> 	@rpath/libusb-1.0.0.dylib (compatibility version 6.0.0, current version 6.0.0)
> 	@rpath/QtGui.framework/Versions/A/QtGui (compatibility version 6.0.0, current version 6.11.1)