### PR TITLE
Update to Qt 6.12.0

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -56,9 +56,9 @@ jobs:
     - name: Fetch Qt
       shell: pwsh
       run: |
-        curl -L -o qt611.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/qt-6.11.1-windows-x64.zip"
-        Expand-Archive qt611.zip -DestinationPath qt611
-        echo "$env:GITHUB_WORKSPACE\qt611\bin" >> $env:GITHUB_PATH
+        curl -L -o qt612.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/qt-6.12.0-windows-x64.zip"
+        Expand-Archive qt612.zip -DestinationPath qt612
+        echo "$env:GITHUB_WORKSPACE\qt612\bin" >> $env:GITHUB_PATH
 
     - name: Fetch js8lib
       shell: pwsh
@@ -81,8 +81,8 @@ jobs:
           -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang `
           -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ `
           -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres `
-          -DQt6_DIR="$workspace/qt611/lib/cmake/Qt6" `
-          -DCMAKE_PREFIX_PATH="$workspace/qt611;$workspace/js8lib/boost-1.88;$workspace/js8lib/hamlib-4.7.2;$workspace/js8lib/fftw3;$workspace/js8lib/libusb-1.0.29" ..
+          -DQt6_DIR="$workspace/qt612/lib/cmake/Qt6" `
+          -DCMAKE_PREFIX_PATH="$workspace/qt612;$workspace/js8lib/boost-1.88;$workspace/js8lib/hamlib-4.7.2;$workspace/js8lib/fftw3;$workspace/js8lib/libusb-1.0.29" ..
 
     - name: Extract version
       shell: pwsh

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -49,9 +49,9 @@ jobs:
     - name: Fetch Qt
       shell: pwsh
       run: |
-        curl -L -o qt611.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/qt-6.11.1-windows-x64.zip"
-        Expand-Archive qt611.zip -DestinationPath qt611
-        echo "$env:GITHUB_WORKSPACE\qt611\bin" >> $env:GITHUB_PATH
+        curl -L -o qt612.zip "https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/qt-6.12.0-windows-x64.zip"
+        Expand-Archive qt612.zip -DestinationPath qt612
+        echo "$env:GITHUB_WORKSPACE\qt612\bin" >> $env:GITHUB_PATH
 
     - name: Fetch js8lib
       shell: pwsh
@@ -74,8 +74,8 @@ jobs:
           -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang `
           -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ `
           -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres `
-          -DQt6_DIR="$workspace/qt611/lib/cmake/Qt6" `
-          -DCMAKE_PREFIX_PATH="$workspace/qt611;$workspace/js8lib/boost-1.88;$workspace/js8lib/hamlib-4.7.2;$workspace/js8lib/fftw3;$workspace/js8lib/libusb-1.0.29" ..
+          -DQt6_DIR="$workspace/qt612/lib/cmake/Qt6" `
+          -DCMAKE_PREFIX_PATH="$workspace/qt612;$workspace/js8lib/boost-1.88;$workspace/js8lib/hamlib-4.7.2;$workspace/js8lib/fftw3;$workspace/js8lib/libusb-1.0.29" ..
 
     - name: Extract version
       shell: pwsh

--- a/.github/workflows/scripts/JS8Call-Build-AppImage.sh
+++ b/.github/workflows/scripts/JS8Call-Build-AppImage.sh
@@ -28,7 +28,7 @@ fi
 
 # --- Tarball URLs ---
 JS8LIB_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/js8lib4.0-Linux_${JS8_ARCH}_pkg.tar.gz"
-QT_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.11.1_Linux_${JS8_ARCH}_pkg.tar.gz"
+QT_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.12.0_Linux_${JS8_ARCH}_pkg.tar.gz"
 
 # --- Directories ---
 BUILD_DIR="$HOME/js8call-appimage-build"
@@ -53,6 +53,7 @@ sudo apt-get install -y \
     zlib1g-dev libbrotli-dev libdbus-1-dev libglib2.0-dev \
     libatspi2.0-dev libgl-dev libegl-dev libgbm-dev \
     libdrm-dev libinput-dev libvulkan-dev \
+    libopengl-dev \
     libxkbcommon-dev libxkbcommon-x11-dev \
     libxcb-util-dev libxcb-image0-dev libxcb-keysyms1-dev \
     libxcb-render-util0-dev libxcb-icccm4-dev libxcb-cursor-dev \
@@ -235,7 +236,7 @@ cp "$BUILD_DIR/JS8Call-improved/.github/workflows/misc/JS8Call.appdata.xml" \
 #   - --output appimage calls appimagetool internally to produce the
 #     final compressed self-executing .AppImage file
 #
