### PR TITLE
UI_Constructor.cpp: add lambda's and guards on audio startup

### DIFF
--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -217,7 +217,12 @@ UI_Constructor::UI_Constructor(QString const &program_info,
     connect(this, &UI_Constructor::initializeAudioOutputStream, m_soundOutput,
             &SoundOutput::setFormat);
     connect(m_soundOutput, &SoundOutput::error, this,
-            &UI_Constructor::showSoundOutError);
+            [this](QString const &errorMsg) {
+                if (m_config.audio_output_device().isNull() || m_config.is_active()) {
+                    return; // nothing configured yet, or user is fixing it in Settings
+                }
+                showSoundOutError(errorMsg);
+            });
     connect(m_soundOutput, &SoundOutput::error, &m_config,
             &Configuration::invalidate_audio_output_device);
     connect(this, &UI_Constructor::outAttenuationChanged, m_soundOutput,
@@ -253,7 +258,12 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             &SoundInput::resume);
     connect(this, &UI_Constructor::finished, m_soundInput, &SoundInput::stop);
     connect(m_soundInput, &SoundInput::error, this,
-            &UI_Constructor::showSoundInError);
+        [this](QString const &errorMsg) {
+            if (m_config.audio_input_device().isNull() || m_config.is_active()) {
+                return;
+            }
+            showSoundInError(errorMsg);
+        });
     connect(m_soundInput, &SoundInput::error, &m_config,
             &Configuration::invalidate_audio_input_device);
     // connect(m_soundInput, &SoundInput::status, this,
@@ -643,15 +653,21 @@ UI_Constructor::UI_Constructor(QString const &program_info,
     m_notificationAudioThread.start(m_notificationAudioThreadPriority);
     m_decoder.start(m_decoderThreadPriority);
 
-    Q_EMIT startAudioInputStream(m_config.audio_input_device(),
-                                 m_framesAudioInputBuffered, m_detector,
-                                 m_config.audio_input_channel());
-    Q_EMIT initializeAudioOutputStream(
-        m_config.audio_output_device(),
-        AudioDevice::Mono == m_config.audio_output_channel() ? 1 : 2,
-        m_msAudioOutputBuffered);
-    Q_EMIT initializeNotificationAudioOutputStream(
-        m_config.notification_audio_output_device(), m_msAudioOutputBuffered);
+    if (!m_config.audio_input_device().isNull()) {
+        Q_EMIT startAudioInputStream(m_config.audio_input_device(),
+            m_framesAudioInputBuffered, m_detector,
+            m_config.audio_input_channel());
+    }
+    if (!m_config.audio_output_device().isNull()) {
+        Q_EMIT initializeAudioOutputStream(
+            m_config.audio_output_device(),
+            AudioDevice::Mono == m_config.audio_output_channel() ? 1 : 2,
+            m_msAudioOutputBuffered);
+    }
+    if (!m_config.notification_audio_output_device().isNull()) {
+        Q_EMIT initializeNotificationAudioOutputStream(
+            m_config.notification_audio_output_device(), m_msAudioOutputBuffered);
+    }
     Q_EMIT transmitFrequency(freq() + m_XIT);
 
     enable_DXCC_entity(


### PR DESCRIPTION
This prevents firing the invalid audio notifications on a fresh non-configured install before the user even has a chance to set them. This does not address everything in the issue I posted, but it addresses the most critical bug.

**Context of why this is needed:**
I found that when I did a fresh install of JS8Call on Ubuntu 26, that the invalid audio interface notifications fired immediately on program startup. I could not close them to even get the configuration dialog to work because the first notification that fired was under the second one. And the second one (that's on top) will not respond until the first one is closed. Nor did the linux UI allow me to move them out of the way. The program was totally locked up, could not quit it from the dock icon, nothing responded in the JS8Call user interface. I ended up killing JS8Call at the command line, configured the Ubuntu user interface to allow tiling open applications, and on subsequent restart used the tiling feature of the UI to get the audio notifications out of the way so it could be actually configured.

This is very bad UI design and not a very good introduction to JS8Call for a new user who has never run the program before. So I fixed it. The other issues noted in my posted issue are still on my radar, however.

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/338