### PR TITLE
Convert replyPushButton from QPushButton to QToolButton to support a menu-driven choice between three reply targets.

### DIFF
--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -10,7 +10,9 @@
 #include <QDateTime>
 #include <QMenu>
 #include <QRegularExpression>
+#include <QStyle>
 #include <QTimeZone>
+#include <QToolButton>
 
 #include <algorithm>
 
@@ -21,6 +23,21 @@ auto pathSegs(QString const &path) {
   auto segs = path.split('>');
   std::reverse(segs.begin(), segs.end());
   return segs;
+}
+
+void setToolButtonMenu(QToolButton *button, QMenu *menu) {
+  button->setPopupMode(menu ? QToolButton::MenuButtonPopup
+                            : QToolButton::DelayedPopup);
+  // Qt style sheets cache property-selector matches. Re-polish after changing
+  // popupMode so the split-button padding rule is applied or removed now.
+  button->style()->unpolish(button);
+  button->style()->polish(button);
+
+  // setMenu() invalidates QToolButton's cached size hint. Keep it after the
+  // style refresh so the next hint uses the newly selected padding rule.
+  button->setMenu(menu);
+  button->updateGeometry();
+  button->update();
 }
 } // namespace
 
@@ -298,8 +315,7 @@ QString MessagePanel::prepareStoreForwardReplyMessage(QString path,
 }
 
 void MessagePanel::resetReplyButton() {
-  ui->replyPushButton->setMenu(nullptr);
-  ui->replyPushButton->setPopupMode(QToolButton::DelayedPopup);
+  setToolButtonMenu(ui->replyPushButton, nullptr);
 
   replyToPathAction->setText(tr("Reply"));
   replyToPathAction->setData(QVariant());
@@ -347,8 +363,7 @@ void MessagePanel::configureReplyButton(int row, const QString &messageText) {
   replyToOriginalAction->setData(prepareReplyMessage(originalSender, placeholder));
   replyToOriginalAction->setEnabled(true);
 
-  ui->replyPushButton->setMenu(replyMenu);
-  ui->replyPushButton->setPopupMode(QToolButton::MenuButtonPopup);
+  setToolButtonMenu(ui->replyPushButton, replyMenu);
 }
 
 void MessagePanel::emitReplyAction(QAction *action) {

--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -1,12 +1,15 @@
 #include "MessagePanel.h"
 #include "JS8_Include/EventFilter.h"
 #include "JS8_Main/Radio.h"
+#include "JS8_Main/Varicode.h"
 #include "JS8_Widgets/DateTableWidgetItem.h"
 #include "JS8_Widgets/SemiSortableHeader.h"
 #include "ui_MessagePanel.h"
 
+#include <QAction>
 #include <QDateTime>
 #include <QMenu>
+#include <QRegularExpression>
 #include <QTimeZone>
 
 #include <algorithm>
@@ -27,6 +30,16 @@ MessagePanel::MessagePanel(QString inboxPath, QWidget *parent)
   inbox->open();
 
   ui->setupUi(this);
+
+  replyMenu = new QMenu(ui->replyPushButton);
+  replyToPathAction = replyMenu->addAction(QString());
+  replyToOriginalViaPathAction = replyMenu->addAction(QString());
+
+  ui->replyPushButton->setPopupMode(QToolButton::MenuButtonPopup);
+  ui->replyPushButton->setDefaultAction(replyToPathAction);
+  connect(replyToPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToPathAction); });
+  connect(replyToOriginalViaPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToOriginalViaPathAction); });
+  resetReplyButton();
 
   // connect selection model changed
   connect(ui->messageTableWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this,
@@ -277,9 +290,71 @@ QString MessagePanel::prepareReplyMessage(QString path, QString text) {
   return QString("%1 MSG %2").arg(path).arg(text);
 }
 
+QString MessagePanel::prepareStoreForwardReplyMessage(QString path,
+                                                      QString recipient,
+                                                      QString text) {
+  return QString("%1 MSG TO:%2 %3").arg(path).arg(recipient).arg(text);
+}
+
+void MessagePanel::resetReplyButton() {
+  ui->replyPushButton->setMenu(nullptr);
+
+  replyToPathAction->setText(tr("Reply"));
+  replyToPathAction->setData(QVariant());
+  replyToPathAction->setEnabled(false);
+
+  replyToOriginalViaPathAction->setText(QString());
+  replyToOriginalViaPathAction->setData(QVariant());
+  replyToOriginalViaPathAction->setEnabled(false);
+}
+
+void MessagePanel::configureReplyButton(int row, const QString &messageText) {
+
+  auto *pathItem = ui->messageTableWidget->item(
+      row, ui->messageTableWidget->columnCount() - 5);
+  if (!pathItem) {
+    return;
+  }
+
+  const auto path = pathItem->data(Qt::UserRole).toString().trimmed();
+  if (path.isEmpty()) {
+    return;
+  }
+
+  const auto placeholder = QStringLiteral("[MESSAGE]");
+  replyToPathAction->setText(tr("Reply to %1").arg(path));
+  replyToPathAction->setData(prepareReplyMessage(path, placeholder));
+  replyToPathAction->setEnabled(true);
+
+  static const QRegularExpression fromSignature(R"((?:^| )FROM (?<callsign>\S+)$)");
+  const auto match = fromSignature.match(messageText);
+  if (!match.hasMatch()) {
+    return;
+  }
+
+  const auto originalSender = match.captured("callsign");
+  if (originalSender.startsWith('@') || !Varicode::isValidCallsign(originalSender, nullptr)) {
+    return;
+  }
+
+  replyToOriginalViaPathAction->setText(tr("Reply to %1 via %2").arg(originalSender, path));
+  replyToOriginalViaPathAction->setData(prepareStoreForwardReplyMessage(path, originalSender, placeholder));
+  replyToOriginalViaPathAction->setEnabled(true);
+  ui->replyPushButton->setMenu(replyMenu);
+}
+
+void MessagePanel::emitReplyAction(QAction *action) {
+  const auto message = action->data().toString();
+  if (!message.isEmpty()) {
+    emit replyMessage(message);
+  }
+}
+
 void MessagePanel::messageTableSelectionChanged(
     const QItemSelection &selected,
     const QItemSelection &/*deselected*/) {
+
+  resetReplyButton();
 
   auto items = ui->messageTableWidget->selectedItems();
   if (items.isEmpty() || items.size() > ui->messageTableWidget->columnCount()) {
@@ -300,6 +375,7 @@ void MessagePanel::messageTableSelectionChanged(
 
   auto text = item->data(Qt::UserRole).toString();
   ui->messageTextEdit->setPlainText(text);
+  configureReplyButton(row, text);
 
   // Mark deselected as read in table
   auto selectedItemIndexes = selected.indexes();
@@ -327,21 +403,4 @@ void MessagePanel::messageTableSelectionChanged(
   }
 
   markMessageRead(mid);
-}
-
-void MessagePanel::on_replyPushButton_clicked() {
-  auto row = ui->messageTableWidget->currentRow();
-
-  // from column
-  auto item = ui->messageTableWidget->item(
-      row, ui->messageTableWidget->columnCount() - 5);
-  if (!item) {
-    return;
-  }
-
-  auto path = item->data(Qt::UserRole).toString();
-  auto text = "[MESSAGE]";
-  auto message = prepareReplyMessage(path, text);
-
-  emit replyMessage(message);
 }

--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -35,7 +35,6 @@ MessagePanel::MessagePanel(QString inboxPath, QWidget *parent)
   replyToPathAction = replyMenu->addAction(QString());
   replyToOriginalViaPathAction = replyMenu->addAction(QString());
 
-  ui->replyPushButton->setPopupMode(QToolButton::MenuButtonPopup);
   ui->replyPushButton->setDefaultAction(replyToPathAction);
   connect(replyToPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToPathAction); });
   connect(replyToOriginalViaPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToOriginalViaPathAction); });