-# QMAKE points it at our private Qt 6.11.1, not the system Qt,
+# QMAKE points it at our private Qt 6.12.0, not the system Qt,
 # so it bundles the right version
 cd "$BUILD_DIR"
 export EXTRA_PLATFORM_PLUGINS="libqwayland.so;libqoffscreen.so;libqeglfs.so;libqlinuxfb.so;libqminimalegl.so;libqminimal.so"

--- a/docs/build_for_MacOS.md
+++ b/docs/build_for_MacOS.md
@@ -21,7 +21,7 @@ Below are the required libraries and tested versions for a JS8Call-improved buil
 
 * boost_1_88_0
 
-* Qt 6.11.1 - this one is non-trivial and is a monster. Failed builds are common and will likely discourage you from trying a JS8Call build. Recommendations below......
+* Qt 6.12.0 - this one is non-trivial and is a monster. Failed builds are common and will likely discourage you from trying a JS8Call build. Recommendations below......
 
 *   There is two ways to obtain the libraries and frameworks to compile JS8Call; either build them yourself or fetch the pre-built libraries.
 
@@ -52,7 +52,7 @@ If you obtain Qt using the online installer for an Intel build it is recommended
 
 Building Qt6 from source for Apple silicon is non-trivial. Consult the Qt documentation on how to build it with FFmpeg audio support. This will require building and installing FFmpeg first, as per the Qt documentation [here](https://doc.qt.io/archives/qt-6.9/qtmultimedia-building-ffmpeg-macos.html). Once FFmpeg is compiled and installed, you can then clone the Qt repository with a series of commands:
 ```
-mkdir ~/development/Qt6.11.1 && mkdir ~/development/Qt6_build
+mkdir ~/development/Qt6.12.0 && mkdir ~/development/Qt6_build
 ```
 Then fetch Qt 6 with:
 ```
@@ -60,7 +60,7 @@ cd  ~/development/Qt6_build && git clone https://github.com/qt/qt5.git Qt6
 ```
 Now you need to initialize your Qt6 repository:
 ```
-cd ~/development/Qt6_build/Qt6 && git checkout 6.11.1
+cd ~/development/Qt6_build/Qt6 && git checkout 6.12.0
 ```
 ```
 ./init-repository --module-subset=qtbase,qtshadertools,qtmultimedia,qtimageformats,qtwebsockets,qtserialport,qtsvg
@@ -71,19 +71,19 @@ cd .. && mkdir qt6-build && cd qt6-build
 ```
 Configure the build:
 ```
-../Qt6/configure -prefix ~/development/Qt611.1 -ffmpeg-dir /usr/local/ffmpeg -ffmpeg-deploy
+../Qt6/configure -prefix ~/development/Qt6.12.0 -ffmpeg-dir /usr/local/ffmpeg -ffmpeg-deploy
 ```
-Now build it and install it. This will install Qt in ~/development/Qt6.11.1
+Now build it and install it. This will install Qt in ~/development/Qt6.12.0
 ```
 cmake --build . --parallel && cmake --install .
 ```
 
-The Qt6.11.1 library that you just built can be used over and over again to build JS8Call. Since the Qt sources are huge, to conserve disk space you can delete the ~/development/Qt6-build source directory for Qt6.
+The Qt6.12.0 library that you just built can be used over and over again to build JS8Call. Since the Qt sources are huge, to conserve disk space you can delete the ~/development/Qt6-build source directory for Qt6.
 
 Now we can finally proceed with building JS8Call. The following command set will have to be modified depending on if you are doing an Intel build using Qt from the online installer, or are doing an Apple silicon build with Qt built from source code. The command as shown is for the Apple silicon build - note the location of the Qt library and adjust accordingly for an Intel build.
 ```
 cd ~/development/JS8Call/src && mkdir build && cd build \
-&& cmake -DCMAKE_PREFIX_PATH="/usr/local/js8lib;~/development/JS8Call/Qt6.11.1" -DCMAKE_BUILD_TYPE=Release .. \
+&& cmake -DCMAKE_PREFIX_PATH="/usr/local/js8lib;~/development/JS8Call/Qt6.12.0" -DCMAKE_BUILD_TYPE=Release .. \
 && cmake --build .
 ```
 If building using the pre-built library that contains Qt (Apple silicon only), then the command is as follows.

--- a/docs/build_for_Windows.md
+++ b/docs/build_for_Windows.md
@@ -15,7 +15,7 @@ Windows 11
 1) Download and install [CMake 4.1.1](https://www.kitware.com/cmake-4-1-1-available-for-download/) from Kitware.
 2) Download and install [git for Windows](https://git-scm.com/install/windows) from GitHub.
 3) Download and install the [Qt Online Installer](https://doc.qt.io/qt-6/qt-online-installation.html) from qt.io. To do this you must create a free account with Qt and log into your new account and you will be able to download it.
-4) After installation of Qt use the Qt Maintenance Tool to install Qt 6.11.1
+4) After installation of Qt use the Qt Maintenance Tool to install Qt 6.12.0
 
 ### Notes On Installation of Qt6
 