@@ -298,6 +297,7 @@ QString MessagePanel::prepareStoreForwardReplyMessage(QString path,
 
 void MessagePanel::resetReplyButton() {
   ui->replyPushButton->setMenu(nullptr);
+  ui->replyPushButton->setPopupMode(QToolButton::DelayedPopup);
 
   replyToPathAction->setText(tr("Reply"));
   replyToPathAction->setData(QVariant());
@@ -341,6 +341,7 @@ void MessagePanel::configureReplyButton(int row, const QString &messageText) {
   replyToOriginalViaPathAction->setData(prepareStoreForwardReplyMessage(path, originalSender, placeholder));
   replyToOriginalViaPathAction->setEnabled(true);
   ui->replyPushButton->setMenu(replyMenu);
+  ui->replyPushButton->setPopupMode(QToolButton::MenuButtonPopup);
 }
 
 void MessagePanel::emitReplyAction(QAction *action) {

--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -344,7 +344,7 @@ void MessagePanel::configureReplyButton(int row, const QString &messageText) {
   replyToPathAction->setData(prepareReplyMessage(path, placeholder));
   replyToPathAction->setEnabled(true);
 
-  static const QRegularExpression fromSignature(R"((?:^| )FROM (?<callsign>\S+)$)");
+  static const QRegularExpression fromSignature(R"((?:^| )FROM (?<callsign>\S+)(?: NEXT MSG ID \d+(?: \+\d+)?)?$)");
   const auto match = fromSignature.match(messageText);
   if (!match.hasMatch()) {
     return;

--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -34,10 +34,12 @@ MessagePanel::MessagePanel(QString inboxPath, QWidget *parent)
   replyMenu = new QMenu(ui->replyPushButton);
   replyToPathAction = replyMenu->addAction(QString());
   replyToOriginalViaPathAction = replyMenu->addAction(QString());
+  replyToOriginalAction = replyMenu->addAction(QString());
 
   ui->replyPushButton->setDefaultAction(replyToPathAction);
   connect(replyToPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToPathAction); });
   connect(replyToOriginalViaPathAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToOriginalViaPathAction); });
+  connect(replyToOriginalAction, &QAction::triggered, this, [this]() { emitReplyAction(replyToOriginalAction); });
   resetReplyButton();
 
   // connect selection model changed
@@ -340,6 +342,11 @@ void MessagePanel::configureReplyButton(int row, const QString &messageText) {
   replyToOriginalViaPathAction->setText(tr("Reply to %1 via %2").arg(originalSender, path));
   replyToOriginalViaPathAction->setData(prepareStoreForwardReplyMessage(path, originalSender, placeholder));
   replyToOriginalViaPathAction->setEnabled(true);
+
+  replyToOriginalAction->setText(tr("Reply to %1").arg(originalSender));
+  replyToOriginalAction->setData(prepareReplyMessage(originalSender, placeholder));
+  replyToOriginalAction->setEnabled(true);
+
   ui->replyPushButton->setMenu(replyMenu);
   ui->replyPushButton->setPopupMode(QToolButton::MenuButtonPopup);
 }

--- a/JS8_UI/MessagePanel.h
+++ b/JS8_UI/MessagePanel.h
@@ -7,7 +7,12 @@
 #include <QPair>
 #include <QWidget>
 
-namespace Ui { class MessagePanel; }
+class QAction;
+class QMenu;
+
+namespace Ui {
+class MessagePanel;
+}
 
 class MessagePanel : public QWidget {
   Q_OBJECT
@@ -29,14 +34,21 @@ public slots:
 private slots:
   void messageTableSelectionChanged(const QItemSelection & /*selected*/,
                                     const QItemSelection & /*deselected*/);
-  void on_replyPushButton_clicked();
 
 private:
+  void configureReplyButton(int row, const QString &messageText);
+  void resetReplyButton();
+  void emitReplyAction(QAction *action);
+  QString prepareStoreForwardReplyMessage(QString path, QString recipient,
+                                          QString text);
   void deleteSelectedMessages(); // shared by context menu + Delete key
   void deleteMessage(int id);
   void markMessageRead(int id);
   Ui::MessagePanel *ui;
   Inbox *inbox;
+  QMenu *replyMenu;
+  QAction *replyToPathAction;
+  QAction *replyToOriginalViaPathAction;
   QString call;
 };
 #endif // JS8CALL_MESSAGEPANEL_H

--- a/JS8_UI/MessagePanel.h
+++ b/JS8_UI/MessagePanel.h
@@ -49,6 +49,7 @@ private:
   QMenu *replyMenu;
   QAction *replyToPathAction;
   QAction *replyToOriginalViaPathAction;
+  QAction *replyToOriginalAction;
   QString call;
 };
 #endif // JS8CALL_MESSAGEPANEL_H