@@ -31,7 +31,7 @@ Windows 11
 
 ### Setting up Qt Creator
 
-- To get started with a CMake project in Qt Creator, open the program and select Open Project. Simply navigate to the CMakeLists.txt in `C:\development\JS8Call-improved` and select it. When the project window opens your available “kits” will be listed on the left side. Simply click the `+` button by the kits you want to use for this project (6.11.1). Qt Creator will create what is called an Initial Configuration. You can select to hide the inactive kits if you installed more than one version of Qt.
+- To get started with a CMake project in Qt Creator, open the program and select Open Project. Simply navigate to the CMakeLists.txt in `C:\development\JS8Call-improved` and select it. When the project window opens your available “kits” will be listed on the left side. Simply click the `+` button by the kits you want to use for this project (6.12.0). Qt Creator will create what is called an Initial Configuration. You can select to hide the inactive kits if you installed more than one version of Qt.
 - You can select Manage Kits at the top left to make sure you have a valid compiler (which should be LLVM-clang) for each one. The default build will be Debug. Under Build Settings select Add, and add a Release configuration and name it Release.
 - Qt Creator automatically creates a build folder in the source tree. Inside the build folder Creator makes folders for each kit and build type. DO NOT delete these. They contain your project build configuration settings for each build type. At present Creator will say there’s no configuration for Release found. Don’t worry about that. We’re going to fix it in the next step where we move to the CMake keys.
 - In the CMake configure settings pane (the center one) switch from Initial Configuration tab to Current Configuration. Then make the following changes:

--- a/tools/Debian-build-deb.sh
+++ b/tools/Debian-build-deb.sh
@@ -29,7 +29,7 @@ fi
 
 # --- Tarball URLs ---
 JS8LIB_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/js8lib4.0-Linux_${JS8_ARCH}_pkg.tar.gz"
-QT_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.11.1_Linux_${JS8_ARCH}_pkg.tar.gz"
+QT_URL="https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.12.0_Linux_${JS8_ARCH}_pkg.tar.gz"
 
 # --- Directories ---
 BUILD_DIR="$HOME/js8call-deb-build"

--- a/tools/Linux-TestBuild-Qt6.sh
+++ b/tools/Linux-TestBuild-Qt6.sh
@@ -5,7 +5,7 @@ set -e
 ####### Ubuntu 24.04 Server only  #######
 
 # --- Qt version to build ---
-QT_VERSION="6.11.1"
+QT_VERSION="6.12.0-beta2"
 QT_TAG="v${QT_VERSION}"
 
 clear