--- a/JS8_UI/MessagePanel.ui
+++ b/JS8_UI/MessagePanel.ui
@@ -218,7 +218,7 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="replyPushButton">
+       <widget class="QToolButton" name="replyPushButton">
         <property name="minimumSize">
          <size>
           <width>0</width>
@@ -227,6 +227,12 @@
         </property>
         <property name="text">
          <string>Reply</string>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+        </property>
+        <property name="autoRaise">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/JS8_UI/styles.h
+++ b/JS8_UI/styles.h
@@ -189,6 +189,16 @@ inline QString buttonStyle() {
             background-color: #ececec;
             color: #888888;
         }
+        QToolButton#replyPushButton::menu-button {
+            width: 12px;
+        }
+        QToolButton#replyPushButton[popupMode="MenuButtonPopup"] {
+            padding-right: 21px;
+        }
+        QToolButton#replyPushButton[popupMode="MenuButtonPopup"][layoutDirection="RightToLeft"] {
+            padding-right: 9px;
+            padding-left: 21px;
+        }
     )";
 
 #elif defined(Q_OS_MACOS)
@@ -214,6 +224,16 @@ inline QString buttonStyle() {
             background-color: #ececec;
             color: #888888;
         }
+        QToolButton#replyPushButton::menu-button {
+            width: 12px;
+        }
+        QToolButton#replyPushButton[popupMode="MenuButtonPopup"] {
+            padding-right: 21px;
+        }
+        QToolButton#replyPushButton[popupMode="MenuButtonPopup"][layoutDirection="RightToLeft"] {
+            padding-right: 9px;
+            padding-left: 21px;
+        }
     )";
 
 #elif defined(Q_OS_LINUX)