--- a/tools/Linux-User-Build-JS8Call.sh
+++ b/tools/Linux-User-Build-JS8Call.sh
@@ -104,6 +104,7 @@ install_deps() {
       at-spi2-core-devel mesa-libGL-devel mesa-libEGL-devel \
       mesa-libgbm-devel libdrm-devel libinput-devel \
       vulkan-loader-devel \
+      libopengl-devel \
       libxkbcommon-devel libxkbcommon-x11-devel \
       xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
       xcb-util-renderutil-devel xcb-util-wm-devel xcb-util-cursor-devel \
@@ -122,6 +123,7 @@ install_deps() {
       libharfbuzz-dev libjpeg-dev libpng-dev \
       zlib1g-dev libbrotli-dev libdbus-1-dev libglib2.0-dev \
       libatspi2.0-dev libgl-dev libegl-dev libgbm-dev \
+      libopengl-dev \
       libdrm-dev libinput-dev libvulkan-dev \
       mesa-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev \
       libxkbcommon-dev libxkbcommon-x11-dev \
@@ -198,7 +200,7 @@ if [ -d "${TOXIC_SYSTEM_LIB}" ] || [ -f "${TOXIC_SYSTEM_BIN}" ] || [ -f "${TOXIC
   divider
   echo -e "${red}CRITICAL SYSTEM NOTICE:
 Legacy components were detected in ${TOXIC_SYSTEM_LIB} or ${TOXIC_SYSTEM_BIN}.
-These paths leak custom Qt 6.11.1 dependencies globally, which crashes KDE Plasma!${clear_color}"
+These paths leak custom Qt 6.12.0 dependencies globally, which crashes KDE Plasma!${clear_color}"
   divider
   read -p "Purge conflicting /usr system-wide paths to fix/protect KDE? Yes(y) / No(n): " PURGE_TOXIC </dev/tty
   if [ "${PURGE_TOXIC}" = "y" ]; then
@@ -247,16 +249,16 @@ JS8Call and install it inside an isolated container path (/opt/lib/js8call).
 It requires sudo access to write to /opt/lib and establish a launch command 
 wrapper inside /opt/bin/.
 
-This execution model completely isolates the custom Qt 6.11.1 libraries, ensuring
+This execution model completely isolates the custom Qt 6.12.0 libraries, ensuring
 that your KDE Desktop Environment or system applications are never corrupted."
 divider
 read -p "Press Enter to continue" </dev/tty
 
 clear
 echo "NOTES:
-The newest versions of JS8Call require Qt v6.11.1 to run correctly. Most
-linux distributions do not package Qt6.11.1. The JS8Call project provides
-pre-compiled Qt6.11.1 libraries that this script will fetch and install strictly 
+The newest versions of JS8Call require Qt v6.12.0 to run correctly. Most
+linux distributions do not package Qt6.12.0. The JS8Call project provides
+pre-compiled Qt6.12.0 libraries that this script will fetch and install strictly 
 to /opt/lib/js8call/Qt. 
 
 By building directly into /opt and launching via a targeted runtime wrapper,
@@ -287,7 +289,7 @@ divider
 sleep 2
 
 # --- Fetch Qt6 and js8lib if not already installed ---
-echo "Checking for Qt 6.11.1..."
+echo "Checking for Qt 6.12.0..."
 divider
 sleep 2
 
@@ -295,27 +297,27 @@ cd "$HOME/development"
 
 if [ ! -d "${JS8_QT_DIR}" ]; then
   if [ "${JS8_ARCH}" = "aarch64" ]; then
-    wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.11.1_Linux_aarch64_pkg.tar.gz
+    wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.12.0_Linux_aarch64_pkg.tar.gz
     wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/js8lib4.0-Linux_aarch64_pkg.tar.gz
-    sudo tar -xzvf Qt6.11.1_Linux_aarch64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}"
-    rm Qt6.11.1_Linux_aarch64_pkg.tar.gz
+    sudo tar -xzvf Qt6.12.0_Linux_aarch64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}"
+    rm Qt6.12.0_Linux_aarch64_pkg.tar.gz
     sudo tar -xzvf js8lib4.0-Linux_aarch64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}" --strip-components=1
     rm js8lib4.0-Linux_aarch64_pkg.tar.gz
   else
-    wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.11.1_Linux_x86_64_pkg.tar.gz
+    wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/Qt6.12.0_Linux_x86_64_pkg.tar.gz
     wget -c https://github.com/JS8Call-improved/js8lib/releases/download/lib%2F4.0/js8lib4.0-Linux_x86_64_pkg.tar.gz
-    sudo tar -xzvf Qt6.11.1_Linux_x86_64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}"
-    rm Qt6.11.1_Linux_x86_64_pkg.tar.gz
+    sudo tar -xzvf Qt6.12.0_Linux_x86_64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}"
+    rm Qt6.12.0_Linux_x86_64_pkg.tar.gz
     sudo tar -xzvf js8lib4.0-Linux_x86_64_pkg.tar.gz -C "${JS8_INSTALL_PREFIX}" --strip-components=1
     rm js8lib4.0-Linux_x86_64_pkg.tar.gz
   fi
-  echo "Qt 6.11.1 and library archives extracted and removed."
+  echo "Qt 6.12.0 and library archives extracted and removed."
   
   # REMOVED DANGEROUS SYSTEM LINKER INJECTIONS (ld.so.conf.d) TO PROTECT KDE PLASMA
   echo "Libraries isolated inside ${JS8_INSTALL_PREFIX}. Global paths untouched."
 
 else
-  echo "Qt 6.11.1 already installed — skipping download."
+  echo "Qt 6.12.0 already installed — skipping download."
   divider
   sleep 2
 fi
@@ -382,7 +384,7 @@ BRANCH=$(git branch --show-current)
 clear
 divider
 echo "JS8Call Build Details:
-  Qt version : 6.11.1 with FFmpeg audio (requires PulseAudio or PipeWire)
+  Qt version : 6.12.0 with FFmpeg audio (requires PulseAudio or PipeWire)
   Branch     : JS8Call-improved ${BRANCH}
   Distro     : ${DISTRO} / ${JS8_ARCH}"
 divider


### PR DESCRIPTION
This moves master to Qt 6.12.0. Qt 6.11.1 has a regression bug that makes testing code I recently wrote for improving the MSG inbox difficult. This has been fixed in Qt 6.12, with the only other change required for linux since 6.12 now requires bundling the OpenGL library with the AppImage instead of using system or vender-installed OpenGL.