@@ -235,6 +255,16 @@ inline QString buttonStyle() {
        QPushButton:disabled, QToolButton:disabled {
            background-color: #ececec;
            color: #888888;
+       }
+       QToolButton#replyPushButton::menu-button {
+           width: 12px;
+       }
+       QToolButton#replyPushButton[popupMode="MenuButtonPopup"] {
+           padding-right: 21px;
+       }
+       QToolButton#replyPushButton[popupMode="MenuButtonPopup"][layoutDirection="RightToLeft"] {
+           padding-right: 9px;
+           padding-left: 21px;
        }
    )";
 
@@ -862,4 +892,3 @@ constexpr const char *SpotButtonStyle =
 
 }
 #endif
-

--- a/JS8_UI/styles.h
+++ b/JS8_UI/styles.h
@@ -155,7 +155,7 @@ static inline QString progress_bar_stylesheet(bool small = false) {
 }
 
 /**
- * @brief Returns a platform-native QPushButton stylesheet.
+ * @brief Returns a platform-native QPushButton/QToolButton stylesheet.
  *
  * Generates a stylesheet that approximates the native button conventions of the
  * specific platform, using system-appropriate fonts, geometry, and accent
@@ -164,22 +164,11 @@ static inline QString progress_bar_stylesheet(bool small = false) {
  *
  * @return A QSS QString suitable for use with @c QWidget::setStyleSheet(),
  *         or an empty default Qt style on unsupported platforms.
- *
- * @note A Linux variant targeting Ubuntu/Noto Sans with a neutral grey palette
- *       (@c #E0E0E0 background, @c #BDBDBD border) has been drafted but is
- * currently commented out pending a styling decision.
- *
- * @note On platforms other than Windows and macOS, Qt's built-in default button
- *       style is returned unchanged. This includes Linux until the pending
- * variant is defined
- *
- * @todo Evaluate and enable the Linux stylesheet when platform styling is
- * decided upon.
  */
 inline QString buttonStyle() {
 #if defined(Q_OS_WIN)
     return R"(
-        QPushButton {
+        QPushButton, QToolButton {
             background-color: #6699ff;
             color: black;
             border: none;
@@ -189,14 +178,14 @@ inline QString buttonStyle() {
             max-height: 15px;
             font-family: "Segoe UI";
         }
-        QPushButton:hover {
+        QPushButton:hover, QToolButton:hover {
             background-color: #4d7fff;
             color: white;
         }
-        QPushButton:pressed {
+        QPushButton:pressed, QToolButton:pressed {
             background-color: #003EAA;
         }
-        QPushButton:disabled {
+        QPushButton:disabled, QToolButton:disabled {
             background-color: #ececec;
             color: #888888;
         }
@@ -204,7 +193,7 @@ inline QString buttonStyle() {
 
 #elif defined(Q_OS_MACOS)
     return R"(
-        QPushButton {
+        QPushButton, QToolButton {
             background-color: #6699ff;
             color: black;
             border: none;
@@ -214,14 +203,14 @@ inline QString buttonStyle() {
             max-height: 15px;
             font-family: "-apple-system";
         }
-        QPushButton:hover {
+        QPushButton:hover, QToolButton:hover {
             background-color: #4d7fff;
             color: white;
         }
-        QPushButton:pressed {
+        QPushButton:pressed, QToolButton:pressed {
             background-color: #003EAA;
         }
-        QPushButton:disabled {
+        QPushButton:disabled, QToolButton:disabled {
             background-color: #ececec;
             color: #888888;
         }
@@ -229,21 +218,21 @@ inline QString buttonStyle() {
 
 #elif defined(Q_OS_LINUX)
     return R"(
-       QPushButton {
+       QPushButton, QToolButton {
            background-color: #6699ff;
            color: black;
            border: none;
            border-radius: 5px;
-           padding: px 9px;
+           padding: 3px 9px;
            font-family: "Ubuntu", "Noto Sans";
        }
-       QPushButton:hover {
+       QPushButton:hover, QToolButton:hover {
            background-color: #4d7fff;
        }
-       QPushButton:pressed {
+       QPushButton:pressed, QToolButton:pressed {
            background-color: #003EAA;
        }
-       QPushButton:disabled {
+       QPushButton:disabled, QToolButton:disabled {
            background-color: #ececec;
            color: #888888;
        }


### PR DESCRIPTION
This is a prototype implementation of a flexible reply button that supports replying either to the relay or to the original sender, as discussed in #321. It is mainly intended for review and evaluation at this stage and does not have to be adopted in exactly this form. After the extensive discussion, I wanted to explore how large and invasive the required changes would actually be. The overall scope of the implementation turned out to be relatively small.

Fixes https://github.com/JS8Call-improved/JS8Call-improved/issues/321