### PR TITLE
activity.db3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ target_sources(
   JS8_Logbook/CountryDat.cpp
   JS8_Logbook/CountriesWorked.cpp
   JS8_Logbook/LogBook.cpp
+  JS8_Main/ActivityDB.cpp
   JS8_Main/AprsInboundRelay.cpp
   JS8_Main/APRSISClient.cpp
   JS8_Main/AttenuationSlider.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ target_sources(
   JS8_Logbook/CountriesWorked.cpp
   JS8_Logbook/LogBook.cpp
   JS8_Main/ActivityDB.cpp
+  JS8_Main/ActivityStorageController.cpp
   JS8_Main/AprsInboundRelay.cpp
   JS8_Main/APRSISClient.cpp
   JS8_Main/AttenuationSlider.cpp

--- a/JS8_Main/ActivityDB.cpp
+++ b/JS8_Main/ActivityDB.cpp
@@ -33,22 +33,14 @@ constexpr char SCHEMA[] =
     "  band   TEXT NOT NULL, "
     "  html   TEXT, "
     "  PRIMARY KEY(config, band)"
+    ");"
+    "CREATE TABLE IF NOT EXISTS legacy_import_v1 ("
+    "  config TEXT NOT NULL PRIMARY KEY"
     ");";
 
-// Two guards on the conflict branch. The enrichment columns (grid,
-// ack_ts, cq_ts) keep their stored value when the incoming one is empty:
-// a bare re-hearing of a station must not wipe enrichment accumulated
-// earlier (grid from a directed frame or logbook backfill, ACK/CQ marks),
-// which the RAM map may no longer hold once aging has dropped the entry.
-// (`through` is deliberately NOT guarded: a direct hearing clears the
-// relay marker in RAM, and the store mirrors that.) And the whole update
-// applies only when the incoming row is at least as fresh as the stored
-// one - rows synthesized from old data (an unread inbox message's
-// original reception parameters, re-emitted on every clear) must not
-// roll a fresh row back to stale values. The timestamp format sorts
-// lexicographically, so TEXT comparison is chronological; an empty
-// (invalid) incoming timestamp never beats a real row - a blank manual
-// re-add of an already-stored callsign is deliberately a no-op.
+// grid, cq_ts, ack_ts: keep the stored value when the incoming one is empty
+// through: deliberately not guarded, so a direct hearing clears the relay
+// WHERE: the update applies only to a row as fresh as the one stored
 constexpr char UPSERT_CALL_SQL[] =
     "INSERT INTO call_activity_v1 "
     "  (config, band, callsign, through, snr, grid, dial, offset, "
@@ -83,19 +75,28 @@ QByteArray toTs(const QDateTime &dt) {
     return dt.toUTC().toString(TS_FORMAT).toUtf8();
 }
 
+/**
+ * @brief Parse a stored timestamp back into a UTC QDateTime.
+ * @param stmt The statement being read.
+ * @param col The column holding the timestamp text.
+ * @return The value, or an invalid QDateTime when the text is empty or
+ *         does not parse.
+ *
+ * The value is constructed directly in UTC, because parsing a full
+ * QDateTime first would normalize through local time - shifting a value
+ * that falls in a DST gap - before the zone could be corrected. Text that
+ * does not parse yields an invalid QDateTime rather than the midnight
+ * QDateTime substitutes, which would turn corrupt text into a
+ * plausible-looking timestamp.
+ */
 QDateTime fromTs(sqlite3_stmt *stmt, int col) {
     auto raw = QByteArray((const char *)sqlite3_column_text(stmt, col),
                           sqlite3_column_bytes(stmt, col));
     if (raw.isEmpty()) return {};
-    // Construct directly in UTC - parsing a full QDateTime first would
-    // normalize through local time (shifting a value that falls in a DST
-    // gap) before the zone could be corrected.
     auto const s = QString::fromUtf8(raw);
     auto const date = QDate::fromString(s.left(10), "yyyy-MM-dd");
     auto const time = QTime::fromString(s.mid(11), "HH:mm:ss");
     if (!date.isValid() || !time.isValid()) {
-        // QDateTime substitutes midnight for an invalid time, which would
-        // turn corrupt text into a plausible-looking timestamp
         return {};
     }
     return QDateTime(date, time, QTimeZone::utc());
@@ -116,34 +117,46 @@ void ActivityDB::captureError() {
     }
 }
 
-// A read or write that failed is counted; enough consecutive failures
-// (a volume that vanished mid-session, creeping corruption) close the
-// handle so isOpen() finally reports the truth - the UI's degraded-mode
-// paths and its throttled reopen retry key off isOpen(), and would
-// otherwise be unreachable for a store that breaks after a good open.
+/**
+ * @brief Record the outcome of one statement and count failures.
+ * @param ok Whether the statement completed.
+ * @return ok unchanged, so a caller can return it directly.
+ *
+ * A read or write that failed is counted; enough consecutive failures (a
+ * volume that vanished mid-session, creeping corruption) close the handle
+ * so isOpen() finally reports the truth - the UI's degraded-mode paths
+ * and its throttled reopen retry key off isOpen(), and would otherwise be
+ * unreachable for a store that breaks after a good open.
+ *
+ * Only a successful data statement proves the handle usable again, so
+ * only that path drops the strike count and any close deferred earlier in
+ * the batch. commit() does not reach here at all when its COMMIT
+ * succeeds, because a COMMIT succeeding says nothing about a batch whose
+ * every data statement failed.
+ *
+ * On failure the error is captured here, immediately after the failing
+ * statement, while sqlite3_errmsg() still describes it.
+ */
 bool ActivityDB::noteResult(bool ok) {
     if (ok) {
-        // A successful statement proves the handle is usable again, so
-        // it drops both the strike count and any close deferred earlier
-        // in this batch. commit() deliberately captures pendingClose_
-        // BEFORE calling this: a COMMIT succeeding says nothing about a
-        // batch whose every data statement failed.
         consecutiveFailures_ = 0;
         pendingClose_ = false;
     } else {
-        // callers invoke this immediately after the failing statement,
-        // while sqlite3_errmsg() still describes it
         captureError();
         noteFailureCaptured();
     }
     return ok;
 }
 
-// like noteResult(false), for failures whose error was already captured
-// before follow-up statements (a rollback) reset sqlite3_errmsg().
-// Inside a transaction the self-close is deferred to commit()/rollback():
-// sqlite3_close would roll the open transaction back, silently discarding
-// every row already written in the batch.
+/**
+ * @brief Count a failure whose error message was already captured.
+ *
+ * Like noteResult(false), for failures whose error was captured before
+ * follow-up statements - a rollback - reset sqlite3_errmsg() to "not an
+ * error". Inside a transaction the self-close is deferred to commit() or
+ * rollback(), because sqlite3_close() would roll the open transaction
+ * back and silently discard every row already written in the batch.
+ */
 void ActivityDB::noteFailureCaptured() {
     if (++consecutiveFailures_ >= 3) {
         if (inTransaction_) {
@@ -154,9 +167,32 @@ void ActivityDB::noteFailureCaptured() {
     }
 }
 
+/**
+ * @brief Open the store, creating or validating its schema.
+ * @return True when the handle is usable.
+ *
+ * WAL keeps an interrupted write from corrupting the store, and with
+ * synchronous=NORMAL commits are not individually fsynced, so frequent
+ * small writes stay cheap on the GUI thread while remaining safe against
+ * application crashes - an OS crash can lose, but not corrupt, the most
+ * recent commits. NORMAL carries that guarantee only under WAL, and WAL
+ * can be refused (filesystems without shared-memory support, such as
+ * network homes), so the sync level is relaxed only after checking what
+ * actually took effect. The busy timeout is set before that probe: the
+ * first WAL conversion takes a lock another connection may briefly hold,
+ * and probing without the timeout would silently leave the session on
+ * the rollback journal.
+ *
+ * The schema is created in one transaction, so a power cut cannot leave
+ * it half-built. Preparing the hot-path statements here doubles as a
+ * schema validation probe: CREATE TABLE IF NOT EXISTS silently accepts a
+ * pre-existing table with different columns, say after a version
+ * downgrade, and without this check every later write would fail with its
+ * return value unexamined - the application would look normal all session
+ * while persisting nothing.
+ */
 bool ActivityDB::open() {
-    // sqlite3_open requires UTF-8 (toLocal8Bit would hand the win32 VFS
-    // ANSI-code-page bytes, silently breaking non-ASCII profile paths)
+    // sqlite3_open needs UTF-8: toLocal8Bit breaks non-ASCII win32 paths
     int rc = sqlite3_open(path_.toUtf8().data(), &db_);
     if (rc != SQLITE_OK) {
         captureError();
@@ -164,18 +200,6 @@ bool ActivityDB::open() {
         return false;
     }
 
-    // WAL keeps an interrupted write from corrupting the store, and with
-    // synchronous=NORMAL commits are not individually fsynced - frequent
-    // small writes stay cheap on the GUI thread while remaining safe
-    // against application crashes (an OS crash can lose, but not corrupt,
-    // the most recent commits). NORMAL carries that guarantee only under
-    // WAL, and WAL can be refused (filesystems without shared-memory
-    // support, e.g. network homes), so check what actually took effect
-    // before relaxing the sync level. The busy timeout covers lock
-    // contention with another process holding the file open.
-    // busy timeout FIRST: the very first WAL conversion takes a lock
-    // another connection may briefly hold, and probing without the
-    // timeout would silently leave the session on the rollback journal
     sqlite3_exec(db_, "PRAGMA busy_timeout=5000;", nullptr, nullptr, nullptr);
     bool wal = false;
     for (int attempt = 0; attempt < 2 && !wal; ++attempt) {
@@ -194,7 +218,6 @@ bool ActivityDB::open() {
                      nullptr);
     }
 
-    // one transaction, so a power cut cannot leave a half-created schema
     rc = sqlite3_exec(db_, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr);
     if (rc == SQLITE_OK) {
         rc = sqlite3_exec(db_, SCHEMA, nullptr, nullptr, nullptr);
@@ -202,8 +225,7 @@ bool ActivityDB::open() {
             rc = sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, nullptr);
             if (rc != SQLITE_OK) captureError();
         } else {
-            // capture the real reason BEFORE the rollback - a successful
-            // ROLLBACK resets sqlite3_errmsg() to "not an error"
+            // capture before the rollback: a good ROLLBACK clears errmsg
             captureError();
             sqlite3_exec(db_, "ROLLBACK;", nullptr, nullptr, nullptr);
         }
@@ -215,12 +237,6 @@ bool ActivityDB::open() {
         return false;
     }
 
-    // Preparing the hot-path statements here doubles as a schema
-    // validation probe: CREATE TABLE IF NOT EXISTS silently accepts a
-    // pre-existing table with different columns (e.g. after a version
-    // downgrade), and without this check every later write would fail
-    // with its return value unexamined - the app would look normal all
-    // session while persisting nothing.
     if (sqlite3_prepare_v2(db_, UPSERT_CALL_SQL, -1, &upsertCallStmt_,
                            nullptr) != SQLITE_OK ||
         sqlite3_prepare_v2(db_, SAVE_RX_TEXT_SQL, -1, &saveRxTextStmt_,
@@ -244,9 +260,7 @@ void ActivityDB::close() {
         saveRxTextStmt_ = nullptr;
     }
     if (db_) {
-        // _v2: defers the real close if anything is still unfinalized,
-        // rather than leaking the handle
-        sqlite3_close_v2(db_); // rolls back any open transaction
+        sqlite3_close_v2(db_);
         db_ = nullptr;
     }
     inTransaction_ = false;
@@ -259,47 +273,47 @@ QString ActivityDB::error() const { return lastError_; }
 
 bool ActivityDB::begin() {
     if (!isOpen() || inTransaction_) return false;
-    // IMMEDIATE, like open()'s schema transaction: take the write lock at
-    // BEGIN (where the busy timeout applies) rather than discovering the
-    // contention at COMMIT, where it cannot be waited out
+    // IMMEDIATE: take the write lock where the busy timeout still applies
     if (sqlite3_exec(db_, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr) !=
         SQLITE_OK) {
-        captureError();
-        return false;
+        return noteResult(false);
     }
     inTransaction_ = true;
     return true;
 }
 
+/**
+ * @brief Commit the open transaction.
+ * @return True when the COMMIT succeeded.
+ *
+ * A successful COMMIT is not evidence that the store recovered: only a
+ * successful data statement is, and any of those has already cleared both
+ * the strike count and any deferred close. This path therefore does not
+ * go through noteResult() at all - resetting the strikes here would let
+ * an all-failing batch that commits cleanly hold the counter at zero
+ * forever, and the handle would never give up.
+ *
+ * A failed COMMIT (SQLITE_BUSY on the non-WAL fallback's lock upgrade,
+ * say) leaves the transaction open, so it is explicitly rolled back:
+ * without that, every later autocommit write would silently join the open
+ * transaction and be lost wholesale when the handle closes. It also
+ * counts as a failure strike, because the successful steps inside a
+ * doomed transaction reset the counter and a store whose commits
+ * persistently fail would otherwise never report unusable.
+ */
 bool ActivityDB::commit() {
     if (!isOpen() || !inTransaction_) return false;
     if (sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, nullptr) ==
         SQLITE_OK) {
         inTransaction_ = false;
-        // A successful COMMIT is not evidence that the store recovered:
-        // only a successful data statement is, and any of those has
-        // already cleared both the strike count and the deferred close.
-        // So this path touches neither - resetting the strikes here
-        // would let an all-failing batch that commits cleanly keep the
-        // counter at zero forever, and the handle would never give up.
-        bool const deferredClose = pendingClose_;
-        bool const ok = true;
-        if (deferredClose) {
-            // strikes accumulated mid-batch and nothing since succeeded:
-            // the commit above kept whatever the batch did write, so the
-            // broken handle can now close
+        if (pendingClose_) {
+            // strikes accumulated mid-batch and nothing since succeeded;
+            // the commit above kept whatever the batch did write
             pendingClose_ = false;
             close();
         }
-        return ok;
+        return true;
     }
-    // A failed COMMIT (e.g. SQLITE_BUSY on the non-WAL fallback's lock
-    // upgrade) leaves the transaction open; without an explicit rollback
-    // every later autocommit write would silently join it and be lost
-    // wholesale when the handle closes. It also counts toward the
-    // failure strikes: the successful steps inside a doomed transaction
-    // reset the counter, so a store whose commits persistently fail
-    // would otherwise never report unusable.
     captureError();
     rollback();
     noteFailureCaptured();
@@ -307,7 +321,7 @@ bool ActivityDB::commit() {
 }
 
 void ActivityDB::rollback() {
-    if (!isOpen() || !inTransaction_) return; // mirrors commit()'s guard
+    if (!isOpen() || !inTransaction_) return;
     sqlite3_exec(db_, "ROLLBACK;", nullptr, nullptr, nullptr);
     inTransaction_ = false;
     if (pendingClose_) {
@@ -332,9 +346,7 @@ bool ActivityDB::upsertCall(const QString &config, const QString &band,
     auto ack8 = toTs(record.ackTimestamp);
     auto utc8 = toTs(record.utcTimestamp);
 
-    // A silently failed bind would leave the parameter NULL, and a NULL
-    // utc_ts makes the freshness guard unsatisfiable - the row could
-    // never be updated again - so every bind is checked.
+    // a failed bind leaves utc_ts NULL, which no freshness guard can meet
     int bindRc = SQLITE_OK;
     bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
     bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
@@ -383,8 +395,7 @@ bool ActivityDB::deleteCall(const QString &config, const QString &band,
     bindRc |= sqlite3_bind_text(stmt, 3, call8.data(), call8.size(),
                                 SQLITE_TRANSIENT);
     if (bindRc != SQLITE_OK) {
-        // an unbound parameter makes the WHERE unsatisfiable, and the
-        // zero-row DELETE would still report success
+        // unbound: the zero-row DELETE would still report success
         sqlite3_finalize(stmt);
         return noteResult(false);
     }
@@ -392,9 +403,9 @@ bool ActivityDB::deleteCall(const QString &config, const QString &band,
     bool ok = sqlite3_step(stmt) == SQLITE_DONE;
     int const changed = ok ? sqlite3_changes(db_) : 0;
     sqlite3_finalize(stmt);
-    // a statement that ran but matched nothing is not a removal - the
-    // row is stored under another band, and the caller must be able to
-    // say so rather than report a silent no-op as success
+    if (ok && changed == 0) {
+        lastError_.clear();
+    }
     return noteResult(ok) && changed > 0;
 }
 
@@ -449,7 +460,7 @@ QList<ActivityDB::CallRecord> ActivityDB::loadCalls(const QString &config,
     if (bindRc != SQLITE_OK) {
         sqlite3_finalize(stmt);
         noteResult(false);
-        return result; // ok stays false: this is a failed read
+        return result;
     }
 
     int rc;
@@ -476,9 +487,6 @@ QList<ActivityDB::CallRecord> ActivityDB::loadCalls(const QString &config,
         result.append(r);
     }
 
-    // a read that failed mid-iteration must not pass for a complete
-    // (possibly empty) band - the caller may act on "no data" by
-    // overwriting what is actually there
     if (ok) *ok = (rc == SQLITE_DONE);
 
     sqlite3_finalize(stmt);
@@ -535,7 +543,7 @@ QString ActivityDB::loadRxText(const QString &config, const QString &band,
     if (bindRc != SQLITE_OK) {
         sqlite3_finalize(stmt);
         noteResult(false);
-        return {}; // ok stays false: this is a failed read
+        return {};
     }
 
     QString result;
@@ -546,8 +554,6 @@ QString ActivityDB::loadRxText(const QString &config, const QString &band,
             sqlite3_column_bytes(stmt, 0));
         rc = sqlite3_step(stmt);
     }
-    // SQLITE_DONE means the read completed - either one row or none; an
-    // error must stay distinguishable from "no stored text" (see loadCalls)
     if (ok) *ok = (rc == SQLITE_DONE);
 
     sqlite3_finalize(stmt);
@@ -580,13 +586,12 @@ bool ActivityDB::clearRxText(const QString &config, const QString &band) {
     return noteResult(ok);
 }
 
-bool ActivityDB::hasConfig(const QString &config, bool *ok) {
+bool ActivityDB::hasImported(const QString &config, bool *ok) {
     if (ok) *ok = false;
     if (!isOpen()) return false;
 
     const char *sql =
-        "SELECT 1 FROM call_activity_v1 WHERE config = ? "
-        "UNION ALL SELECT 1 FROM rx_text_v1 WHERE config = ? LIMIT 1;";
+        "SELECT 1 FROM legacy_import_v1 WHERE config = ? LIMIT 1;";
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
@@ -595,10 +600,8 @@ bool ActivityDB::hasConfig(const QString &config, bool *ok) {
     }
 
     auto c8 = config.toUtf8();
-    int bindRc = SQLITE_OK;
-    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
-    bindRc |= sqlite3_bind_text(stmt, 2, c8.data(), c8.size(), SQLITE_TRANSIENT);
-    if (bindRc != SQLITE_OK) {
+    if (sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT) !=
+        SQLITE_OK) {
         sqlite3_finalize(stmt);
         noteResult(false);
         return false;
@@ -612,6 +615,28 @@ bool ActivityDB::hasConfig(const QString &config, bool *ok) {
     return rc == SQLITE_ROW;
 }
 
+bool ActivityDB::markImported(const QString &config) {
+    if (!isOpen()) return false;
+
+    const char *sql =
+        "INSERT OR IGNORE INTO legacy_import_v1 (config) VALUES (?);";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return noteResult(false);
+
+    auto c8 = config.toUtf8();
+    if (sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT) !=
+        SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    return noteResult(ok);
+}
+
 bool ActivityDB::clearConfig(const QString &config) {
     if (!isOpen()) return false;
 
@@ -622,10 +647,6 @@ bool ActivityDB::clearConfig(const QString &config) {
 
     auto c8 = config.toUtf8();
 
-    // Both tables or neither. When the caller has not already batched us
-    // into its own transaction we need our own; if it cannot be opened,
-    // do nothing at all rather than destroy one table and report
-    // failure for the other.
     bool ownTransaction = false;
     if (!inTransaction_) {
         if (!begin()) {
@@ -648,8 +669,75 @@ bool ActivityDB::clearConfig(const QString &config) {
         }
         if (sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT) !=
             SQLITE_OK) {
-            // an unbound config makes the WHERE unsatisfiable, and the
-            // zero-row DELETE would still report success
+            sqlite3_finalize(stmt);
+            noteResult(false);
+            ok = false;
+            continue;
+        }
+        bool stepOk = sqlite3_step(stmt) == SQLITE_DONE;
+        sqlite3_finalize(stmt);
+        noteResult(stepOk);
+        ok = stepOk && ok;
+    }
+
+    if (ownTransaction) {
+        if (ok) {
+            ok = commit();
+        } else {
+            rollback();
+        }
+    }
+
+    return ok;
+}
+
+bool ActivityDB::copyConfig(const QString &from, const QString &to) {
+    if (!isOpen()) return false;
+
+    const char *sqlCalls =
+        "INSERT OR IGNORE INTO call_activity_v1 "
+        "  (config, band, callsign, through, snr, grid, dial, offset, "
+        "   bits, tdrift, cq_ts, ack_ts, utc_ts, submode) "
+        "SELECT ?, band, callsign, through, snr, grid, dial, offset, "
+        "       bits, tdrift, cq_ts, ack_ts, utc_ts, submode "
+        "FROM call_activity_v1 WHERE config = ?;";
+    const char *sqlText =
+        "INSERT OR IGNORE INTO rx_text_v1 (config, band, html) "
+        "SELECT ?, band, html FROM rx_text_v1 WHERE config = ?;";
+    const char *sqlMarker =
+        "INSERT OR IGNORE INTO legacy_import_v1 (config) "
+        "SELECT ? FROM legacy_import_v1 WHERE config = ?;";
+
+    auto f8 = from.toUtf8();
+    auto t8 = to.toUtf8();
+
+    bool ownTransaction = false;
+    if (!inTransaction_) {
+        if (!begin()) {
+            return false;
+        }
+        ownTransaction = true;
+    }
+    bool ok = true;
+
+    for (const char *sql : {sqlCalls, sqlText, sqlMarker}) {
+        if (!isOpen()) {
+            ok = false;
+            break;
+        }
+        sqlite3_stmt *stmt;
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            noteResult(false);
+            ok = false;
+            continue;
+        }
+        // 1 is the destination the SELECT writes, 2 the source it reads
+        int bindRc = SQLITE_OK;
+        bindRc |= sqlite3_bind_text(stmt, 1, t8.data(), t8.size(),
+                                    SQLITE_TRANSIENT);
+        bindRc |= sqlite3_bind_text(stmt, 2, f8.data(), f8.size(),
+                                    SQLITE_TRANSIENT);
+        if (bindRc != SQLITE_OK) {
             sqlite3_finalize(stmt);
             noteResult(false);
             ok = false;

--- a/JS8_Main/ActivityDB.cpp
+++ b/JS8_Main/ActivityDB.cpp
@@ -1,0 +1,673 @@
+/**
+ * @file ActivityDB.cpp
+ * @brief Persistent per-band activity storage implementation.
+ */
+
+#include "ActivityDB.h"
+#include "vendor/sqlite3/sqlite3.h"
+
+#include <QTimeZone>
+
+namespace {
+
+constexpr char SCHEMA[] =
+    "CREATE TABLE IF NOT EXISTS call_activity_v1 ("
+    "  config   TEXT NOT NULL, "
+    "  band     TEXT NOT NULL, "
+    "  callsign TEXT NOT NULL, "
+    "  through  TEXT, "
+    "  snr      INTEGER, "
+    "  grid     TEXT, "
+    "  dial     INTEGER, "
+    "  offset   INTEGER, "
+    "  bits     INTEGER, "
+    "  tdrift   REAL, "
+    "  cq_ts    TEXT NOT NULL DEFAULT '', "
+    "  ack_ts   TEXT NOT NULL DEFAULT '', "
+    "  utc_ts   TEXT NOT NULL DEFAULT '', "
+    "  submode  INTEGER, "
+    "  PRIMARY KEY(config, band, callsign)"
+    ");"
+    "CREATE TABLE IF NOT EXISTS rx_text_v1 ("
+    "  config TEXT NOT NULL, "
+    "  band   TEXT NOT NULL, "
+    "  html   TEXT, "
+    "  PRIMARY KEY(config, band)"
+    ");";
+
+// Two guards on the conflict branch. The enrichment columns (grid,
+// ack_ts, cq_ts) keep their stored value when the incoming one is empty:
+// a bare re-hearing of a station must not wipe enrichment accumulated
+// earlier (grid from a directed frame or logbook backfill, ACK/CQ marks),
+// which the RAM map may no longer hold once aging has dropped the entry.
+// (`through` is deliberately NOT guarded: a direct hearing clears the
+// relay marker in RAM, and the store mirrors that.) And the whole update
+// applies only when the incoming row is at least as fresh as the stored
+// one - rows synthesized from old data (an unread inbox message's
+// original reception parameters, re-emitted on every clear) must not
+// roll a fresh row back to stale values. The timestamp format sorts
+// lexicographically, so TEXT comparison is chronological; an empty
+// (invalid) incoming timestamp never beats a real row - a blank manual
+// re-add of an already-stored callsign is deliberately a no-op.
+constexpr char UPSERT_CALL_SQL[] =
+    "INSERT INTO call_activity_v1 "
+    "  (config, band, callsign, through, snr, grid, dial, offset, "
+    "   bits, tdrift, cq_ts, ack_ts, utc_ts, submode) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+    "ON CONFLICT(config, band, callsign) DO UPDATE SET "
+    "  through = excluded.through, "
+    "  snr = excluded.snr, "
+    "  grid = CASE WHEN excluded.grid <> '' "
+    "         THEN excluded.grid ELSE call_activity_v1.grid END, "
+    "  dial = excluded.dial, "
+    "  offset = excluded.offset, "
+    "  bits = excluded.bits, "
+    "  tdrift = excluded.tdrift, "
+    "  cq_ts = CASE WHEN excluded.cq_ts <> '' "
+    "          THEN excluded.cq_ts ELSE call_activity_v1.cq_ts END, "
+    "  ack_ts = CASE WHEN excluded.ack_ts <> '' "
+    "           THEN excluded.ack_ts ELSE call_activity_v1.ack_ts END, "
+    "  utc_ts = CASE WHEN excluded.utc_ts <> '' "
+    "           THEN excluded.utc_ts ELSE call_activity_v1.utc_ts END, "
+    "  submode = excluded.submode "
+    "WHERE excluded.utc_ts >= call_activity_v1.utc_ts;";
+
+constexpr char SAVE_RX_TEXT_SQL[] =
+    "INSERT INTO rx_text_v1 (config, band, html) VALUES (?, ?, ?) "
+    "ON CONFLICT(config, band) DO UPDATE SET html = excluded.html;";
+
+constexpr char TS_FORMAT[] = "yyyy-MM-dd HH:mm:ss";
+
+QByteArray toTs(const QDateTime &dt) {
+    if (!dt.isValid()) return {};
+    return dt.toUTC().toString(TS_FORMAT).toUtf8();
+}
+
+QDateTime fromTs(sqlite3_stmt *stmt, int col) {
+    auto raw = QByteArray((const char *)sqlite3_column_text(stmt, col),
+                          sqlite3_column_bytes(stmt, col));
+    if (raw.isEmpty()) return {};
+    // Construct directly in UTC - parsing a full QDateTime first would
+    // normalize through local time (shifting a value that falls in a DST
+    // gap) before the zone could be corrected.
+    auto const s = QString::fromUtf8(raw);
+    auto const date = QDate::fromString(s.left(10), "yyyy-MM-dd");
+    auto const time = QTime::fromString(s.mid(11), "HH:mm:ss");
+    if (!date.isValid() || !time.isValid()) {
+        // QDateTime substitutes midnight for an invalid time, which would
+        // turn corrupt text into a plausible-looking timestamp
+        return {};
+    }
+    return QDateTime(date, time, QTimeZone::utc());
+}
+
+} // namespace
+
+ActivityDB::ActivityDB(const QString &path)
+    : path_{path}, db_{nullptr}, inTransaction_{false},
+      pendingClose_{false}, consecutiveFailures_{0},
+      upsertCallStmt_{nullptr}, saveRxTextStmt_{nullptr} {}
+
+ActivityDB::~ActivityDB() { close(); }
+
+void ActivityDB::captureError() {
+    if (db_) {
+        lastError_ = QString::fromUtf8(sqlite3_errmsg(db_));
+    }
+}
+
+// A read or write that failed is counted; enough consecutive failures
+// (a volume that vanished mid-session, creeping corruption) close the
+// handle so isOpen() finally reports the truth - the UI's degraded-mode
+// paths and its throttled reopen retry key off isOpen(), and would
+// otherwise be unreachable for a store that breaks after a good open.
+bool ActivityDB::noteResult(bool ok) {
+    if (ok) {
+        // A successful statement proves the handle is usable again, so
+        // it drops both the strike count and any close deferred earlier
+        // in this batch. commit() deliberately captures pendingClose_
+        // BEFORE calling this: a COMMIT succeeding says nothing about a
+        // batch whose every data statement failed.
+        consecutiveFailures_ = 0;
+        pendingClose_ = false;
+    } else {
+        // callers invoke this immediately after the failing statement,
+        // while sqlite3_errmsg() still describes it
+        captureError();
+        noteFailureCaptured();
+    }
+    return ok;
+}
+
+// like noteResult(false), for failures whose error was already captured
+// before follow-up statements (a rollback) reset sqlite3_errmsg().
+// Inside a transaction the self-close is deferred to commit()/rollback():
+// sqlite3_close would roll the open transaction back, silently discarding
+// every row already written in the batch.
+void ActivityDB::noteFailureCaptured() {
+    if (++consecutiveFailures_ >= 3) {
+        if (inTransaction_) {
+            pendingClose_ = true;
+        } else {
+            close();
+        }
+    }
+}
+
+bool ActivityDB::open() {
+    // sqlite3_open requires UTF-8 (toLocal8Bit would hand the win32 VFS
+    // ANSI-code-page bytes, silently breaking non-ASCII profile paths)
+    int rc = sqlite3_open(path_.toUtf8().data(), &db_);
+    if (rc != SQLITE_OK) {
+        captureError();
+        close();
+        return false;
+    }
+
+    // WAL keeps an interrupted write from corrupting the store, and with
+    // synchronous=NORMAL commits are not individually fsynced - frequent
+    // small writes stay cheap on the GUI thread while remaining safe
+    // against application crashes (an OS crash can lose, but not corrupt,
+    // the most recent commits). NORMAL carries that guarantee only under
+    // WAL, and WAL can be refused (filesystems without shared-memory
+    // support, e.g. network homes), so check what actually took effect
+    // before relaxing the sync level. The busy timeout covers lock
+    // contention with another process holding the file open.
+    // busy timeout FIRST: the very first WAL conversion takes a lock
+    // another connection may briefly hold, and probing without the
+    // timeout would silently leave the session on the rollback journal
+    sqlite3_exec(db_, "PRAGMA busy_timeout=5000;", nullptr, nullptr, nullptr);
+    bool wal = false;
+    for (int attempt = 0; attempt < 2 && !wal; ++attempt) {
+        sqlite3_stmt *stmt = nullptr;
+        if (sqlite3_prepare_v2(db_, "PRAGMA journal_mode=WAL;", -1, &stmt,
+                               nullptr) == SQLITE_OK) {
+            if (sqlite3_step(stmt) == SQLITE_ROW) {
+                wal = qstricmp((const char *)sqlite3_column_text(stmt, 0),
+                               "wal") == 0;
+            }
+            sqlite3_finalize(stmt);
+        }
+    }
+    if (wal) {
+        sqlite3_exec(db_, "PRAGMA synchronous=NORMAL;", nullptr, nullptr,
+                     nullptr);
+    }
+
+    // one transaction, so a power cut cannot leave a half-created schema
+    rc = sqlite3_exec(db_, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr);
+    if (rc == SQLITE_OK) {
+        rc = sqlite3_exec(db_, SCHEMA, nullptr, nullptr, nullptr);
+        if (rc == SQLITE_OK) {
+            rc = sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, nullptr);
+            if (rc != SQLITE_OK) captureError();
+        } else {
+            // capture the real reason BEFORE the rollback - a successful
+            // ROLLBACK resets sqlite3_errmsg() to "not an error"
+            captureError();
+            sqlite3_exec(db_, "ROLLBACK;", nullptr, nullptr, nullptr);
+        }
+    } else {
+        captureError();
+    }
+    if (rc != SQLITE_OK) {
+        close();
+        return false;
+    }
+
+    // Preparing the hot-path statements here doubles as a schema
+    // validation probe: CREATE TABLE IF NOT EXISTS silently accepts a
+    // pre-existing table with different columns (e.g. after a version
+    // downgrade), and without this check every later write would fail
+    // with its return value unexamined - the app would look normal all
+    // session while persisting nothing.
+    if (sqlite3_prepare_v2(db_, UPSERT_CALL_SQL, -1, &upsertCallStmt_,
+                           nullptr) != SQLITE_OK ||
+        sqlite3_prepare_v2(db_, SAVE_RX_TEXT_SQL, -1, &saveRxTextStmt_,
+                           nullptr) != SQLITE_OK) {
+        captureError();
+        close();
+        return false;
+    }
+
+    consecutiveFailures_ = 0;
+    return true;
+}
+
+void ActivityDB::close() {
+    if (upsertCallStmt_) {
+        sqlite3_finalize(upsertCallStmt_);
+        upsertCallStmt_ = nullptr;
+    }
+    if (saveRxTextStmt_) {
+        sqlite3_finalize(saveRxTextStmt_);
+        saveRxTextStmt_ = nullptr;
+    }
+    if (db_) {
+        // _v2: defers the real close if anything is still unfinalized,
+        // rather than leaking the handle
+        sqlite3_close_v2(db_); // rolls back any open transaction
+        db_ = nullptr;
+    }
+    inTransaction_ = false;
+    pendingClose_ = false;
+}
+
+bool ActivityDB::isOpen() const { return db_ != nullptr; }
+
+QString ActivityDB::error() const { return lastError_; }
+
+bool ActivityDB::begin() {
+    if (!isOpen() || inTransaction_) return false;
+    // IMMEDIATE, like open()'s schema transaction: take the write lock at
+    // BEGIN (where the busy timeout applies) rather than discovering the
+    // contention at COMMIT, where it cannot be waited out
+    if (sqlite3_exec(db_, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr) !=
+        SQLITE_OK) {
+        captureError();
+        return false;
+    }
+    inTransaction_ = true;
+    return true;
+}
+
+bool ActivityDB::commit() {
+    if (!isOpen() || !inTransaction_) return false;
+    if (sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, nullptr) ==
+        SQLITE_OK) {
+        inTransaction_ = false;
+        // A successful COMMIT is not evidence that the store recovered:
+        // only a successful data statement is, and any of those has
+        // already cleared both the strike count and the deferred close.
+        // So this path touches neither - resetting the strikes here
+        // would let an all-failing batch that commits cleanly keep the
+        // counter at zero forever, and the handle would never give up.
+        bool const deferredClose = pendingClose_;
+        bool const ok = true;
+        if (deferredClose) {
+            // strikes accumulated mid-batch and nothing since succeeded:
+            // the commit above kept whatever the batch did write, so the
+            // broken handle can now close
+            pendingClose_ = false;
+            close();
+        }
+        return ok;
+    }
+    // A failed COMMIT (e.g. SQLITE_BUSY on the non-WAL fallback's lock
+    // upgrade) leaves the transaction open; without an explicit rollback
+    // every later autocommit write would silently join it and be lost
+    // wholesale when the handle closes. It also counts toward the
+    // failure strikes: the successful steps inside a doomed transaction
+    // reset the counter, so a store whose commits persistently fail
+    // would otherwise never report unusable.
+    captureError();
+    rollback();
+    noteFailureCaptured();
+    return false;
+}
+
+void ActivityDB::rollback() {
+    if (!isOpen() || !inTransaction_) return; // mirrors commit()'s guard
+    sqlite3_exec(db_, "ROLLBACK;", nullptr, nullptr, nullptr);
+    inTransaction_ = false;
+    if (pendingClose_) {
+        pendingClose_ = false;
+        close();
+    }
+}
+
+bool ActivityDB::upsertCall(const QString &config, const QString &band,
+                            const CallRecord &record) {
+    if (!isOpen() || !upsertCallStmt_) return false;
+
+    auto *stmt = upsertCallStmt_;
+    sqlite3_reset(stmt);
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    auto call8 = record.callsign.toUtf8();
+    auto through8 = record.through.toUtf8();
+    auto grid8 = record.grid.toUtf8();
+    auto cq8 = toTs(record.cqTimestamp);
+    auto ack8 = toTs(record.ackTimestamp);
+    auto utc8 = toTs(record.utcTimestamp);
+
+    // A silently failed bind would leave the parameter NULL, and a NULL
+    // utc_ts makes the freshness guard unsatisfiable - the row could
+    // never be updated again - so every bind is checked.
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 3, call8.data(), call8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 4, through8.data(), through8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_int(stmt, 5, record.snr);
+    bindRc |= sqlite3_bind_text(stmt, 6, grid8.data(), grid8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_int64(stmt, 7, (sqlite3_int64)record.dial);
+    bindRc |= sqlite3_bind_int(stmt, 8, record.offset);
+    bindRc |= sqlite3_bind_int(stmt, 9, record.bits);
+    bindRc |= sqlite3_bind_double(stmt, 10, record.tdrift);
+    bindRc |= sqlite3_bind_text(stmt, 11, cq8.data(), cq8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 12, ack8.data(), ack8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 13, utc8.data(), utc8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_int(stmt, 14, record.submode);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+    return noteResult(ok);
+}
+
+bool ActivityDB::deleteCall(const QString &config, const QString &band,
+                            const QString &callsign) {
+    if (!isOpen()) return false;
+
+    const char *sql =
+        "DELETE FROM call_activity_v1 "
+        "WHERE config = ? AND band = ? AND callsign = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return noteResult(false);
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    auto call8 = callsign.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 3, call8.data(), call8.size(),
+                                SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        // an unbound parameter makes the WHERE unsatisfiable, and the
+        // zero-row DELETE would still report success
+        sqlite3_finalize(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    int const changed = ok ? sqlite3_changes(db_) : 0;
+    sqlite3_finalize(stmt);
+    // a statement that ran but matched nothing is not a removal - the
+    // row is stored under another band, and the caller must be able to
+    // say so rather than report a silent no-op as success
+    return noteResult(ok) && changed > 0;
+}
+
+bool ActivityDB::deleteCalls(const QString &config, const QString &band) {
+    if (!isOpen()) return false;
+
+    const char *sql =
+        "DELETE FROM call_activity_v1 WHERE config = ? AND band = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return noteResult(false);
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    return noteResult(ok);
+}
+
+QList<ActivityDB::CallRecord> ActivityDB::loadCalls(const QString &config,
+                                                    const QString &band,
+                                                    bool *ok) {
+    QList<CallRecord> result;
+    if (ok) *ok = false;
+    if (!isOpen()) return result;
+
+    const char *sql =
+        "SELECT callsign, through, snr, grid, dial, offset, bits, tdrift, "
+        "       cq_ts, ack_ts, utc_ts, submode "
+        "FROM call_activity_v1 WHERE config = ? AND band = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        noteResult(false);
+        return result;
+    }
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        noteResult(false);
+        return result; // ok stays false: this is a failed read
+    }
+
+    int rc;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        CallRecord r;
+        r.callsign = QString::fromUtf8(
+            (const char *)sqlite3_column_text(stmt, 0),
+            sqlite3_column_bytes(stmt, 0));
+        r.through = QString::fromUtf8(
+            (const char *)sqlite3_column_text(stmt, 1),
+            sqlite3_column_bytes(stmt, 1));
+        r.snr = sqlite3_column_int(stmt, 2);
+        r.grid = QString::fromUtf8(
+            (const char *)sqlite3_column_text(stmt, 3),
+            sqlite3_column_bytes(stmt, 3));
+        r.dial = (quint64)sqlite3_column_int64(stmt, 4);
+        r.offset = sqlite3_column_int(stmt, 5);
+        r.bits = sqlite3_column_int(stmt, 6);
+        r.tdrift = (float)sqlite3_column_double(stmt, 7);
+        r.cqTimestamp = fromTs(stmt, 8);
+        r.ackTimestamp = fromTs(stmt, 9);
+        r.utcTimestamp = fromTs(stmt, 10);
+        r.submode = sqlite3_column_int(stmt, 11);
+        result.append(r);
+    }
+
+    // a read that failed mid-iteration must not pass for a complete
+    // (possibly empty) band - the caller may act on "no data" by
+    // overwriting what is actually there
+    if (ok) *ok = (rc == SQLITE_DONE);
+
+    sqlite3_finalize(stmt);
+    noteResult(rc == SQLITE_DONE);
+    return result;
+}
+
+bool ActivityDB::saveRxText(const QString &config, const QString &band,
+                            const QString &html) {
+    if (!isOpen() || !saveRxTextStmt_) return false;
+
+    auto *stmt = saveRxTextStmt_;
+    sqlite3_reset(stmt);
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    auto h8 = html.toUtf8();
+    int bindRc = SQLITE_OK;
+    // explicit lengths, not -1: strlen would truncate at an embedded NUL
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 3, h8.data(), h8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+    return noteResult(ok);
+}
+
+QString ActivityDB::loadRxText(const QString &config, const QString &band,
+                               bool *ok) {
+    if (ok) *ok = false;
+    if (!isOpen()) return {};
+
+    const char *sql =
+        "SELECT html FROM rx_text_v1 WHERE config = ? AND band = ? LIMIT 1;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        noteResult(false);
+        return {};
+    }
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        noteResult(false);
+        return {}; // ok stays false: this is a failed read
+    }
+
+    QString result;
+    int rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        result = QString::fromUtf8(
+            (const char *)sqlite3_column_text(stmt, 0),
+            sqlite3_column_bytes(stmt, 0));
+        rc = sqlite3_step(stmt);
+    }
+    // SQLITE_DONE means the read completed - either one row or none; an
+    // error must stay distinguishable from "no stored text" (see loadCalls)
+    if (ok) *ok = (rc == SQLITE_DONE);
+
+    sqlite3_finalize(stmt);
+    noteResult(rc == SQLITE_DONE);
+    return result;
+}
+
+bool ActivityDB::clearRxText(const QString &config, const QString &band) {
+    if (!isOpen()) return false;
+
+    const char *sql =
+        "DELETE FROM rx_text_v1 WHERE config = ? AND band = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return noteResult(false);
+
+    auto c8 = config.toUtf8();
+    auto b8 = band.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, b8.data(), b8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        return noteResult(false);
+    }
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    return noteResult(ok);
+}
+
+bool ActivityDB::hasConfig(const QString &config, bool *ok) {
+    if (ok) *ok = false;
+    if (!isOpen()) return false;
+
+    const char *sql =
+        "SELECT 1 FROM call_activity_v1 WHERE config = ? "
+        "UNION ALL SELECT 1 FROM rx_text_v1 WHERE config = ? LIMIT 1;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        noteResult(false);
+        return false;
+    }
+
+    auto c8 = config.toUtf8();
+    int bindRc = SQLITE_OK;
+    bindRc |= sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    bindRc |= sqlite3_bind_text(stmt, 2, c8.data(), c8.size(), SQLITE_TRANSIENT);
+    if (bindRc != SQLITE_OK) {
+        sqlite3_finalize(stmt);
+        noteResult(false);
+        return false;
+    }
+
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    bool const completed = (rc == SQLITE_ROW || rc == SQLITE_DONE);
+    noteResult(completed);
+    if (ok) *ok = completed;
+    return rc == SQLITE_ROW;
+}
+
+bool ActivityDB::clearConfig(const QString &config) {
+    if (!isOpen()) return false;
+
+    const char *sqlCalls =
+        "DELETE FROM call_activity_v1 WHERE config = ?;";
+    const char *sqlText =
+        "DELETE FROM rx_text_v1 WHERE config = ?;";
+
+    auto c8 = config.toUtf8();
+
+    // Both tables or neither. When the caller has not already batched us
+    // into its own transaction we need our own; if it cannot be opened,
+    // do nothing at all rather than destroy one table and report
+    // failure for the other.
+    bool ownTransaction = false;
+    if (!inTransaction_) {
+        if (!begin()) {
+            return false;
+        }
+        ownTransaction = true;
+    }
+    bool ok = true;
+
+    for (const char *sql : {sqlCalls, sqlText}) {
+        if (!isOpen()) { // noteResult() may have closed a failing handle
+            ok = false;
+            break;
+        }
+        sqlite3_stmt *stmt;
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            noteResult(false);
+            ok = false;
+            continue;
+        }
+        if (sqlite3_bind_text(stmt, 1, c8.data(), c8.size(), SQLITE_TRANSIENT) !=
+            SQLITE_OK) {
+            // an unbound config makes the WHERE unsatisfiable, and the
+            // zero-row DELETE would still report success
+            sqlite3_finalize(stmt);
+            noteResult(false);
+            ok = false;
+            continue;
+        }
+        bool stepOk = sqlite3_step(stmt) == SQLITE_DONE;
+        sqlite3_finalize(stmt);
+        noteResult(stepOk);
+        ok = stepOk && ok;
+    }
+
+    if (ownTransaction) {
+        if (ok) {
+            ok = commit();
+        } else {
+            rollback();
+        }
+    }
+
+    return ok;
+}

--- a/JS8_Main/ActivityDB.h
+++ b/JS8_Main/ActivityDB.h
@@ -1,3 +1,7 @@
+/**
+ * @file ActivityDB.h
+ * @brief Declares the SQLite store behind activity.db3 (issue #267).
+ */
 #pragma once
 
 #include <QDateTime>
@@ -18,17 +22,14 @@
  * renames follow automatically, a settings reset orphans the old rows
  * and starts clean, and nothing ever infers that stored rows should
  * be deleted or moved. Deleting a configuration leaves its rows
- * behind (orphaned, never shown); a clone shares its source's id and
- * hence its activity.
+ * behind (orphaned, never shown); a clone mints an id of its own and
+ * takes a copy of its source's rows under it at its first start, so the
+ * two then diverge.
  *
  * Writes happen as activity arrives (write-on-change), not at shutdown,
  * so a crash, power loss, or SIGKILL loses at most the in-flight row
- * rather than everything since the last clean close. The database is
- * opened in WAL mode with synchronous=NORMAL: commits are not
- * individually fsynced, keeping frequent small writes off the GUI
- * thread's critical path, while the WAL keeps an interrupted write from
- * corrupting the store. Where the filesystem refuses WAL, the default
- * rollback journal and full synchronous level are kept instead.
+ * rather than everything since the last clean close; open() covers the
+ * journal and synchronous levels that keep those writes cheap and safe.
  *
  * Rows are never aged out of the store. The callsign-aging setting is
  * applied to what a band load contributes, bounding what a session
@@ -36,16 +37,11 @@
  * activity survives restarts and upgrades without flooding the table.
  *
  * The legacy [CallActivity] group and RXActivity key in the .ini are
- * imported once per configuration, in a single transaction, so a failed
- * import retries on the next start instead of being silently lost. They
- * are left in place for older versions of the software, following the
- * inbox_v1 -> inbox_v2 migration pattern. The import itself happens in
- * UI_Constructor, which knows the ini layout and the band plan. Its
- * fire-once marker lives in the configuration's own settings, so it
- * travels with the configuration through renames and clones; because
- * the data it gates lives here instead, the import also re-runs if the
- * marker is set while this configuration has nothing stored (an ini
- * restored without its database).
+ * imported once per configuration by ActivityStorageController, which
+ * knows the ini layout and the band plan, and left in place for older
+ * versions of the software, following the inbox_v1 -> inbox_v2
+ * migration pattern. The fire-once marker is a row here keyed by the
+ * configuration id, so it follows the data.
  */
 
 struct sqlite3;
@@ -82,44 +78,74 @@ public:
     bool open();
     void close();
 
-    // False after a failed open(), and after enough consecutive
-    // read/write failures that the handle closed itself - so a store
-    // that breaks mid-session (vanished volume, creeping corruption)
-    // eventually reports unusable instead of failing every call forever.
+    /**
+     * @brief Whether the handle is usable.
+     *
+     * False after a failed open(), and after enough consecutive
+     * read/write failures that the handle closed itself - so a store
+     * that breaks mid-session (vanished volume, creeping corruption)
+     * eventually reports unusable instead of failing every call forever.
+     */
     bool isOpen() const;
 
-    // The message captured at the most recent failure. Meaningful after
-    // any call here returns false - including after the failing call ran
-    // further (successful) statements such as a rollback, which would
-    // have reset sqlite3_errmsg() to "not an error".
+    /**
+     * @brief The message captured at the most recent failure.
+     *
+     * Meaningful after any call here returns false - including after the
+     * failing call ran further (successful) statements such as a
+     * rollback, which would have reset sqlite3_errmsg() to "not an
+     * error".
+     */
     QString error() const;
 
-    // Batch several writes into a single transaction (legacy import, QSY
-    // offset rewrites). A failed begin() leaves autocommit in effect, so
-    // the individual writes still land - just unbatched; a failed
-    // commit() rolls the batch back itself, so the connection can never
-    // be left stuck inside a transaction that would silently swallow
-    // every later write.
+    /**
+     * @brief Batch several writes into a single transaction (legacy
+     *        import, QSY offset rewrites).
+     *
+     * A failed begin() leaves autocommit in effect, so the individual
+     * writes still land - just unbatched.
+     */
     bool begin();
+
+    /**
+     * @brief Commit the open transaction.
+     *
+     * A failed commit() rolls the batch back itself, so the connection
+     * can never be left stuck inside a transaction that would silently
+     * swallow every later write.
+     */
     bool commit();
+
+    /// @brief Roll the open transaction back.
     void rollback();
+
+    /// @brief Whether a transaction is currently open.
     bool inTransaction() const { return inTransaction_; }
 
     // Call activity
     bool upsertCall(const QString &config, const QString &band,
                     const CallRecord &record);
-    // True only when a row was actually removed: a statement that ran
-    // but matched nothing (the row is filed under another band) reports
-    // false, so the caller can tell the user rather than appear to have
-    // deleted something.
+    /**
+     * @brief Remove one stored call from a band.
+     * @return True only when a row was actually removed.
+     *
+     * A statement that ran but matched nothing (the row is filed under
+     * another band) reports false, so the caller can tell the user rather
+     * than appear to have deleted something. error() is empty in that
+     * case, and carries a message only when the statement itself failed.
+     */
     bool deleteCall(const QString &config, const QString &band,
                     const QString &callsign);
     bool deleteCalls(const QString &config, const QString &band);
 
-    // Loads a band's rows. A read error is not the same as an empty band:
-    // when ok is provided it reports whether the read completed, so a
-    // transient I/O failure can be kept from being treated as - and then
-    // overwriting - genuinely absent data.
+    /**
+     * @brief Load a band's stored calls.
+     * @param ok When provided, reports whether the read completed.
+     *
+     * A read error is not the same as an empty band, so a transient I/O
+     * failure can be kept from being treated as - and then overwriting -
+     * genuinely absent data.
+     */
     QList<CallRecord> loadCalls(const QString &config, const QString &band,
                                 bool *ok = nullptr);
 
@@ -130,16 +156,54 @@ public:
                        bool *ok = nullptr);
     bool clearRxText(const QString &config, const QString &band);
 
-    // Whether anything is stored for a configuration. When ok is
-    // provided it reports whether the probe completed, so a failed read
-    // is never mistaken for "nothing stored".
-    bool hasConfig(const QString &config, bool *ok = nullptr);
+    /**
+     * @brief Whether the legacy .ini import has run for a configuration.
+     * @param config The id to probe.
+     * @param ok When provided, reports whether the probe completed.
+     * @return True when the marker row is present.
+     */
+    bool hasImported(const QString &config, bool *ok = nullptr);
 
-    // Wipe everything stored for a configuration (the startup
-    // "Reset ... Call Activity and RX History" behavior, the user-facing
-    // "Clear All Activity" actions, and the fresh-start wipe after a
-    // configuration reset).
+    /**
+     * @brief Record that the legacy .ini import has run.
+     * @param config The id the marker is filed under.
+     * @return True when the marker was written or already there.
+     *
+     * Written inside the import's transaction, so a failed import rolls
+     * it back with the rows. clearConfig() deliberately leaves it.
+     */
+    bool markImported(const QString &config);
+
+    /**
+     * @brief Wipe everything stored for a configuration.
+     *
+     * The startup "Reset ... Call Activity and RX History" behavior, the
+     * user-facing "Clear All Activity" actions, and the fresh-start wipe
+     * after a configuration reset. Both tables or neither: where a
+     * transaction cannot be opened it does nothing, rather than destroy
+     * one table and fail on the other.
+     */
     bool clearConfig(const QString &config);
+
+    /**
+     * @brief Copy everything stored for one configuration under a second
+     *        configuration's id.
+     * @param from The id whose rows are read.
+     * @param to The id the copies are written under.
+     * @return True when all three tables were copied.
+     *
+     * The clone half of the scheme above: a cloned configuration mints
+     * its own id and takes a private copy of its source's rows, rather
+     * than sharing them. Rows the destination already holds win, because
+     * a clone whose copy was deferred by a degraded start may have
+     * written newer ones of its own in the meantime. All three tables
+     * or none: the copy runs in one transaction, so a failure leaves
+     * nothing half-copied and the whole copy retries at the next start.
+     * That holds when the copy opens the transaction itself; inside a
+     * caller's transaction a failure is only reported, and the caller's
+     * rollback governs.
+     */
+    bool copyConfig(const QString &from, const QString &to);
 
 private:
     void captureError();
@@ -152,9 +216,7 @@ private:
     bool          inTransaction_;
     bool          pendingClose_; // third strike landed mid-transaction
     int           consecutiveFailures_;
-    // The two hot-path statements are prepared once at open() - which
-    // doubles as a schema validation probe against a pre-existing
-    // incompatible table - and reused for the life of the handle.
+    /// Prepared once at open() and reused for the life of the handle.
     sqlite3_stmt *upsertCallStmt_;
     sqlite3_stmt *saveRxTextStmt_;
 };

--- a/JS8_Main/ActivityDB.h
+++ b/JS8_Main/ActivityDB.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <QDateTime>
+#include <QList>
+#include <QString>
+
+/**
+ * @class ActivityDB
+ * @brief Persistent per-band activity storage (activity.db3).
+ *
+ * Stores the Call Activity table and the RX text history in a dedicated
+ * SQLite database, keyed by (configuration, band, callsign) so that
+ * activity heard on one band can never be attributed to another (issue
+ * #267), and keyed by configuration name so that MultiSettings
+ * configurations each keep their own activity, mirroring the way each
+ * configuration keeps its own settings group in the .ini. The key is
+ * a UUID each configuration generates once into its own settings, so
+ * renames follow automatically, a settings reset orphans the old rows
+ * and starts clean, and nothing ever infers that stored rows should
+ * be deleted or moved. Deleting a configuration leaves its rows
+ * behind (orphaned, never shown); a clone shares its source's id and
+ * hence its activity.
+ *
+ * Writes happen as activity arrives (write-on-change), not at shutdown,
+ * so a crash, power loss, or SIGKILL loses at most the in-flight row
+ * rather than everything since the last clean close. The database is
+ * opened in WAL mode with synchronous=NORMAL: commits are not
+ * individually fsynced, keeping frequent small writes off the GUI
+ * thread's critical path, while the WAL keeps an interrupted write from
+ * corrupting the store. Where the filesystem refuses WAL, the default
+ * rollback journal and full synchronous level are kept instead.
+ *
+ * Rows are never aged out of the store. The callsign-aging setting is
+ * applied to what a band load contributes, bounding what a session
+ * shows, while the store itself keeps everything - so long-term
+ * activity survives restarts and upgrades without flooding the table.
+ *
+ * The legacy [CallActivity] group and RXActivity key in the .ini are
+ * imported once per configuration, in a single transaction, so a failed
+ * import retries on the next start instead of being silently lost. They
+ * are left in place for older versions of the software, following the
+ * inbox_v1 -> inbox_v2 migration pattern. The import itself happens in
+ * UI_Constructor, which knows the ini layout and the band plan. Its
+ * fire-once marker lives in the configuration's own settings, so it
+ * travels with the configuration through renames and clones; because
+ * the data it gates lives here instead, the import also re-runs if the
+ * marker is set while this configuration has nothing stored (an ini
+ * restored without its database).
+ */
+
+struct sqlite3;
+struct sqlite3_stmt;
+
+class ActivityDB {
+public:
+    /**
+     * @brief One persisted Call Activity row - the full CallDetail field
+     *        set, so a band round-trip within a session loses nothing
+     *        (the legacy .ini group stored only a subset).
+     */
+    struct CallRecord {
+        QString   callsign;
+        QString   through;
+        int       snr = 0;
+        QString   grid;
+        quint64   dial = 0;
+        int       offset = 0;
+        int       bits = 0;
+        float     tdrift = 0.0f;
+        QDateTime cqTimestamp;
+        QDateTime ackTimestamp;
+        QDateTime utcTimestamp;
+        int       submode = 0;
+    };
+
+    explicit ActivityDB(const QString &path);
+    ~ActivityDB();
+
+    ActivityDB(const ActivityDB &) = delete;
+    ActivityDB &operator=(const ActivityDB &) = delete;
+
+    bool open();
+    void close();
+
+    // False after a failed open(), and after enough consecutive
+    // read/write failures that the handle closed itself - so a store
+    // that breaks mid-session (vanished volume, creeping corruption)
+    // eventually reports unusable instead of failing every call forever.
+    bool isOpen() const;
+
+    // The message captured at the most recent failure. Meaningful after
+    // any call here returns false - including after the failing call ran
+    // further (successful) statements such as a rollback, which would
+    // have reset sqlite3_errmsg() to "not an error".
+    QString error() const;
+
+    // Batch several writes into a single transaction (legacy import, QSY
+    // offset rewrites). A failed begin() leaves autocommit in effect, so
+    // the individual writes still land - just unbatched; a failed
+    // commit() rolls the batch back itself, so the connection can never
+    // be left stuck inside a transaction that would silently swallow
+    // every later write.
+    bool begin();
+    bool commit();
+    void rollback();
+    bool inTransaction() const { return inTransaction_; }
+
+    // Call activity
+    bool upsertCall(const QString &config, const QString &band,
+                    const CallRecord &record);
+    // True only when a row was actually removed: a statement that ran
+    // but matched nothing (the row is filed under another band) reports
+    // false, so the caller can tell the user rather than appear to have
+    // deleted something.
+    bool deleteCall(const QString &config, const QString &band,
+                    const QString &callsign);
+    bool deleteCalls(const QString &config, const QString &band);
+
+    // Loads a band's rows. A read error is not the same as an empty band:
+    // when ok is provided it reports whether the read completed, so a
+    // transient I/O failure can be kept from being treated as - and then
+    // overwriting - genuinely absent data.
+    QList<CallRecord> loadCalls(const QString &config, const QString &band,
+                                bool *ok = nullptr);
+
+    // RX text history (one HTML document per configuration + band)
+    bool saveRxText(const QString &config, const QString &band,
+                    const QString &html);
+    QString loadRxText(const QString &config, const QString &band,
+                       bool *ok = nullptr);
+    bool clearRxText(const QString &config, const QString &band);
+
+    // Whether anything is stored for a configuration. When ok is
+    // provided it reports whether the probe completed, so a failed read
+    // is never mistaken for "nothing stored".
+    bool hasConfig(const QString &config, bool *ok = nullptr);
+
+    // Wipe everything stored for a configuration (the startup
+    // "Reset ... Call Activity and RX History" behavior, the user-facing
+    // "Clear All Activity" actions, and the fresh-start wipe after a
+    // configuration reset).
+    bool clearConfig(const QString &config);
+
+private:
+    void captureError();
+    bool noteResult(bool ok);
+    void noteFailureCaptured();
+
+    QString       path_;
+    sqlite3      *db_;
+    QString       lastError_;
+    bool          inTransaction_;
+    bool          pendingClose_; // third strike landed mid-transaction
+    int           consecutiveFailures_;
+    // The two hot-path statements are prepared once at open() - which
+    // doubles as a schema validation probe against a pre-existing
+    // incompatible table - and reused for the life of the handle.
+    sqlite3_stmt *upsertCallStmt_;
+    sqlite3_stmt *saveRxTextStmt_;
+};

--- a/JS8_Main/ActivitySettingsKeys.h
+++ b/JS8_Main/ActivitySettingsKeys.h
@@ -1,0 +1,21 @@
+/**
+ * @file ActivitySettingsKeys.h
+ * @brief The settings keys that bind a configuration to its activity.
+ */
+#pragma once
+
+/**
+ * @namespace ActivitySettings
+ * @brief The per-configuration settings keys of the activity store.
+ *
+ * Declared once and shared, because MultiSettings writes the clone
+ * marker that ActivityStorageController reads: were the two spellings to
+ * drift apart, a clone would silently keep its source's id and the two
+ * configurations would then share - and clear - each other's history.
+ */
+namespace ActivitySettings {
+/// The key a configuration stores its activity store id under.
+inline constexpr char ACTIVITY_DB_ID_KEY[] = "ActivityDbId";
+/// The marker that replaces that id in a clone, naming its source.
+inline constexpr char ACTIVITY_DB_CLONE_FROM_KEY[] = "ActivityDbCloneFrom";
+} // namespace ActivitySettings

--- a/JS8_Main/ActivityStorageController.cpp
+++ b/JS8_Main/ActivityStorageController.cpp
@@ -1,0 +1,1241 @@
+/**
+ * @file ActivityStorageController.cpp
+ * @brief Orchestration above ActivityDB - see the class documentation.
+ */
+
+#include "ActivityStorageController.h"
+
+#include "JS8_Main/ActivitySettingsKeys.h"
+#include "JS8_Main/Bands.h"
+#include "JS8_Main/DriftingDateTime.h"
+#include "JS8_Main/Varicode.h"
+#include "JS8_UI/Configuration.h"
+
+#include <QDir>
+#include <QLoggingCategory>
+#include <QScrollBar>
+#include <QSettings>
+#include <QTextBlock>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextDocumentFragment>
+#include <QTextEdit>
+#include <QUuid>
+#include <QVariant>
+
+Q_DECLARE_LOGGING_CATEGORY(activitystoragecontroller_js8)
+
+namespace {
+/**
+ * @brief Order two timestamps, treating an invalid one as the older.
+ * @param lhs The candidate timestamp.
+ * @param rhs The timestamp it must beat.
+ * @return true if lhs is valid and strictly newer than rhs.
+ *
+ * Explicit rather than QDateTime's operators: since Qt 6.8 a comparison
+ * involving an invalid QDateTime is unordered, so both < and <= return
+ * false and a row carrying no timestamp - every manually added station,
+ * and every legacy-imported row - would win. Shared by the seed and by
+ * persistCallActivity()'s cache merge, so both resolve a stored row
+ * against a live one identically.
+ */
+bool newerThan(QDateTime const &lhs, QDateTime const &rhs) {
+    if (!lhs.isValid()) return false;
+    if (!rhs.isValid()) return true;
+    return rhs < lhs;
+}
+
+/**
+ * @brief Carry a displaced row's enrichment onto the row that won.
+ * @param winner The newer row, enriched in place.
+ * @param loser The row it replaces.
+ *
+ * Mirrors the UPSERT's own CASE guards: a bare re-hearing carries no
+ * grid and neither timestamp, so taking them from the row it displaces
+ * keeps what the database correctly kept.
+ */
+void carryEnrichment(CallDetail &winner, CallDetail const &loser) {
+    if (winner.grid.isEmpty()) winner.grid = loser.grid;
+    if (!winner.ackTimestamp.isValid())
+        winner.ackTimestamp = loser.ackTimestamp;
+    if (!winner.cqTimestamp.isValid())
+        winner.cqTimestamp = loser.cqTimestamp;
+}
+} // namespace
+
+ActivityStorageController::ActivityStorageController(Context context,
+                                                     QObject *parent)
+    : QObject(parent), m_ctx(std::move(context)) {
+    m_rxTextSaveTimer.setSingleShot(true);
+    m_rxTextSaveTimer.setInterval(5000);
+    m_rxTextSaveMaxTimer.setSingleShot(true);
+    m_rxTextSaveMaxTimer.setInterval(30000);
+}
+
+ActivityStorageController::~ActivityStorageController() = default;
+
+/**
+ * @brief Wire up the debounced write-on-change persistence of the RX pane.
+ *
+ * Any change re-arms the short debounce, so the stored copy trails the
+ * pane by at most a few seconds instead of being written only at
+ * shutdown. The second timer is armed once and deliberately not
+ * restarted by further changes: sustained sub-interval traffic (fast
+ * submodes, busy nets) would otherwise re-arm the debounce faster than
+ * it can fire, deferring the write - and growing the crash-loss window -
+ * indefinitely.
+ */
+void ActivityStorageController::setupRxTextAutosave() {
+    auto const flushRxText = [this]() {
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        saveRxTextForBand(m_activityBand);
+    };
+    connect(&m_rxTextSaveTimer, &QTimer::timeout, this, flushRxText);
+    connect(&m_rxTextSaveMaxTimer, &QTimer::timeout, this, flushRxText);
+    connect(m_ctx.rxTextEdit->document(), &QTextDocument::contentsChanged,
+            this, [this]() {
+                m_rxTextSaveTimer.start();
+                if (!m_rxTextSaveMaxTimer.isActive()) {
+                    m_rxTextSaveMaxTimer.start();
+                }
+            });
+}
+
+/**
+ * @brief Start the grace period for an as-yet unconfirmed bucket.
+ *
+ * While it runs, RX text for the startup guess is held in the pane rather
+ * than filed under a band the rig has not reported; see
+ * saveRxTextForBand().
+ */
+void ActivityStorageController::beginStartupGrace() {
+    m_activityStartupTimer.start();
+}
+
+/**
+ * @brief Show the legacy ini RX text on a degraded or disabled start.
+ *
+ * Purely for display, and only on a degraded start or a disabled
+ * session: nothing here can reach the store either way. The window's
+ * startup already restored that copy from the ini and never rewrites it,
+ * so showing it beats showing an empty pane.
+ *
+ * The copy's extent is recorded in m_rxTextLegacyBand and
+ * m_rxTextLegacyBlocks, because the recovery seed and the close-time
+ * sweep treat only the text below it as this session's own.
+ */
+void ActivityStorageController::showLegacyRxTextIfDegraded() {
+    if ((activityDB()->isOpen() && !m_activityStoreDisabled) ||
+        m_ctx.config->reset_activity()) {
+        return;
+    }
+    m_ctx.settings->beginGroup("UI_Constructor");
+    auto const legacy = m_ctx.settings->value("RXActivity", "").toString();
+    m_ctx.settings->endGroup();
+    if (legacy.isEmpty()) {
+        return;
+    }
+    m_ctx.rxTextEdit->setHtml(legacy);
+    m_ctx.clearRxFrameBlockNumbers();
+    auto const *doc = m_ctx.rxTextEdit->document();
+    m_rxTextLegacyShown = true;
+    m_rxTextLegacyBand = m_activityBand;
+    m_rxTextLegacyBlocks = doc->blockCount();
+    if (doc->lastBlock().length() <= 1) {
+        // an append may splice into this trailing empty block
+        --m_rxTextLegacyBlocks;
+    }
+}
+
+/**
+ * @brief The rig reported the band the window already believes it is on.
+ * @param band The band reported.
+ *
+ * Confirms the bucket, moving the panes first if they are still showing
+ * the startup guess. The confirmed flag is set only after
+ * switchActivityBucket(), so the flush inside that switch still sees the
+ * outgoing bucket as unconfirmed - otherwise the startup guess's pane,
+ * which by then holds this band's decodes too, is written under the
+ * guessed band.
+ */
+void ActivityStorageController::bandUnchanged(QString const &band) {
+    if (m_activityBandLoaded && m_activityBand != band) {
+        switchActivityBucket(band);
+    }
+    m_activityBandConfirmed = true;
+    m_activityBandConfirmedBands.insert(band);
+}
+
+/**
+ * @brief The rig reported a different band from the one on screen.
+ * @param band The band reported.
+ *
+ * The confirmed flag is set after switchActivityBucket(), so the flush
+ * inside it still treats the outgoing bucket as the startup guess it is.
+ * The band is also recorded as confirmed, so the close-time sweep does
+ * not skip its RX text.
+ */
+void ActivityStorageController::bandChanged(QString const &band) {
+    switchActivityBucket(band);
+    m_activityBandConfirmed = true;
+    m_activityBandConfirmedBands.insert(band);
+}
+
+/**
+ * @brief Move the activity panes from one storage bucket to another.
+ * @param band The bucket to show: a band name, or "" for out-of-plan.
+ *
+ * Every caller - a band change, and the rig's first report correcting the
+ * startup guess - goes through here, so no path can leave one bucket's
+ * activity on screen under another's name, which is issue #267 itself.
+ *
+ * The outgoing bucket, when it is still the startup guess, has its cached
+ * panes dropped rather than parked: its pane may hold text and stations
+ * heard on the band the rig has just reported, and restoring that cache
+ * on a later visit would file them under the guessed band. The bucket
+ * reloads from the store at its next visit. Where the rig has not
+ * reported at all only the two per-bucket panes move; clearActivity()
+ * would also empty the compose box and the decode, command and spot
+ * queues the session has accumulated.
+ */
+void ActivityStorageController::switchActivityBucket(QString const &band) {
+    if (m_activityBandLoaded && m_activityBand == band) {
+        return;
+    }
+    if (m_activityBandLoaded) {
+        if (m_activityBandConfirmed) {
+            saveRxTextForBand(m_activityBand);
+            m_ctx.cacheActivity(m_activityBand);
+        } else {
+            m_ctx.dropBandCache(m_activityBand);
+            m_activitySeeded.remove(m_activityBand);
+            m_rxTextDirtyBands.remove(m_activityBand);
+            if (m_rxTextLegacyShown && m_activityBand == m_rxTextLegacyBand) {
+                m_rxTextLegacyShown = false;
+                m_rxTextLegacyBand.clear();
+                m_rxTextLegacyBlocks = 0;
+            }
+        }
+    }
+
+    if (m_ctx.lastBand->isEmpty()) {
+        m_ctx.rxTextEdit->clear();
+        m_ctx.clearRxFrameBlockNumbers();
+        m_ctx.clearCallActivityPane();
+    } else {
+        m_ctx.clearActivityPanes();
+    }
+    m_ctx.restoreActivity(band);
+}
+
+/**
+ * @brief Take up the bucket the window has just restored on screen.
+ * @param band The bucket now displayed.
+ * @param paneReloaded True when the panes were actually reloaded from the
+ *        RAM band caches; false when re-entering the bucket already on
+ *        screen, where the live panes are newer than any cache entry.
+ *
+ * A reload disarms the saver and resyncs its change tracking, since what
+ * was restored is what the cache holds. A band whose last flush failed is
+ * the exception: its tracking is left at the -1 sentinel so it keeps
+ * reporting unsaved, and its debounce is restarted here, because only
+ * document activity would otherwise arm it and a quiet band would never
+ * retry.
+ */
+void ActivityStorageController::bucketRestored(QString const &band,
+                                               bool paneReloaded) {
+    if (paneReloaded) {
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_rxTextLastSavedRevision =
+            m_rxTextDirtyBands.contains(band)
+                ? -1
+                : m_ctx.rxTextEdit->document()->revision();
+        m_rxTextLastSavedBand = band;
+        if (m_rxTextDirtyBands.contains(band)) {
+            m_rxTextSaveTimer.start();
+        }
+    }
+
+    m_activityBand = band;
+    m_activityBandLoaded = true;
+
+    if (!m_activitySeeded.contains(band)) {
+        seedActivityForBand(band);
+    }
+}
+
+/**
+ * @brief Path of the per-band activity store, beside the message inbox.
+ * @return The absolute native path of activity.db3.
+ */
+QString ActivityStorageController::activityPath() const {
+    return QDir::toNativeSeparators(
+        m_ctx.config->writeable_data_dir().absoluteFilePath("activity.db3"));
+}
+
+/**
+ * @brief The activity store, opened on first use.
+ *
+ * A store that fails to open - or that closed itself after repeated
+ * failures - is retried on a throttle rather than per call. Callers may
+ * always use the returned object: every method on it is a no-op while it
+ * is closed. The throttle is armed however the handle ended up closed, so
+ * a store that breaks mid-session is retried too, and discovering that
+ * self-close here is its one operator-visible signal, the per-write
+ * warnings being suppressed once the handle is closed.
+ *
+ * The status message is emitted once per failure episode rather than once
+ * per retry because showStatusMessage() temporarily hides the statusbar's
+ * mode and frequency readouts, and a blink every thirty seconds would
+ * blank the operator's primary readouts indefinitely. The handle is never
+ * replaced while a batch holds it, or callers inside beginBatch() and
+ * endBatch() would be left with a dangling pointer and a vanished
+ * transaction.
+ */
+ActivityDB *ActivityStorageController::activityDB() {
+    if (m_activityDB && !m_activityDB->isOpen() &&
+        !m_activityDBRetryTimer.isValid()) {
+        m_activityDBRetryTimer.start();
+        qCWarning(activitystoragecontroller_js8)
+            << "activity store closed after repeated failures:"
+            << m_activityDB->error();
+        m_ctx.showStatusMessage(
+            tr("Activity database unavailable - activity is not being "
+               "saved (%1)")
+                .arg(m_activityDB->error()));
+    }
+    bool const retrying = m_activityDB && !m_activityDB->isOpen() &&
+                          m_activityDBRetryTimer.isValid() &&
+                          m_activityDBRetryTimer.hasExpired(30 * 1000) &&
+                          m_activityBatchDepth == 0;
+    if (retrying) {
+        m_activityDB.reset();
+    }
+    if (!m_activityDB) {
+        m_activityDB = std::make_unique<ActivityDB>(activityPath());
+        if (!m_activityDB->open()) {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not open" << activityPath() << ":"
+                << m_activityDB->error();
+            if (!retrying) {
+                m_ctx.showStatusMessage(
+                    tr("Activity database unavailable - activity will "
+                       "not be saved (%1)")
+                        .arg(m_activityDB->error()));
+            }
+            m_activityDBRetryTimer.start();
+        } else {
+            m_activityDBRetryTimer.invalidate();
+            if (retrying && m_activityBandLoaded &&
+                !m_activitySeeded.contains(m_activityBand)) {
+                // deferred: a seed re-enters this accessor
+                QTimer::singleShot(0, this, [this]() {
+                    if (m_activityBandLoaded &&
+                        !m_activitySeeded.contains(m_activityBand)) {
+                        seedActivityForBand(m_activityBand);
+                        m_ctx.displayActivity();
+                    }
+                });
+            }
+        }
+    }
+    return m_activityDB.get();
+}
+
+/**
+ * @brief Open a write batch; nested batches share one transaction.
+ *
+ * Batches are lazy: opening one records only the intent and the
+ * transaction starts at the first write inside it, so a decode cycle that
+ * persists nothing costs nothing - no BEGIN IMMEDIATE taking the write
+ * lock on the GUI thread with its 5 s busy timeout, and no store-reopen
+ * probe on behalf of a caller that never writes. The outermost begin also
+ * clears the previous batch's failed-BEGIN mark, so a batch whose
+ * transaction could not be opened does not suppress the next one's.
+ */
+void ActivityStorageController::beginBatch() {
+    if (m_activityBatchDepth == 0) {
+        m_activityBatchBeginFailed = false;
+    }
+    ++m_activityBatchDepth;
+}
+
+/**
+ * @brief Start the transaction a batch deferred, at its first write.
+ *
+ * A BEGIN that fails is attempted once per batch rather than once per
+ * write, each attempt being able to block the GUI thread for the busy
+ * timeout. That batch's writes then run as autocommits, as they do after
+ * any failed BEGIN, and the failure counts toward the store's self-close.
+ */
+void ActivityStorageController::startActivityBatchIfPending() {
+    if (m_activityBatchDepth > 0 && !m_activityBatchBeginFailed &&
+        m_activityDB && m_activityDB->isOpen() &&
+        !m_activityDB->inTransaction()) {
+        m_activityBatchBeginFailed = !m_activityDB->begin();
+    }
+}
+
+/// @brief Close the outermost batch, committing its transaction.
+void ActivityStorageController::endBatch() {
+    if (m_activityBatchDepth == 1) {
+        // the handle begin() used, so the accessor cannot swap in a
+        // fresh one first
+        if (m_activityDB && m_activityDB->inTransaction() &&
+            !m_activityDB->commit()) {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not commit activity batch:"
+                << m_activityDB->error();
+        }
+        m_activityBatchBeginFailed = false;
+    }
+    --m_activityBatchDepth;
+}
+
+/**
+ * @brief The storage key for this MultiSettings configuration.
+ * @return A UUID generated once into the configuration's own settings.
+ *
+ * Activity is keyed by that id rather than by the configuration name: it
+ * follows the configuration through renames automatically, is purged
+ * with the settings by MultiSettings' "Reset Configuration" - orphaning
+ * the old rows and starting clean, with no wipe heuristics that could
+ * misfire - and a clone, arriving with a marker naming its source in
+ * place of an id, mints a fresh one here and takes a copy of its
+ * source's rows under it at its first start, so the two then diverge.
+ * The id is captured once, because during a configuration switch
+ * MultiSettings updates its state before this window closes and the
+ * outgoing configuration's final flush must not land under the incoming
+ * configuration's key.
+ */
+QString ActivityStorageController::activityConfigId() const {
+    if (m_activityConfigId.isEmpty()) {
+        auto id = m_ctx.settings->value(ActivitySettings::ACTIVITY_DB_ID_KEY)
+                      .toString();
+        if (id.isEmpty()) {
+            id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+            m_ctx.settings->setValue(ActivitySettings::ACTIVITY_DB_ID_KEY,
+                                     id);
+        }
+        m_activityConfigId = id;
+    }
+    return m_activityConfigId;
+}
+
+/// @brief Convert a displayed call detail into a storable row.
+ActivityDB::CallRecord
+ActivityStorageController::toCallRecord(CallDetail const &d) const {
+    ActivityDB::CallRecord r;
+    r.callsign = d.call.trimmed();
+    r.through = d.through;
+    r.snr = d.snr;
+    r.grid = d.grid;
+    r.dial = d.dial;
+    r.offset = d.offset;
+    r.bits = d.bits;
+    r.tdrift = d.tdrift;
+    r.cqTimestamp = d.cqTimestamp;
+    r.ackTimestamp = d.ackTimestamp;
+    r.utcTimestamp = d.utcTimestamp;
+    r.submode = d.submode;
+    return r;
+}
+
+/// @brief Convert a stored row back into a displayed call detail.
+CallDetail ActivityStorageController::fromCallRecord(
+    ActivityDB::CallRecord const &r) const {
+    CallDetail cd = {};
+    cd.call = r.callsign;
+    cd.through = r.through;
+    cd.snr = r.snr;
+    cd.grid = r.grid;
+    cd.dial = r.dial;
+    cd.offset = r.offset;
+    cd.bits = r.bits;
+    cd.tdrift = r.tdrift;
+    cd.cqTimestamp = r.cqTimestamp;
+    cd.ackTimestamp = r.ackTimestamp;
+    cd.utcTimestamp = r.utcTimestamp;
+    cd.submode = r.submode;
+    return cd;
+}
+
+/**
+ * @brief Write one call-activity row to the store.
+ * @param d The row to persist.
+ * @param fallbackToCurrentBand File a row carrying no dial under the
+ *        bucket on screen; passed only where that is genuinely where it
+ *        belongs (a manually added station, a logbook grid backfill, and
+ *        qsy()'s offset write-back for those same rows).
+ *
+ * Rows are filed under the band of their own dial frequency, because
+ * processDecodeEvent() deliberately stamps records with the capture-time
+ * dial so that decodes completing after a QSY, and inbox senders, keep
+ * the band they were heard on - keying by the live band would be issue
+ * #267 all over again. A dial that resolves to no band files under "",
+ * the out-of-plan bucket.
+ *
+ * A row filed under a bucket other than the one on screen is merged into
+ * that bucket's cached table rather than forcing a re-seed of it: the
+ * seed's RX-text merge is not idempotent against a pane restored from the
+ * RAM cache, so un-seeding a bucket to refresh its call table would
+ * splice that bucket's stored history in behind itself on every return
+ * visit. The merge follows the seed's own rules - a cached row with a
+ * strictly newer timestamp stands, otherwise the incoming row replaces it
+ * and carries the cached row's enrichment across.
+ */
+void ActivityStorageController::persistCallActivity(
+    CallDetail const &d, bool fallbackToCurrentBand) {
+    if (m_activityStoreDisabled || d.call.trimmed().isEmpty()) {
+        return;
+    }
+
+    auto band = m_ctx.config->bands()->find(d.dial);
+    if (band.isEmpty() && d.dial == 0 && fallbackToCurrentBand &&
+        m_activityBandConfirmed) {
+        band = m_activityBand;
+    }
+
+    auto const r = toCallRecord(d);
+    activityDB(); // resolve (and possibly recover) before the batch opens
+    startActivityBatchIfPending();
+    if (band != m_activityBand) {
+        auto cached = m_ctx.callActivityBandCache->find(band);
+        if (cached != m_ctx.callActivityBandCache->end()) {
+            auto const key = d.call.trimmed();
+            auto const shown = cached->constFind(key);
+            if (shown == cached->constEnd() ||
+                !newerThan(shown->utcTimestamp, d.utcTimestamp)) {
+                auto row = d;
+                if (shown != cached->constEnd()) {
+                    carryEnrichment(row, *shown);
+                }
+                (*cached)[key] = row;
+            }
+        }
+    }
+
+    if (!activityDB()->upsertCall(activityConfigId(), band, r) &&
+        activityDB()->isOpen()) {
+        qCWarning(activitystoragecontroller_js8)
+            << "could not persist call activity for" << r.callsign << ":"
+            << lastStoreError();
+    }
+}
+
+/**
+ * @brief Rewrite every displayed offset after a waterfall nudge.
+ * @param hzDelta The shift applied to the receiver's offsets.
+ *
+ * Only rows whose own dial belongs to the current band are written back:
+ * entries displayed here but keyed to another band (post-QSY stragglers,
+ * inbox senders carrying their message's dial) did not QSY, and dial-less
+ * RAM-only entries must not be promoted into the store by a nudge. The
+ * dial-less rows this bucket does store - manual adds - take the
+ * fallback path instead, since Bands::find(0) resolves to "".
+ */
+void ActivityStorageController::adjustCallActivityOffsets(int hzDelta) {
+    if (m_ctx.callActivity->isEmpty()) {
+        return;
+    }
+    beginBatch();
+    for (auto [key, value] : m_ctx.callActivity->asKeyValueRange()) {
+        value.offset -= hzDelta;
+        auto const rowBand = m_ctx.config->bands()->find(value.dial);
+        if (rowBand == m_activityBand) {
+            persistCallActivity(value);
+        } else if (value.dial == 0 && !m_activityBand.isEmpty()) {
+            persistCallActivity(value, true);
+        }
+    }
+    endBatch();
+}
+
+/**
+ * @brief HTML of everything below the degraded start's legacy ini copy.
+ * @param doc The RX pane's document, or a cached copy of it.
+ * @return The session text below the copy, or "" when there is none.
+ */
+QString
+ActivityStorageController::htmlBelowLegacyCopy(QTextDocument *doc) const {
+    if (doc->blockCount() <= m_rxTextLegacyBlocks) {
+        return {};
+    }
+    QTextCursor cursor(doc->findBlockByNumber(m_rxTextLegacyBlocks));
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    if (cursor.selection().toPlainText().trimmed().isEmpty()) {
+        return {};
+    }
+    return cursor.selection().toHtml();
+}
+
+/**
+ * @brief Merge a bucket's stored history into the session, once.
+ * @param band The bucket to seed.
+ *
+ * Runs at a bucket's first visit each session. Stored rows are merged
+ * under whatever the session already holds - the newer of the two wins
+ * per callsign, and stored enrichment (grid, ACK and CQ marks) survives a
+ * bare re-hearing - and the stored RX text is placed behind the pane's
+ * own lines. Until a bucket has been seeded its RX-text saves are
+ * suppressed, so a document that does not contain the stored history can
+ * never overwrite it; a failed seed is retried at the flush cadence, at
+ * the next visit to the bucket, and after the store reopens. A failed
+ * load returns without touching the RX pane, or the retry would splice
+ * the stored text in a second time.
+ *
+ * The callsign-aging setting is applied to what the store contributes,
+ * mirroring master's save-time prune: it bounds what a session can load,
+ * while the store itself keeps everything, and without it stale rows
+ * reach consumers that put an SNR on the air. Rows the session has
+ * already heard are never pruned. The enrichment carried across from a
+ * stored row mirrors the UPSERT's own CASE guards, so a bare re-hearing
+ * cannot drop from the table what the database correctly kept.
+ */
+void ActivityStorageController::seedActivityForBand(QString const &band) {
+    if (m_activityStoreDisabled || !activityDB()->isOpen()) {
+        return;
+    }
+    auto const config = activityConfigId();
+
+    bool callsOk = false;
+    auto const stored = activityDB()->loadCalls(config, band, &callsOk);
+    if (callsOk) {
+        auto const aging = m_ctx.config->callsign_aging();
+        auto const agingNow = DriftingDateTime::currentDateTimeUtc();
+
+        QMap<QString, CallDetail> merged;
+        foreach (auto const &r, stored) {
+            auto const cd = fromCallRecord(r);
+            if (aging && !m_ctx.callActivity->contains(cd.call) &&
+                m_ctx.inboxCounts->value(cd.call, 0) <= 0 &&
+                cd.utcTimestamp.isValid() &&
+                cd.utcTimestamp.secsTo(agingNow) / 60 >= aging) {
+                continue;
+            }
+            merged[cd.call] = cd;
+        }
+
+        QList<CallDetail> ramWinners;
+        for (auto it = m_ctx.callActivity->constBegin();
+             it != m_ctx.callActivity->constEnd(); ++it) {
+            auto const found = merged.constFind(it.key());
+            if (found != merged.constEnd() &&
+                newerThan(found->utcTimestamp, it->utcTimestamp)) {
+                continue;
+            }
+
+            auto live = it.value();
+            if (found != merged.constEnd()) {
+                carryEnrichment(live, *found);
+                if (newerThan(it->utcTimestamp, found->utcTimestamp)) {
+                    ramWinners.append(live);
+                }
+            } else {
+                ramWinners.append(live);
+            }
+            merged[it.key()] = live;
+        }
+        *m_ctx.callActivity = merged;
+        if (!ramWinners.isEmpty()) {
+            beginBatch();
+            foreach (auto const &cd, ramWinners) {
+                if (cd.dial == 0) {
+                    // Bands::find(0) is "": this would file it out-of-plan
+                    continue;
+                }
+                persistCallActivity(cd);
+            }
+            endBatch();
+        }
+    } else {
+        qCWarning(activitystoragecontroller_js8)
+            << "could not load call activity for band" << band << ":"
+            << lastStoreError();
+        return;
+    }
+
+    // re-resolve: a load can self-close the handle a pointer came from
+    bool rxOk = false;
+    auto const storedHtml = activityDB()->loadRxText(config, band, &rxOk);
+    if (rxOk) {
+        auto sessionHtml = QString{};
+        if (m_rxTextLegacyShown && band == m_rxTextLegacyBand) {
+            sessionHtml = htmlBelowLegacyCopy(m_ctx.rxTextEdit->document());
+        } else if (!m_ctx.rxTextEdit->toPlainText().trimmed().isEmpty()) {
+            sessionHtml = m_ctx.rxTextEdit->toHtml();
+        }
+        if (!storedHtml.isEmpty()) {
+            m_ctx.rxTextEdit->setHtml(storedHtml);
+            if (!sessionHtml.isEmpty()) {
+                auto cursor = QTextCursor(m_ctx.rxTextEdit->document());
+                cursor.movePosition(QTextCursor::End);
+                if (cursor.block().length() > 1) {
+                    cursor.insertBlock();
+                }
+                cursor.insertHtml(sessionHtml);
+            }
+            m_ctx.clearRxFrameBlockNumbers();
+            QTimer::singleShot(0, this, [this]() {
+                m_ctx.rxTextEdit->verticalScrollBar()->setValue(
+                    m_ctx.rxTextEdit->verticalScrollBar()->maximum());
+            });
+        }
+        if (m_rxTextLegacyShown && band == m_rxTextLegacyBand) {
+            m_rxTextLegacyShown = false;
+            m_rxTextLegacyBand.clear();
+            m_rxTextLegacyBlocks = 0;
+        }
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_rxTextLastSavedBand = band;
+        if (sessionHtml.isEmpty()) {
+            m_rxTextLastSavedRevision =
+                m_ctx.rxTextEdit->document()->revision();
+        } else {
+            m_rxTextLastSavedRevision = -1;
+        }
+    } else {
+        qCWarning(activitystoragecontroller_js8)
+            << "could not load RX text for band" << band << ":"
+            << lastStoreError();
+    }
+
+    if (callsOk && rxOk) {
+        m_activitySeeded.insert(band);
+        qCDebug(activitystoragecontroller_js8)
+            << "loaded" << stored.size() << "stored calls for band" << band;
+        if (m_rxTextLastSavedRevision == -1) {
+            saveRxTextForBand(band);
+        }
+    }
+}
+
+/**
+ * @brief Persist the RX pane for a bucket, if it is safe to do so.
+ * @param band The bucket the pane's contents belong to.
+ *
+ * Declines while the bucket is only the startup guess (RX text carries no
+ * per-line frequency, so it could be filed under a band it was never
+ * heard on) or while the bucket is unseeded, marking it for the
+ * close-time sweep in both cases. An empty pane removes the stored row
+ * rather than storing an empty one, or the debounced save after a Clear
+ * would resurrect it. The startup grace period covers a station running
+ * without CAT, and an unseeded bucket retries its seed at this flush
+ * cadence, so one transient store failure cannot disable persistence for
+ * a whole parked session.
+ *
+ * After a failed save the debounce is re-armed here, because the flush
+ * stopped both timers before calling and only new document activity would
+ * otherwise restart them - a band that fell quiet after one failed save
+ * would never try again. It is re-armed at sixty seconds rather than
+ * five, the thirty-second cap timer then setting the actual retry
+ * cadence: a store that stays unwritable would otherwise serialise the
+ * whole unbounded RX document on the GUI thread every five seconds
+ * forever. That back-off lasts until the next successful save.
+ */
+void ActivityStorageController::saveRxTextForBand(QString const &band) {
+    if (m_activityStoreDisabled) {
+        return;
+    }
+    if (!m_activityBandConfirmed && band == m_activityBand &&
+        m_activityStartupTimer.isValid() &&
+        !m_activityStartupTimer.hasExpired(60 * 1000)) {
+        m_rxTextDirtyBands.insert(band);
+        return;
+    }
+    if (!m_activitySeeded.contains(band)) {
+        m_rxTextDirtyBands.insert(band);
+        if (band == m_activityBand && !m_activityShuttingDown &&
+            activityDB()->isOpen() &&
+            (!m_seedRetryTimer.isValid() ||
+             m_seedRetryTimer.hasExpired(30 * 1000))) {
+            m_seedRetryTimer.start();
+            seedActivityForBand(band);
+            m_ctx.displayActivity();
+        }
+        return;
+    }
+
+    int const revision = m_ctx.rxTextEdit->document()->revision();
+    if (revision == m_rxTextLastSavedRevision &&
+        band == m_rxTextLastSavedBand) {
+        return;
+    }
+
+    activityDB(); // resolve (and possibly recover) before the batch opens
+    startActivityBatchIfPending();
+
+    bool ok;
+    if (m_ctx.rxTextEdit->document()->isEmpty()) {
+        ok = activityDB()->clearRxText(activityConfigId(), band);
+    } else {
+        ok = activityDB()->saveRxText(activityConfigId(), band,
+                                      m_ctx.rxTextEdit->toHtml());
+    }
+
+    if (ok) {
+        m_rxTextLastSavedRevision = revision;
+        m_rxTextLastSavedBand = band;
+        m_rxTextDirtyBands.remove(band);
+        if (m_rxTextSaveTimer.interval() != 5000) {
+            m_rxTextSaveTimer.setInterval(5000);
+        }
+    } else {
+        m_rxTextDirtyBands.insert(band);
+        if (!m_activityShuttingDown && band == m_activityBand) {
+            m_rxTextSaveTimer.start(60 * 1000);
+            if (!m_rxTextSaveMaxTimer.isActive()) {
+                m_rxTextSaveMaxTimer.start();
+            }
+        }
+        if (activityDB()->isOpen()) {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not save RX text for band" << band << ":"
+                << lastStoreError();
+        }
+    }
+}
+
+/**
+ * @brief Erase the legacy [CallActivity] group and RXActivity key.
+ *
+ * Master's writeSettings() rewrote both at every close, so a reset
+ * genuinely destroyed the old data; leaving them in place would keep a
+ * full, readable copy of everything the user asked to erase, and would
+ * let an older build or a later un-tick resurrect it.
+ */
+void ActivityStorageController::purgeLegacyActivityIni() {
+    m_ctx.settings->beginGroup("CallActivity");
+    m_ctx.settings->remove("");
+    m_ctx.settings->endGroup();
+    m_ctx.settings->beginGroup("UI_Constructor");
+    m_ctx.settings->remove("RXActivity");
+    m_ctx.settings->endGroup();
+}
+
+/**
+ * @brief One-time import of the legacy .ini activity data into
+ *        activity.db3, following the inbox_v1 -> inbox_v2 pattern: the
+ *        legacy [CallActivity] group and RXActivity key are read once and
+ *        left in place for older versions of the software.
+ * @return True when the configuration needs no further import.
+ *
+ * Rows are attributed to the band each record was heard on, via its
+ * stored dial; the RX text blob has no per-line frequency, so it goes to
+ * the band of the last-known dial. The fire-once marker is a row in the
+ * store keyed by the configuration id, so it follows the data it gates;
+ * one that cannot be read defers the import rather than risk a re-import.
+ *
+ * A clone arrives with a marker naming its source in place of an id of
+ * its own; the source's rows are copied under the fresh id first, and the
+ * marker is removed only once that copy has run, so a failure retries at
+ * the next start rather than losing the inherited history. The import is
+ * one transaction with the marker inside it: marking a partial import
+ * done would lose the failed rows, the ini group never being re-read.
+ *
+ * A requested reset that cannot run disables the session, and the legacy
+ * ini keys are purged even then: they hold a copy of the same activity,
+ * which a later reopen or un-tick would otherwise splice back.
+ */
+bool ActivityStorageController::importLegacyActivityIfNeeded() {
+    auto *db = activityDB();
+    auto const cloneFrom =
+        m_ctx.settings->value(ActivitySettings::ACTIVITY_DB_CLONE_FROM_KEY)
+            .toString();
+    if (!db->isOpen()) {
+        if (m_ctx.config->reset_activity()) {
+            m_activityStoreDisabled = true;
+            purgeLegacyActivityIni();
+        }
+        if (!cloneFrom.isEmpty()) {
+            m_activityStoreDisabled = true;
+            qCWarning(activitystoragecontroller_js8)
+                << "clone copy deferred: the activity store is closed";
+            m_ctx.showStatusMessage(
+                tr("Activity database unavailable - the cloned "
+                   "configuration's history will be copied at the next "
+                   "start"));
+        }
+        return false;
+    }
+
+    auto const config = activityConfigId();
+
+    if (!cloneFrom.isEmpty()) {
+        if (m_ctx.config->reset_activity()) {
+            m_ctx.settings->remove(
+                ActivitySettings::ACTIVITY_DB_CLONE_FROM_KEY);
+        } else if (db->copyConfig(cloneFrom, config)) {
+            m_ctx.settings->remove(
+                ActivitySettings::ACTIVITY_DB_CLONE_FROM_KEY);
+            qCDebug(activitystoragecontroller_js8)
+                << "copied stored activity of configuration" << cloneFrom
+                << "into" << config;
+        } else {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not copy the cloned configuration's activity:"
+                << db->error();
+            m_ctx.showStatusMessage(
+                tr("Could not copy the cloned configuration's activity - "
+                   "activity will not be saved this session (%1)")
+                    .arg(db->error()));
+            m_activityStoreDisabled = true;
+            return false;
+        }
+    }
+
+    if (m_ctx.config->reset_activity()) {
+        if (!db->clearConfig(config)) {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not reset stored activity:" << db->error();
+            m_ctx.showStatusMessage(
+                tr("Could not reset stored activity - activity will not "
+                   "be saved this session (%1)")
+                    .arg(db->error()));
+            m_activityStoreDisabled = true;
+            purgeLegacyActivityIni();
+            return false;
+        }
+
+        purgeLegacyActivityIni();
+        if (!db->markImported(config)) {
+            qCWarning(activitystoragecontroller_js8)
+                << "could not record the import marker:" << db->error();
+        }
+        return true;
+    }
+
+    bool probeOk = false;
+    if (db->hasImported(config, &probeOk)) return true;
+    if (!probeOk) {
+        qCWarning(activitystoragecontroller_js8)
+            << "could not read the import marker:" << db->error();
+        return false;
+    }
+
+    m_ctx.settings->beginGroup("Common");
+    auto const lastDial =
+        m_ctx.settings
+            ->value("DialFreq", QVariant::fromValue<Radio::Frequency>(
+                                    m_ctx.defaultDial))
+            .value<Radio::Frequency>();
+    m_ctx.settings->endGroup();
+    auto const fallbackBand = m_ctx.config->bands()->find(lastDial);
+
+    if (!db->begin()) {
+        qCWarning(activitystoragecontroller_js8)
+            << "could not start legacy activity import:" << db->error();
+        return false;
+    }
+
+    bool allOk = true;
+    int imported = 0;
+    m_ctx.settings->beginGroup("CallActivity");
+    foreach (auto call, m_ctx.settings->allKeys()) {
+        auto values = m_ctx.settings->value(call).toMap();
+
+        ActivityDB::CallRecord r;
+        r.callsign = call;
+        r.snr = values.value("snr", -64).toInt();
+        r.grid = values.value("grid", "").toString();
+        r.dial = values.value("dial", 0).value<Radio::Frequency>();
+        r.offset = values.value("freq", 0).toInt();
+        r.tdrift = values.value("tdrift", 0).toFloat();
+        r.ackTimestamp = values.value("ackTimestamp").toDateTime();
+        r.utcTimestamp = values.value("utcTimestamp").toDateTime();
+        r.submode = values.value("submode", Varicode::JS8CallNormal).toInt();
+
+        auto band = m_ctx.config->bands()->find(r.dial);
+        if (band.isEmpty() && r.dial == 0) {
+            band = fallbackBand;
+        }
+
+        if (db->upsertCall(config, band, r)) {
+            ++imported;
+        } else {
+            allOk = false;
+        }
+    }
+    m_ctx.settings->endGroup();
+
+    m_ctx.settings->beginGroup("UI_Constructor");
+    auto const html = m_ctx.settings->value("RXActivity", "").toString();
+    m_ctx.settings->endGroup();
+
+    if (!html.isEmpty()) {
+        bool haveOk = false;
+        auto const have = db->loadRxText(config, fallbackBand, &haveOk);
+        if (haveOk && have.isEmpty()) {
+            allOk = db->saveRxText(config, fallbackBand, html) && allOk;
+        } else if (!haveOk) {
+            allOk = false;
+        }
+    }
+
+    allOk = db->markImported(config) && allOk;
+    if (!allOk || !db->commit()) {
+        db->rollback();
+        qCWarning(activitystoragecontroller_js8)
+            << "legacy activity import failed - will retry on next start:"
+            << db->error();
+        return false;
+    }
+
+    qCDebug(activitystoragecontroller_js8)
+        << "imported" << imported << "legacy call activity rows into"
+        << activityPath();
+    return true;
+}
+
+/**
+ * @brief Storage half of the "Clear All Activity" action.
+ *
+ * Called after the window has cleared the panes: clearActivity()'s inbox
+ * refresh re-persists every unread sender and would otherwise repopulate
+ * the store the wipe had just emptied.
+ *
+ * "All" spans every band and the session's RAM band caches, not just the
+ * bucket on screen: dropping only the current band's rows would let the
+ * others reload as if never cleared, and a hop back to a previously
+ * visited band would restore its pre-clear snapshot for the next
+ * debounced save to write straight back into the store. Every bucket is
+ * then marked unseeded - on success because the store is empty, on
+ * failure because the panes no longer hold the stored history and a save
+ * would destroy it. A session whose store is disabled empties the panes
+ * and says so, rather than reporting a delete that did not happen.
+ */
+void ActivityStorageController::clearAllActivity() {
+    if (m_activityStoreDisabled) {
+        m_ctx.showStatusMessage(
+            tr("Activity is not being saved this session - the stored "
+               "history was not cleared"));
+    }
+    bool const stored = m_activityStoreDisabled ||
+                        activityDB()->clearConfig(activityConfigId());
+    if (!stored) {
+        qCWarning(activitystoragecontroller_js8)
+            << "clear all activity failed:" << lastStoreError();
+        m_ctx.showStatusMessage(tr("Could not clear stored activity (%1)")
+                                    .arg(lastStoreError()));
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_seedRetryTimer.start();
+    }
+
+    purgeLegacyActivityIni();
+
+    m_ctx.clearBandCaches();
+    m_rxTextDirtyBands.clear();
+    m_activitySeeded.clear();
+    m_rxTextLegacyShown = false;
+    m_rxTextLegacyBand.clear();
+    m_rxTextLegacyBlocks = 0;
+    m_rxTextLastSavedRevision = m_ctx.rxTextEdit->document()->revision();
+    m_rxTextLastSavedBand = m_activityBand;
+}
+
+/**
+ * @brief The "Clear RX Activity" action, store and pane.
+ *
+ * The store is cleared before the pane: if the delete fails the pane
+ * keeps its text, so no later seed can splice the stored history back in
+ * and re-persist it, silently undoing the clear. On that failure the
+ * bucket is forced unseeded before saves resume - the pane no longer
+ * holds the stored text, so a save would overwrite it - and the debounce
+ * the pane clear arms is stopped, or its retry would seed the bucket and
+ * put the "cleared" text back on screen. A session whose store is
+ * disabled clears the pane and says so, rather than reporting a delete
+ * that did not happen.
+ */
+void ActivityStorageController::clearRxActivity() {
+    if (m_activityStoreDisabled) {
+        m_ctx.showStatusMessage(
+            tr("Activity is not being saved this session - the stored "
+               "history was not cleared"));
+    }
+    bool const stored =
+        m_activityStoreDisabled ||
+        activityDB()->clearRxText(activityConfigId(), m_activityBand);
+    if (!stored) {
+        qCWarning(activitystoragecontroller_js8)
+            << "clear RX activity failed:" << lastStoreError();
+        m_ctx.showStatusMessage(tr("Could not clear stored RX text (%1)")
+                                    .arg(lastStoreError()));
+        m_activitySeeded.remove(m_activityBand);
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_seedRetryTimer.start();
+    }
+    if (m_rxTextLegacyShown && m_activityBand == m_rxTextLegacyBand) {
+        m_rxTextLegacyShown = false;
+        m_rxTextLegacyBand.clear();
+        m_rxTextLegacyBlocks = 0;
+    }
+    // clears unconditionally - this is also the compose box's way out
+    m_ctx.clearRxPane();
+    m_rxTextLastSavedRevision = m_ctx.rxTextEdit->document()->revision();
+    m_rxTextLastSavedBand = m_activityBand;
+    m_rxTextDirtyBands.remove(m_activityBand);
+}
+
+/**
+ * @brief The "Clear Call Activity" action, store and pane.
+ *
+ * Bucket-scoped by design: a row displayed here but stored under another
+ * band (its own dial's band - e.g. a decode that completed just after a
+ * QSY) is that band's history, which this action cannot see and must not
+ * destroy. Unread inbox senders reappear regardless - they are
+ * re-synthesized from inbox.db3, the source of truth for unread mail.
+ *
+ * On a failed delete the bucket is deliberately not un-seeded: the RX
+ * pane is untouched and still contains this bucket's stored text, so
+ * forcing a re-seed would splice that history in a second time. The rows
+ * simply return at the next session, which the message above reports. A
+ * session whose store is disabled clears the pane and says so, rather
+ * than reporting a delete that did not happen.
+ */
+void ActivityStorageController::clearCallActivity() {
+    if (m_activityStoreDisabled) {
+        m_ctx.showStatusMessage(
+            tr("Activity is not being saved this session - the stored "
+               "history was not cleared"));
+    }
+    if (!m_activityStoreDisabled &&
+        !activityDB()->deleteCalls(activityConfigId(), m_activityBand)) {
+        qCWarning(activitystoragecontroller_js8)
+            << "clear call activity failed:" << lastStoreError();
+        m_ctx.showStatusMessage(
+            tr("Could not clear stored call activity (%1)")
+                .arg(lastStoreError()));
+    }
+    m_ctx.clearCallActivityPane();
+}
+
+/**
+ * @brief Drop one station's stored row for the bucket on screen.
+ * @param call The callsign the operator removed from the table.
+ *
+ * Bucket-scoped: only the on-screen bucket's stored row is deleted. A row
+ * the same station holds on another band is that band's history, which
+ * this context cannot see and must not destroy; an unread inbox sender
+ * reappears regardless, re-synthesized from inbox.db3. Rows are stored
+ * under the trimmed callsign. A closed store is reported as such, rather
+ * than as the row being filed under another band; that state is read
+ * before the delete, so a delete whose own failure closes the handle
+ * still reports only the removal. That message is read off the handle
+ * directly, as endBatch() does, so a third-strike self-close cannot add
+ * the accessor's own status message on top of this one.
+ */
+void ActivityStorageController::removeStoredCall(QString const &call) {
+    if (m_activityStoreDisabled || !m_activityBandLoaded) {
+        return;
+    }
+    bool const wasOpen = activityDB()->isOpen();
+    if (activityDB()->deleteCall(activityConfigId(), m_activityBand,
+                                 call.trimmed())) {
+        return;
+    }
+    if (!wasOpen) {
+        m_ctx.showStatusMessage(
+            tr("Activity database unavailable - %1 was not removed from "
+               "stored activity")
+                .arg(call));
+        return;
+    }
+    auto const why = lastStoreError();
+    m_ctx.showStatusMessage(
+        why.isEmpty()
+            ? tr("%1 is stored under another band and will return there")
+                  .arg(call)
+            : tr("Could not remove %1 from stored activity (%2)")
+                  .arg(call, why));
+}
+
+/**
+ * @brief Final flush of everything the session has not written yet.
+ *
+ * Covers anything the debounced save timer has not written. A bucket that
+ * was never seeded - the store was unusable at its first visit - gets one
+ * last seed attempt first, because saves are suppressed while unseeded
+ * and the whole session's RX text would otherwise be discarded, where the
+ * legacy ini path always wrote it. m_activityShuttingDown is then set so
+ * that the flush cannot re-enter the seed's own retry, and its table
+ * rebuild, while the window is tearing down.
+ *
+ * Bands whose text never reached the store - visited while it was down,
+ * or left before a seed succeeded - survive only in the RAM band cache,
+ * and this is their last chance. A seeded bucket's cached document
+ * already contains that bucket's stored history, so it replaces the
+ * stored row; an unseeded one does not, so it is appended to whatever is
+ * stored rather than replacing it.
+ */
+void ActivityStorageController::flushOnClose() {
+    if (!m_activitySeeded.contains(m_activityBand) &&
+        !m_activityStoreDisabled && activityDB()->isOpen()) {
+        seedActivityForBand(m_activityBand);
+    }
+    m_activityShuttingDown = true;
+    m_activityBandConfirmed = true;
+    saveRxTextForBand(m_activityBand);
+
+    if (!m_activityStoreDisabled) {
+        foreach (auto const &dirty, m_rxTextDirtyBands) {
+            if (dirty == m_activityBand ||
+                !m_ctx.rxTextBandCache->contains(dirty)) {
+                continue;
+            }
+            if (!m_activityBandConfirmedBands.contains(dirty)) {
+                continue;
+            }
+            auto cached = m_ctx.rxTextBandCache->value(dirty);
+            QTextDocument cachedDoc;
+            cachedDoc.setHtml(cached);
+            if (m_rxTextLegacyShown && dirty == m_rxTextLegacyBand) {
+                cached = htmlBelowLegacyCopy(&cachedDoc);
+                if (cached.isEmpty()) {
+                    continue;
+                }
+                cachedDoc.setHtml(cached);
+            }
+            if (cachedDoc.isEmpty()) {
+                // a cleared pane serialises to a full HTML skeleton
+                activityDB()->clearRxText(activityConfigId(), dirty);
+                continue;
+            }
+
+            if (m_activitySeeded.contains(dirty)) {
+                activityDB()->saveRxText(activityConfigId(), dirty,
+                                         cached);
+                continue;
+            }
+
+            bool ok = false;
+            auto const storedHtml =
+                activityDB()->loadRxText(activityConfigId(), dirty, &ok);
+            if (!ok) {
+                continue;
+            }
+            if (storedHtml.isEmpty()) {
+                activityDB()->saveRxText(activityConfigId(), dirty,
+                                         cached);
+                continue;
+            }
+            QTextDocument doc;
+            doc.setHtml(storedHtml);
+            QTextCursor cursor(&doc);
+            cursor.movePosition(QTextCursor::End);
+            if (cursor.block().length() > 1) {
+                cursor.insertBlock();
+            }
+            cursor.insertHtml(cached);
+            activityDB()->saveRxText(activityConfigId(), dirty,
+                                     doc.toHtml());
+        }
+    }
+}
+
+Q_LOGGING_CATEGORY(activitystoragecontroller_js8,
+                   "activitystoragecontroller.js8", QtWarningMsg)

--- a/JS8_Main/ActivityStorageController.cpp
+++ b/JS8_Main/ActivityStorageController.cpp
@@ -197,7 +197,10 @@ void ActivityStorageController::bandChanged(QString const &band) {
  * reloads from the store at its next visit. Where the rig has not
  * reported at all only the two per-bucket panes move; clearActivity()
  * would also empty the compose box and the decode, command and spot
- * queues the session has accumulated.
+ * queues the session has accumulated. That state is the confirmation
+ * flag, not an empty bucket name: "" is also the out-of-plan bucket,
+ * whose Band Activity must not follow the panes to a band the rig later
+ * reports.
  */
 void ActivityStorageController::switchActivityBucket(QString const &band) {
     if (m_activityBandLoaded && m_activityBand == band) {
@@ -219,7 +222,7 @@ void ActivityStorageController::switchActivityBucket(QString const &band) {
         }
     }
 
-    if (m_ctx.lastBand->isEmpty()) {
+    if (!m_activityBandConfirmed) {
         m_ctx.rxTextEdit->clear();
         m_ctx.clearRxFrameBlockNumbers();
         m_ctx.clearCallActivityPane();

--- a/JS8_Main/ActivityStorageController.h
+++ b/JS8_Main/ActivityStorageController.h
@@ -1,0 +1,303 @@
+/**
+ * @file ActivityStorageController.h
+ * @brief Declares the orchestration layer above ActivityDB (issue #267).
+ */
+#pragma once
+
+#include "JS8_Main/ActivityDB.h"
+#include "JS8_Main/CallDetail.h"
+
+#include <QElapsedTimer>
+#include <QMap>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QTimer>
+
+#include <functional>
+#include <memory>
+
+class Configuration;
+class QSettings;
+class QTextDocument;
+class QTextEdit;
+
+/**
+ * @class ActivityStorageController
+ * @brief Orchestrates per-band persistent activity storage (issue #267).
+ *
+ * ActivityDB is the SQLite wrapper; this is everything above it - which
+ * bucket the panes belong to, when a bucket's stored history may be
+ * merged into the session, when the RX pane may be written back, the
+ * write batching, the one-time legacy .ini import, and the close-time
+ * sweep. It deliberately does not know about UI_Constructor: the window
+ * state it needs arrives through Context, so the window keeps only a
+ * pointer to this object and thin delegating calls.
+ *
+ * "Bucket" rather than "band" throughout: the bucket a pane belongs to
+ * is a band name, or "" - the out-of-plan bucket, which persists
+ * activity heard on dials outside the band plan (transverter IFs,
+ * channelized operation) the way the legacy un-banded ini did.
+ */
+class ActivityStorageController : public QObject {
+    Q_OBJECT
+
+public:
+    /**
+     * @brief The window state and operations this controller needs.
+     *
+     * A deliberately narrow, explicit interface. The pointers are to
+     * objects that outlive this controller; the callbacks are the only
+     * way it reaches back into the window.
+     */
+    struct Context {
+        Configuration const *config = nullptr;
+        /// The current configuration's settings (legacy import, config id).
+        QSettings *settings = nullptr;
+        /// The dial the ini falls back to when it has never recorded one.
+        Radio::Frequency defaultDial = 0;
+        QTextEdit *rxTextEdit = nullptr;
+        /// The band the rig last reported; "" before its first report.
+        QString const *lastBand = nullptr;
+        /// The live Call Activity table; a seed merges stored rows into it.
+        QMap<QString, CallDetail> *callActivity = nullptr;
+        /// Unread-message counts; unread senders are exempt from aging.
+        QMap<QString, int> const *inboxCounts = nullptr;
+        QMap<QString, QMap<QString, CallDetail>> *callActivityBandCache =
+            nullptr;
+        QMap<QString, QString> const *rxTextBandCache = nullptr;
+
+        std::function<void(QString const &)> showStatusMessage;
+        std::function<void()> displayActivity;
+        std::function<void()> clearRxFrameBlockNumbers;
+        /// UI_Constructor::clearActivity - every pane and session queue.
+        std::function<void()> clearActivityPanes;
+        /// UI_Constructor::clearRXActivity.
+        std::function<void()> clearRxPane;
+        /// UI_Constructor::clearCallActivity.
+        std::function<void()> clearCallActivityPane;
+        /// UI_Constructor::cacheActivity - park the panes under a bucket.
+        std::function<void(QString const &)> cacheActivity;
+        /// Forget every per-band cache the window holds for one bucket.
+        std::function<void(QString const &)> dropBandCache;
+        /// UI_Constructor::restoreActivity - show a bucket's panes.
+        std::function<void(QString const &)> restoreActivity;
+        /// Empty every RAM band cache (the "Clear All Activity" action).
+        std::function<void()> clearBandCaches;
+    };
+
+    /**
+     * @brief Construct the controller over an already-built window.
+     * @param context The window state and callbacks it may use.
+     * @param parent Optional QObject parent. UI_Constructor passes none
+     *  and holds the sole owning std::unique_ptr instead: the window is
+     *  the only thing that ever refers to this object, and single
+     *  ownership keeps the teardown order obvious rather than relying on
+     *  a member unique_ptr running before ~QObject reaps its children.
+     */
+    explicit ActivityStorageController(Context context,
+                                       QObject *parent = nullptr);
+    ~ActivityStorageController() override;
+
+    // Startup
+
+    /**
+     * @brief Import the legacy .ini activity once per configuration.
+     * @return true if an import ran to completion this call.
+     */
+    bool importLegacyActivityIfNeeded();
+    /**
+     * @brief Start the grace period allowed for the rig to report a band.
+     *
+     * Until it does (or this lapses, covering Rig=None), RX text is not
+     * filed: it carries no per-line frequency, so the bucket would only
+     * be the previous session's guess.
+     */
+    void beginStartupGrace();
+    /**
+     * @brief Show the legacy .ini RX text when the store is unavailable.
+     *
+     * Display only, and recorded as such, so a later recovery does not
+     * bank a second copy of history the import already holds.
+     */
+    void showLegacyRxTextIfDegraded();
+    /**
+     * @brief Connect the debounced RX-text write-back timers.
+     */
+    void setupRxTextAutosave();
+
+    // The bucket on screen
+
+    /// @brief The bucket the on-screen panes belong to ("" = out-of-plan).
+    QString currentBucket() const { return m_activityBand; }
+    /// @brief Whether a bucket has been restored into the panes yet.
+    bool isBucketLoaded() const { return m_activityBandLoaded; }
+    /**
+     * @brief The rig reported the band the panes already hold.
+     * @param band The confirmed band name.
+     */
+    void bandUnchanged(QString const &band);
+    /**
+     * @brief The rig reported a different band; park and switch buckets.
+     * @param band The newly confirmed band name.
+     */
+    void bandChanged(QString const &band);
+    /**
+     * @brief Record that the window has restored a bucket's panes.
+     * @param band The bucket restored.
+     * @param paneReloaded true if the RX pane was replaced wholesale.
+     */
+    void bucketRestored(QString const &band, bool paneReloaded);
+
+    // Writes
+
+    /**
+     * @brief Upsert one station into the store.
+     * @param d The station as displayed.
+     * @param fallbackToCurrentBand File under the on-screen bucket when
+     *  the record carries no usable dial frequency of its own.
+     */
+    void persistCallActivity(CallDetail const &d,
+                             bool fallbackToCurrentBand = false);
+    /**
+     * @brief Shift every stored offset for the current bucket.
+     * @param hzDelta Signed offset change in Hz.
+     */
+    void adjustCallActivityOffsets(int hzDelta);
+    /**
+     * @brief Open a write batch; nested batches share one transaction.
+     */
+    void beginBatch();
+    /**
+     * @brief Close a write batch, committing at the outermost level.
+     */
+    void endBatch();
+
+    // User-facing clears
+
+    /// @brief Drop every stored row, across all buckets and both panes.
+    void clearAllActivity();
+    /// @brief Drop the current bucket's stored RX text.
+    void clearRxActivity();
+    /// @brief Drop the current bucket's stored Call Activity rows.
+    void clearCallActivity();
+    /**
+     * @brief Drop one station from the current bucket.
+     * @param call The callsign to remove.
+     */
+    void removeStoredCall(QString const &call);
+
+    // Shutdown
+
+    /**
+     * @brief Final flush: sweep every confirmed bucket's pending writes.
+     */
+    void flushOnClose();
+
+private:
+    QString activityPath() const;
+    ActivityDB *activityDB();
+    QString activityConfigId() const;
+    // single conversion pair, so a CallDetail field added later fails to
+    // persist/restore loudly at the one site instead of silently in
+    // hand-copied blocks
+    ActivityDB::CallRecord toCallRecord(CallDetail const &) const;
+    CallDetail fromCallRecord(ActivityDB::CallRecord const &) const;
+    void seedActivityForBand(QString const &band);
+    QString htmlBelowLegacyCopy(QTextDocument *doc) const;
+    void purgeLegacyActivityIni();
+    /**
+     * @brief The store's last error, read off the handle directly.
+     *
+     * Failure branches read this rather than activityDB()->error(): a
+     * failure that was the handle's third strike has just closed it, and
+     * going through the accessor would push its own status message on top
+     * of the one the caller is about to show.
+     */
+    QString lastStoreError() const {
+        return m_activityDB ? m_activityDB->error() : QString{};
+    }
+    void startActivityBatchIfPending();
+    void saveRxTextForBand(QString const &band);
+    void switchActivityBucket(QString const &band);
+
+    Context m_ctx;
+
+    std::unique_ptr<ActivityDB> m_activityDB;
+    QElapsedTimer m_activityDBRetryTimer; // throttles reopen attempts
+    // The storage bucket the on-screen call activity / RX text belongs
+    // to: a band name, or "" - the out-of-plan bucket, which persists
+    // activity heard on dials outside the band plan (transverter IFs,
+    // channelized operation) the way the legacy un-banded ini did.
+    // Usually this equals the rig's band, but at startup the panes are
+    // preloaded from the last-known dial before the rig has reported
+    // one, and that data must be flushed to - and cleared as - the
+    // bucket it was loaded from, not whatever the rig later reports.
+    QString m_activityBand;
+    bool m_activityBandLoaded = false; // false until the first restore
+    // Buckets whose stored rows have been seeded into the session's RAM
+    // caches. Seeding happens once per bucket per session; until it has
+    // succeeded, RX-text saves for that bucket are suppressed - the
+    // on-screen document does not contain the stored history, so saving
+    // it would overwrite (or, empty, delete) that history.
+    QSet<QString> m_activitySeeded;
+    // Degraded start: the store was down, so readSettings showed the
+    // legacy ini copy in the RX pane. That copy is history the one-time
+    // import already banked - only text BELOW it is session text. These
+    // mark which bucket shows it and how many blocks it spans, so the
+    // recovery seed and the close-time sweep never merge a second copy
+    // of the history behind the stored one. The flag, not the band name,
+    // says whether a copy is shown: "" is a bucket in its own right.
+    bool m_rxTextLegacyShown = false;
+    QString m_rxTextLegacyBand;
+    int m_rxTextLegacyBlocks = 0;
+    // Depth counter so nested write bursts (a decode drain that calls
+    // refreshInboxCounts, say) share one transaction.
+    int m_activityBatchDepth = 0;
+    // Set when the current batch's BEGIN failed, so it is attempted once
+    // per batch rather than once per write; cleared at each outermost
+    // beginBatch() and endBatch().
+    bool m_activityBatchBeginFailed = false;
+    // Bands whose latest RX text never reached the store (a flush failed
+    // while the store was down): restores re-arm their saves and
+    // closeEvent sweeps the stragglers from the RAM band cache.
+    QSet<QString> m_rxTextDirtyBands;
+    // Set when a requested startup reset, or a clone's inherited-activity
+    // copy, could not be applied: nothing is read or written for the rest
+    // of the session, so no write of this session can be destroyed by the
+    // wipe that retries at the next start.
+    bool m_activityStoreDisabled = false;
+    // Set in flushOnClose: suppresses the seed retry that a final flush
+    // would otherwise trigger while the window is tearing down.
+    bool m_activityShuttingDown = false;
+    // False until the rig has actually reported a band, and set
+    // unconditionally at close. While false the storage bucket is only
+    // the last session's guess, so RX text - which has no per-line
+    // frequency - must not be filed under it. The startup grace period
+    // (covering Rig=None) does not set this: it is honoured by the
+    // RX-text save alone.
+    bool m_activityBandConfirmed = false;
+    // Buckets the rig has actually reported this session. The close-time
+    // sweep writes only these: a bucket that was never confirmed holds a
+    // pane that may contain text heard on a different band - its cache is
+    // dropped, not parked, when the switch leaves it.
+    QSet<QString> m_activityBandConfirmedBands;
+    QElapsedTimer m_activityStartupTimer;
+    QElapsedTimer m_seedRetryTimer; // throttles failed-seed retries
+    QTimer m_rxTextSaveTimer; // debounces RX-text writes to activity.db3
+    // Cap on the debounce: sustained sub-interval document changes (busy
+    // nets, fast submodes) restart m_rxTextSaveTimer indefinitely, so this
+    // timer - armed once and not restarted - bounds how stale the stored
+    // copy can get.
+    QTimer m_rxTextSaveMaxTimer;
+    // Storage id captured at first use: MultiSettings updates its
+    // current configuration BEFORE the window closes during a
+    // configuration switch, so reading it at close time would file the
+    // outgoing configuration's activity under the incoming one.
+    mutable QString m_activityConfigId;
+    // Skip unchanged RX-text rewrites via the document's revision
+    // counter - unlike hashing toHtml(), checking it costs nothing, so
+    // an idle debounce tick never serializes the (unbounded) document.
+    int m_rxTextLastSavedRevision = -1;
+    QString m_rxTextLastSavedBand;
+};

--- a/JS8_Main/ActivityStorageController.h
+++ b/JS8_Main/ActivityStorageController.h
@@ -223,79 +223,35 @@ private:
 
     std::unique_ptr<ActivityDB> m_activityDB;
     QElapsedTimer m_activityDBRetryTimer; // throttles reopen attempts
-    // The storage bucket the on-screen call activity / RX text belongs
-    // to: a band name, or "" - the out-of-plan bucket, which persists
-    // activity heard on dials outside the band plan (transverter IFs,
-    // channelized operation) the way the legacy un-banded ini did.
-    // Usually this equals the rig's band, but at startup the panes are
-    // preloaded from the last-known dial before the rig has reported
-    // one, and that data must be flushed to - and cleared as - the
-    // bucket it was loaded from, not whatever the rig later reports.
     QString m_activityBand;
     bool m_activityBandLoaded = false; // false until the first restore
-    // Buckets whose stored rows have been seeded into the session's RAM
-    // caches. Seeding happens once per bucket per session; until it has
-    // succeeded, RX-text saves for that bucket are suppressed - the
-    // on-screen document does not contain the stored history, so saving
-    // it would overwrite (or, empty, delete) that history.
     QSet<QString> m_activitySeeded;
     // Degraded start: the store was down, so readSettings showed the
-    // legacy ini copy in the RX pane. That copy is history the one-time
-    // import already banked - only text BELOW it is session text. These
-    // mark which bucket shows it and how many blocks it spans, so the
-    // recovery seed and the close-time sweep never merge a second copy
-    // of the history behind the stored one. The flag, not the band name,
-    // says whether a copy is shown: "" is a bucket in its own right.
+    // legacy ini copy in the RX pane.
     bool m_rxTextLegacyShown = false;
     QString m_rxTextLegacyBand;
     int m_rxTextLegacyBlocks = 0;
-    // Depth counter so nested write bursts (a decode drain that calls
-    // refreshInboxCounts, say) share one transaction.
+    // Depth counter
     int m_activityBatchDepth = 0;
-    // Set when the current batch's BEGIN failed, so it is attempted once
-    // per batch rather than once per write; cleared at each outermost
-    // beginBatch() and endBatch().
     bool m_activityBatchBeginFailed = false;
-    // Bands whose latest RX text never reached the store (a flush failed
-    // while the store was down): restores re-arm their saves and
-    // closeEvent sweeps the stragglers from the RAM band cache.
     QSet<QString> m_rxTextDirtyBands;
     // Set when a requested startup reset, or a clone's inherited-activity
-    // copy, could not be applied: nothing is read or written for the rest
-    // of the session, so no write of this session can be destroyed by the
-    // wipe that retries at the next start.
+    // copy, could not be applied
     bool m_activityStoreDisabled = false;
-    // Set in flushOnClose: suppresses the seed retry that a final flush
-    // would otherwise trigger while the window is tearing down.
+    // Set in flushOnClose
     bool m_activityShuttingDown = false;
     // False until the rig has actually reported a band, and set
-    // unconditionally at close. While false the storage bucket is only
-    // the last session's guess, so RX text - which has no per-line
-    // frequency - must not be filed under it. The startup grace period
-    // (covering Rig=None) does not set this: it is honoured by the
-    // RX-text save alone.
+    // unconditionally at close
     bool m_activityBandConfirmed = false;
-    // Buckets the rig has actually reported this session. The close-time
-    // sweep writes only these: a bucket that was never confirmed holds a
-    // pane that may contain text heard on a different band - its cache is
-    // dropped, not parked, when the switch leaves it.
+    // Buckets the rig has actually reported this session
     QSet<QString> m_activityBandConfirmedBands;
     QElapsedTimer m_activityStartupTimer;
     QElapsedTimer m_seedRetryTimer; // throttles failed-seed retries
     QTimer m_rxTextSaveTimer; // debounces RX-text writes to activity.db3
-    // Cap on the debounce: sustained sub-interval document changes (busy
-    // nets, fast submodes) restart m_rxTextSaveTimer indefinitely, so this
-    // timer - armed once and not restarted - bounds how stale the stored
-    // copy can get.
     QTimer m_rxTextSaveMaxTimer;
-    // Storage id captured at first use: MultiSettings updates its
-    // current configuration BEFORE the window closes during a
-    // configuration switch, so reading it at close time would file the
-    // outgoing configuration's activity under the incoming one.
+    // Storage id captured at first use
     mutable QString m_activityConfigId;
-    // Skip unchanged RX-text rewrites via the document's revision
-    // counter - unlike hashing toHtml(), checking it costs nothing, so
-    // an idle debounce tick never serializes the (unbounded) document.
+    // Skip unchanged RX-text rewrites via the document's revision counter
     int m_rxTextLastSavedRevision = -1;
     QString m_rxTextLastSavedBand;
 };

--- a/JS8_Main/ActivityStorageController.h
+++ b/JS8_Main/ActivityStorageController.h
@@ -57,8 +57,6 @@ public:
         /// The dial the ini falls back to when it has never recorded one.
         Radio::Frequency defaultDial = 0;
         QTextEdit *rxTextEdit = nullptr;
-        /// The band the rig last reported; "" before its first report.
-        QString const *lastBand = nullptr;
         /// The live Call Activity table; a seed merges stored rows into it.
         QMap<QString, CallDetail> *callActivity = nullptr;
         /// Unread-message counts; unread senders are exempt from aging.

--- a/JS8_Main/CallDetail.h
+++ b/JS8_Main/CallDetail.h
@@ -1,0 +1,33 @@
+/**
+ * @file CallDetail.h
+ * @brief Defines the Call Activity record shared by the UI and storage.
+ */
+#pragma once
+
+#include "JS8_Main/Radio.h"
+
+#include <QDateTime>
+#include <QString>
+
+/**
+ * @brief One station in the Call Activity table.
+ *
+ * Lives outside mainwindow.h so that the storage layer (ActivityDB and
+ * ActivityStorageController) can convert to and from it without pulling
+ * the whole window in. UI_Constructor aliases it, so it is still spelled
+ * CallDetail everywhere it was before.
+ */
+struct CallDetail {
+    QString call;
+    QString through;
+    QString grid;
+    Radio::Frequency dial;
+    int offset;
+    QDateTime cqTimestamp;
+    QDateTime ackTimestamp;
+    QDateTime utcTimestamp;
+    int snr;
+    int bits;
+    float tdrift;
+    int submode;
+};

--- a/JS8_Main/Inbox.cpp
+++ b/JS8_Main/Inbox.cpp
@@ -78,7 +78,7 @@ QString column_text(sqlite3_stmt* const stmt, int const iCol) {
 // Message's params() now has a real column behind it.
 Message row_to_message(sqlite3_stmt* const stmt) {
     auto const type = column_text(stmt, 1);
-    auto const dial = sqlite3_column_int(stmt, 11);
+    auto const dial = (quint64)sqlite3_column_int64(stmt, 11);
     auto const offset = sqlite3_column_int(stmt, 12);
 
     QVariantMap params{
@@ -277,7 +277,11 @@ bool Inbox::migrateV1ToV2() {
         sqlite3_bind_text(ins, 9, g8.constData(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(ins, 10, e8.constData(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_double(ins, 11, params.value("TDRIFT").toDouble());
-        sqlite3_bind_int(ins, 12, params.value("DIAL").toInt());
+        // 64-bit: a dial is a Radio::Frequency, and the band plan runs
+        // past 2^31 Hz - truncating it to 0 would file the sender's
+        // activity under no band at all
+        sqlite3_bind_int64(ins, 12,
+                           (sqlite3_int64)params.value("DIAL").toULongLong());
         sqlite3_bind_int(ins, 13, params.value("OFFSET").toInt());
         sqlite3_bind_int(ins, 14, params.value("SNR").toInt());
         sqlite3_bind_int(ins, 15, params.value("SUBMODE").toInt());
@@ -466,7 +470,8 @@ int bind_message_fields(sqlite3_stmt* const stmt, int idx, Message const& m,
     sqlite3_bind_text(stmt, idx++, b.grid.constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, idx++, b.extra.constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_double(stmt, idx++, params.value("TDRIFT").toDouble());
-    sqlite3_bind_int(stmt, idx++, params.value("DIAL").toInt());
+    sqlite3_bind_int64(stmt, idx++,
+                       (sqlite3_int64)params.value("DIAL").toULongLong());
     sqlite3_bind_int(stmt, idx++, params.value("OFFSET").toInt());
     sqlite3_bind_int(stmt, idx++, params.value("SNR").toInt());
     sqlite3_bind_int(stmt, idx++, params.value("SUBMODE").toInt());

--- a/JS8_Main/Inbox.cpp
+++ b/JS8_Main/Inbox.cpp
@@ -277,9 +277,6 @@ bool Inbox::migrateV1ToV2() {
         sqlite3_bind_text(ins, 9, g8.constData(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(ins, 10, e8.constData(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_double(ins, 11, params.value("TDRIFT").toDouble());
-        // 64-bit: a dial is a Radio::Frequency, and the band plan runs
-        // past 2^31 Hz - truncating it to 0 would file the sender's
-        // activity under no band at all
         sqlite3_bind_int64(ins, 12,
                            (sqlite3_int64)params.value("DIAL").toULongLong());
         sqlite3_bind_int(ins, 13, params.value("OFFSET").toInt());

--- a/JS8_Main/MultiSettings.cpp
+++ b/JS8_Main/MultiSettings.cpp
@@ -7,6 +7,7 @@
 #include "JS8MessageBox.h"
 #include "JS8_Include/SettingsGroup.h"
 #include "JS8_Include/pimpl_impl.h"
+#include "JS8_Main/ActivitySettingsKeys.h"
 #include "qt_helpers.h"
 
 #include <QAction>
@@ -173,6 +174,10 @@ class MultiSettings::impl final : public QObject {
 
     // write the settings values from the dictionary to the current group
     void load_from(Dictionary const &, bool add_placeholder = true);
+
+    // swap a clone's inherited activity store id for the marker that
+    // makes it take its own copy of the stored activity
+    void mark_activity_clone(Dictionary &);
 
     // clone this configuration
     void clone_configuration(QMenu *, QMenu const *);
@@ -572,6 +577,38 @@ void MultiSettings::impl::select_configuration(QString const &target_name) {
     }
 }
 
+/**
+ * @brief Mark a dictionary that is about to become a clone's settings.
+ * @param settings The copied settings, modified in place.
+ *
+ * A configuration's stored activity lives in activity.db3 keyed by an id
+ * the configuration generates once into its own settings, so a clone
+ * that inherited that id verbatim would read and write its source's
+ * rows: a clear, a reset or a per-band wipe in either would destroy the
+ * other's history. Replacing the id with a marker naming the source
+ * leaves the clone with no id of its own, so it mints a fresh one at its
+ * first start and copies the source's rows under it, after which the two
+ * diverge.
+ *
+ * A source that has never needed an id has none, and the clone then has
+ * nothing to copy: the dictionary is left as it is. A pending clone (already
+ * carrying the marker) keeps it, so the new clone inherits the same
+ * grandparent the source itself will use once its own copy runs.
+ */
+void MultiSettings::impl::mark_activity_clone(Dictionary &settings) {
+    if (settings.contains(ActivitySettings::ACTIVITY_DB_CLONE_FROM_KEY)) {
+        settings.remove(ActivitySettings::ACTIVITY_DB_ID_KEY);
+        return;
+    }
+    if (!settings.contains(ActivitySettings::ACTIVITY_DB_ID_KEY)) {
+        return;
+    }
+    auto const source_id =
+        settings.take(ActivitySettings::ACTIVITY_DB_ID_KEY);
+    settings.insert(ActivitySettings::ACTIVITY_DB_CLONE_FROM_KEY,
+                    source_id);
+}
+
 void MultiSettings::impl::clone_configuration(QMenu *parent_menu,
                                               QMenu const *menu) {
     auto const &current_group = settings_.group();
@@ -602,6 +639,7 @@ void MultiSettings::impl::clone_configuration(QMenu *parent_menu,
     } while (settings_.childGroups().contains(new_name) ||
              new_name == current_);
     SettingsGroup new_group{&settings_, new_name};
+    mark_activity_clone(source_settings);
     load_from(source_settings);
 
     // insert the new configuration sub menu in the parent menu
@@ -660,6 +698,7 @@ void MultiSettings::impl::clone_into_configuration(QMenu const *menu) {
                 SettingsGroup source_group{&settings_, source_name};
                 new_settings_ = get_settings();
             }
+            mark_activity_clone(new_settings_);
 
             // purge target settings and replace
             if (target_name == current_) {

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -1151,9 +1151,6 @@ UI_Constructor::UI_Constructor(QString const &program_info,
         } else {
             if (Varicode::isValidCallsign(callsign, nullptr)) {
                 if (!m_callActivity.contains(callsign)) {
-                    // adding a callsign that is already listed is a
-                    // no-op - overwriting would blank the entry (and
-                    // the store deliberately ignores a blank re-add)
                     CallDetail cd = {};
                     cd.call = callsign;
                     m_callActivity[callsign] = cd;

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -71,6 +71,56 @@ UI_Constructor::UI_Constructor(QString const &program_info,
       m_aprsClient{new APRSISClient{"rotate.aprs2.net", 14580}},
       m_aprsInboundRelay{nullptr} {
     ui->setupUi(this);
+
+    // Per-band persistent activity storage (activity.db3) - issue #267.
+    // Built as soon as the panes exist, because readSettings() below runs
+    // the one-time legacy import and the startup preload through it.
+    {
+        ActivityStorageController::Context context;
+        context.config = &m_config;
+        context.settings = m_settings;
+        context.defaultDial = Default::DIAL_FREQUENCY;
+        context.rxTextEdit = ui->textEditRX;
+        context.lastBand = &m_lastBand;
+        context.callActivity = &m_callActivity;
+        context.inboxCounts = &m_rxInboxCountCache;
+        context.callActivityBandCache = &m_callActivityBandCache;
+        context.rxTextBandCache = &m_rxTextBandCache;
+        context.showStatusMessage = [this](QString const &message) {
+            showStatusMessage(message);
+        };
+        context.displayActivity = [this]() { displayActivity(true); };
+        context.clearRxFrameBlockNumbers = [this]() {
+            m_rxFrameBlockNumbers.clear();
+        };
+        context.clearActivityPanes = [this]() { clearActivity(); };
+        context.clearRxPane = [this]() { clearRXActivity(); };
+        context.clearCallActivityPane = [this]() { clearCallActivity(); };
+        context.cacheActivity = [this](QString const &key) {
+            cacheActivity(key);
+        };
+        context.restoreActivity = [this](QString const &key) {
+            restoreActivity(key);
+        };
+        context.clearBandCaches = [this]() {
+            m_callActivityBandCache.clear();
+            m_rxTextBandCache.clear();
+            m_bandActivityBandCache.clear();
+            m_heardGraphIncomingBandCache.clear();
+            m_heardGraphOutgoingBandCache.clear();
+        };
+        context.dropBandCache = [this](QString const &key) {
+            m_callActivityBandCache.remove(key);
+            m_rxTextBandCache.remove(key);
+            m_bandActivityBandCache.remove(key);
+            m_heardGraphIncomingBandCache.remove(key);
+            m_heardGraphOutgoingBandCache.remove(key);
+        };
+        // no QObject parent: the unique_ptr is the sole owner
+        m_activityStorage =
+            std::make_unique<ActivityStorageController>(std::move(context));
+    }
+
     ui->frame->setStyleSheet(logFrameStyle());
     ui->logWidget->setStyleSheet(Styles::LogWidgetStyle);
     ui->dialFreqUpButton->setStyleSheet(Styles::DialFreqUpDownButtonStyle);
@@ -807,14 +857,6 @@ UI_Constructor::UI_Constructor(QString const &program_info,
 
     auto clearActionAll = new QAction(QString("Clear All Lists"), nullptr);
     connect(clearActionAll, &QAction::triggered, this, [this]() {
-        if (QMessageBox::Yes !=
-            QMessageBox::question(
-                this, "Clear All Activity",
-                "Are you sure you would like to clear all activity?",
-                QMessageBox::Yes | QMessageBox::No)) {
-            return;
-        }
-
         on_actionClear_All_Activity_triggered();
     });
 
@@ -851,32 +893,7 @@ UI_Constructor::UI_Constructor(QString const &program_info,
         }
     });
 
-    // Debounced write-on-change persistence of the RX text pane to
-    // activity.db3: any change (re)arms a short single-shot timer, so the
-    // stored copy trails the pane by at most a few seconds instead of
-    // being written only at shutdown. The second timer is armed once and
-    // NOT restarted by further changes: sustained sub-interval traffic
-    // (fast submodes, busy nets) would otherwise re-arm the debounce
-    // faster than it can fire, deferring the write - and growing the
-    // crash-loss window - indefinitely.
-    m_rxTextSaveTimer.setSingleShot(true);
-    m_rxTextSaveTimer.setInterval(5000);
-    m_rxTextSaveMaxTimer.setSingleShot(true);
-    m_rxTextSaveMaxTimer.setInterval(30000);
-    auto const flushRxText = [this]() {
-        m_rxTextSaveTimer.stop();
-        m_rxTextSaveMaxTimer.stop();
-        saveRxTextForBand(m_activityBand);
-    };
-    connect(&m_rxTextSaveTimer, &QTimer::timeout, this, flushRxText);
-    connect(&m_rxTextSaveMaxTimer, &QTimer::timeout, this, flushRxText);
-    connect(ui->textEditRX->document(), &QTextDocument::contentsChanged, this,
-            [this]() {
-                m_rxTextSaveTimer.start();
-                if (!m_rxTextSaveMaxTimer.isActive()) {
-                    m_rxTextSaveMaxTimer.start();
-                }
-            });
+    m_activityStorage->setupRxTextAutosave();
 
     ui->textEditRX->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(
@@ -1141,7 +1158,8 @@ UI_Constructor::UI_Constructor(QString const &program_info,
                     CallDetail cd = {};
                     cd.call = callsign;
                     m_callActivity[callsign] = cd;
-                    persistCallActivity(cd, true); // manual add: current band
+                    // manual add: current band
+                    m_activityStorage->persistCallActivity(cd, true);
                 }
             } else {
                 JS8MessageBox::critical_message(
@@ -1166,32 +1184,8 @@ UI_Constructor::UI_Constructor(QString const &program_info,
         } else if (selectedCall.startsWith("@")) {
             m_config.removeGroup(selectedCall);
         } else if (m_callActivity.contains(selectedCall)) {
-            // Bucket-scoped: only the on-screen bucket's stored row is
-            // deleted. A row the same station holds on another band is
-            // that band's history, which this context cannot see and
-            // must not destroy; an unread inbox sender reappears
-            // regardless, re-synthesized from inbox.db3. Rows are
-            // stored under the trimmed callsign.
             m_callActivity.remove(selectedCall);
-            if (!m_activityStoreDisabled && m_activityBandLoaded &&
-                !activityDB()->deleteCall(activityConfigId(),
-                                          m_activityBand,
-                                          selectedCall.trimmed())) {
-                // the row would reappear at the next visit to this band,
-                // so say so rather than letting it look removed
-                // false also means "matched nothing": the row is filed
-                // under the band it was heard on, which this bucket's
-                // clear cannot reach
-                auto const why = activityDB()->error();
-                showStatusMessage(
-                    why.isEmpty()
-                        ? tr("%1 is stored under another band and will "
-                             "return there")
-                              .arg(selectedCall)
-                        : tr("Could not remove %1 from stored activity "
-                             "(%2)")
-                              .arg(selectedCall, why));
-            }
+            m_activityStorage->removeStoredCall(selectedCall);
         }
 
         displayActivity(true);

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -815,13 +815,13 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             return;
         }
 
-        clearActivity();
+        on_actionClear_All_Activity_triggered();
     });
 
     // setup tablewidget context menus
     auto clearAction1 = new QAction(QString("Clear"), ui->textEditRX);
     connect(clearAction1, &QAction::triggered, this,
-            [this]() { clearRXActivity(); });
+            [this]() { on_actionClear_RX_Activity_triggered(); });
 
     auto saveAction = new QAction(QString("Save As..."), ui->textEditRX);
     connect(saveAction, &QAction::triggered, this, [this]() {
@@ -850,6 +850,33 @@ UI_Constructor::UI_Constructor(QString const &program_info,
             stream << text;
         }
     });
+
+    // Debounced write-on-change persistence of the RX text pane to
+    // activity.db3: any change (re)arms a short single-shot timer, so the
+    // stored copy trails the pane by at most a few seconds instead of
+    // being written only at shutdown. The second timer is armed once and
+    // NOT restarted by further changes: sustained sub-interval traffic
+    // (fast submodes, busy nets) would otherwise re-arm the debounce
+    // faster than it can fire, deferring the write - and growing the
+    // crash-loss window - indefinitely.
+    m_rxTextSaveTimer.setSingleShot(true);
+    m_rxTextSaveTimer.setInterval(5000);
+    m_rxTextSaveMaxTimer.setSingleShot(true);
+    m_rxTextSaveMaxTimer.setInterval(30000);
+    auto const flushRxText = [this]() {
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        saveRxTextForBand(m_activityBand);
+    };
+    connect(&m_rxTextSaveTimer, &QTimer::timeout, this, flushRxText);
+    connect(&m_rxTextSaveMaxTimer, &QTimer::timeout, this, flushRxText);
+    connect(ui->textEditRX->document(), &QTextDocument::contentsChanged, this,
+            [this]() {
+                m_rxTextSaveTimer.start();
+                if (!m_rxTextSaveMaxTimer.isActive()) {
+                    m_rxTextSaveMaxTimer.start();
+                }
+            });
 
     ui->textEditRX->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(
@@ -1078,7 +1105,7 @@ UI_Constructor::UI_Constructor(QString const &program_info,
     auto clearAction4 =
         new QAction(QString("Clear Entire List"), ui->tableWidgetCalls);
     connect(clearAction4, &QAction::triggered, this,
-            [this]() { clearCallActivity(); });
+            [this]() { on_actionClear_Call_Activity_triggered(); });
 
     auto addStation = new QAction(QString("Add New Station or Group..."),
                                   ui->tableWidgetCalls);
@@ -1107,9 +1134,15 @@ UI_Constructor::UI_Constructor(QString const &program_info,
 
         } else {
             if (Varicode::isValidCallsign(callsign, nullptr)) {
-                CallDetail cd = {};
-                cd.call = callsign;
-                m_callActivity[callsign] = cd;
+                if (!m_callActivity.contains(callsign)) {
+                    // adding a callsign that is already listed is a
+                    // no-op - overwriting would blank the entry (and
+                    // the store deliberately ignores a blank re-add)
+                    CallDetail cd = {};
+                    cd.call = callsign;
+                    m_callActivity[callsign] = cd;
+                    persistCallActivity(cd, true); // manual add: current band
+                }
             } else {
                 JS8MessageBox::critical_message(
                     this, QString("%1 is not a valid callsign or group")
@@ -1133,7 +1166,32 @@ UI_Constructor::UI_Constructor(QString const &program_info,
         } else if (selectedCall.startsWith("@")) {
             m_config.removeGroup(selectedCall);
         } else if (m_callActivity.contains(selectedCall)) {
+            // Bucket-scoped: only the on-screen bucket's stored row is
+            // deleted. A row the same station holds on another band is
+            // that band's history, which this context cannot see and
+            // must not destroy; an unread inbox sender reappears
+            // regardless, re-synthesized from inbox.db3. Rows are
+            // stored under the trimmed callsign.
             m_callActivity.remove(selectedCall);
+            if (!m_activityStoreDisabled && m_activityBandLoaded &&
+                !activityDB()->deleteCall(activityConfigId(),
+                                          m_activityBand,
+                                          selectedCall.trimmed())) {
+                // the row would reappear at the next visit to this band,
+                // so say so rather than letting it look removed
+                // false also means "matched nothing": the row is filed
+                // under the band it was heard on, which this bucket's
+                // clear cannot reach
+                auto const why = activityDB()->error();
+                showStatusMessage(
+                    why.isEmpty()
+                        ? tr("%1 is stored under another band and will "
+                             "return there")
+                              .arg(selectedCall)
+                        : tr("Could not remove %1 from stored activity "
+                             "(%2)")
+                              .arg(selectedCall, why));
+            }
         }
 
         displayActivity(true);

--- a/JS8_Mainwindow/UI_Constructor.cpp
+++ b/JS8_Mainwindow/UI_Constructor.cpp
@@ -81,7 +81,6 @@ UI_Constructor::UI_Constructor(QString const &program_info,
         context.settings = m_settings;
         context.defaultDial = Default::DIAL_FREQUENCY;
         context.rxTextEdit = ui->textEditRX;
-        context.lastBand = &m_lastBand;
         context.callActivity = &m_callActivity;
         context.inboxCounts = &m_rxInboxCountCache;
         context.callActivityBandCache = &m_callActivityBandCache;

--- a/JS8_Mainwindow/displayCallActivity.cpp
+++ b/JS8_Mainwindow/displayCallActivity.cpp
@@ -478,11 +478,12 @@ void UI_Constructor::displayCallActivity() {
         // pass with nothing to backfill opens none, and so never
         // reaches the store from inside a repaint.
         if (!backfilledGrids.isEmpty()) {
-            beginActivityBatch();
+            m_activityStorage->beginBatch();
             foreach (QString const &backfilled, backfilledGrids) {
-                persistCallActivity(m_callActivity.value(backfilled), true);
+                m_activityStorage->persistCallActivity(
+                    m_callActivity.value(backfilled), true);
             }
-            endActivityBatch();
+            m_activityStorage->endBatch();
         }
 
         // Set table color

--- a/JS8_Mainwindow/displayCallActivity.cpp
+++ b/JS8_Mainwindow/displayCallActivity.cpp
@@ -97,16 +97,31 @@ void UI_Constructor::displayCallActivity() {
                     return lhs < rhs;
             };
 
-        auto const compareTimestamp = [this](QString const &lhsKey,
-                                             QString const &rhsKey) {
-            return m_callActivity[lhsKey].utcTimestamp <
-                   m_callActivity[rhsKey].utcTimestamp;
+        // Order invalid timestamps explicitly as oldest. Rows carrying
+        // none are routine now that stored activity is loaded (manually
+        // added stations, legacy-imported rows), and std::stable_sort
+        // requires a strict weak ordering: leaving the outcome to
+        // QDateTime's own comparison of invalid values would not
+        // guarantee one.
+        auto const olderThan = [](QDateTime const &lhs,
+                                  QDateTime const &rhs) {
+            if (!lhs.isValid()) return rhs.isValid();
+            if (!rhs.isValid()) return false;
+            return lhs < rhs;
         };
 
-        auto const compareAckTimestamp = [this](QString const &lhsKey,
-                                                QString const &rhsKey) {
-            return m_callActivity[rhsKey].ackTimestamp <
-                   m_callActivity[lhsKey].ackTimestamp;
+        auto const compareTimestamp = [this, olderThan](
+                                          QString const &lhsKey,
+                                          QString const &rhsKey) {
+            return olderThan(m_callActivity[lhsKey].utcTimestamp,
+                             m_callActivity[rhsKey].utcTimestamp);
+        };
+
+        auto const compareAckTimestamp = [this, olderThan](
+                                             QString const &lhsKey,
+                                             QString const &rhsKey) {
+            return olderThan(m_callActivity[rhsKey].ackTimestamp,
+                             m_callActivity[lhsKey].ackTimestamp);
         };
 
         auto const compareSNR =
@@ -188,6 +203,14 @@ void UI_Constructor::displayCallActivity() {
                          });
 
         int callsignAging = m_config.callsign_aging();
+
+        // Stations whose grid the logbook backfill filled in below. The
+        // render pass itself must not touch the database - it runs
+        // several times a decode period - so the writes are deferred to
+        // a single batch after the loop, and a pass that backfills
+        // nothing does no database work at all.
+        QStringList backfilledGrids;
+
         foreach (QString call, keys) {
             if (call.trimmed().isEmpty()) {
                 continue;
@@ -348,12 +371,17 @@ void UI_Constructor::displayCallActivity() {
                                               logDetailComment);
                 }
 
-                if (gridItemEmpty && !logDetailGrid.isEmpty()) {
-                    gridItem->setText(logDetailGrid.trimmed().left(4));
-                    gridItem->setToolTip(logDetailGrid.trimmed());
+                // guard on the trimmed grid: a whitespace-only GRIDSQUARE
+                // in the ADIF would otherwise pass the check, store an
+                // empty grid, and re-enter this branch - with its
+                // synchronous persist - on every display pass
+                auto const logGrid = logDetailGrid.trimmed();
+                if (gridItemEmpty && !logGrid.isEmpty()) {
+                    gridItem->setText(logGrid.left(4));
+                    gridItem->setToolTip(logGrid);
 
                     auto const vector =
-                        Geodesic::vector(m_config.my_grid(), d.grid);
+                        Geodesic::vector(m_config.my_grid(), logGrid);
                     auto const units = !showColumn("call", "labels");
 
                     distanceItem->setText(
@@ -362,9 +390,13 @@ void UI_Constructor::displayCallActivity() {
                     if (auto const azimuth = vector.azimuth())
                         azimuthItem->setToolTip(azimuth.compass().toString());
 
-                    // update the call activity cache with the loaded grid
+                    // update the call activity cache with the loaded
+                    // grid and note the station for the deferred write
+                    // below, so the persist happens once per pass
+                    // rather than once per row inside the render
                     if (m_callActivity.contains(d.call)) {
-                        m_callActivity[call].grid = logDetailGrid.trimmed();
+                        m_callActivity[d.call].grid = logGrid;
+                        backfilledGrids.append(d.call);
                     }
                 }
 
@@ -437,6 +469,20 @@ void UI_Constructor::displayCallActivity() {
                         QBrush(m_config.color_primary_highlight()));
                 }
             }
+        }
+
+        // Persist the logbook grid backfills, if there were any. Fall
+        // back to the current band so the backfill also persists for
+        // manually added (dial-less) stations instead of silently
+        // reverting every restart. One transaction covers the lot; a
+        // pass with nothing to backfill opens none, and so never
+        // reaches the store from inside a repaint.
+        if (!backfilledGrids.isEmpty()) {
+            beginActivityBatch();
+            foreach (QString const &backfilled, backfilledGrids) {
+                persistCallActivity(m_callActivity.value(backfilled), true);
+            }
+            endActivityBatch();
         }
 
         // Set table color

--- a/JS8_Mainwindow/displayCallActivity.cpp
+++ b/JS8_Mainwindow/displayCallActivity.cpp
@@ -97,12 +97,7 @@ void UI_Constructor::displayCallActivity() {
                     return lhs < rhs;
             };
 
-        // Order invalid timestamps explicitly as oldest. Rows carrying
-        // none are routine now that stored activity is loaded (manually
-        // added stations, legacy-imported rows), and std::stable_sort
-        // requires a strict weak ordering: leaving the outcome to
-        // QDateTime's own comparison of invalid values would not
-        // guarantee one.
+        // Order invalid timestamps explicitly as oldest.
         auto const olderThan = [](QDateTime const &lhs,
                                   QDateTime const &rhs) {
             if (!lhs.isValid()) return rhs.isValid();
@@ -204,11 +199,7 @@ void UI_Constructor::displayCallActivity() {
 
         int callsignAging = m_config.callsign_aging();
 
-        // Stations whose grid the logbook backfill filled in below. The
-        // render pass itself must not touch the database - it runs
-        // several times a decode period - so the writes are deferred to
-        // a single batch after the loop, and a pass that backfills
-        // nothing does no database work at all.
+        // Stations whose grid the logbook backfill filled in below
         QStringList backfilledGrids;
 
         foreach (QString call, keys) {
@@ -390,10 +381,7 @@ void UI_Constructor::displayCallActivity() {
                     if (auto const azimuth = vector.azimuth())
                         azimuthItem->setToolTip(azimuth.compass().toString());
 
-                    // update the call activity cache with the loaded
-                    // grid and note the station for the deferred write
-                    // below, so the persist happens once per pass
-                    // rather than once per row inside the render
+                    // update the call activity cache
                     if (m_callActivity.contains(d.call)) {
                         m_callActivity[d.call].grid = logGrid;
                         backfilledGrids.append(d.call);
@@ -471,12 +459,7 @@ void UI_Constructor::displayCallActivity() {
             }
         }
 
-        // Persist the logbook grid backfills, if there were any. Fall
-        // back to the current band so the backfill also persists for
-        // manually added (dial-less) stations instead of silently
-        // reverting every restart. One transaction covers the lot; a
-        // pass with nothing to backfill opens none, and so never
-        // reaches the store from inside a repaint.
+        // Persist the logbook grid backfills, if there were any.
         if (!backfilledGrids.isEmpty()) {
             m_activityStorage->beginBatch();
             foreach (QString const &backfilled, backfilledGrids) {

--- a/JS8_Mainwindow/processRxActivity.cpp
+++ b/JS8_Mainwindow/processRxActivity.cpp
@@ -19,7 +19,7 @@ void UI_Constructor::processRxActivity() {
 
     // one transaction for the whole drain - each logged station persists,
     // and a busy cycle would otherwise pay one autocommit per row
-    beginActivityBatch();
+    m_activityStorage->beginBatch();
 
     while (!m_rxActivityQueue.isEmpty()) {
         ActivityDetail d = m_rxActivityQueue.dequeue();
@@ -152,7 +152,7 @@ void UI_Constructor::processRxActivity() {
         }
     }
 
-    endActivityBatch();
+    m_activityStorage->endBatch();
 
 #if 0
     // TODO: this works but should also print in the rx window.

--- a/JS8_Mainwindow/processRxActivity.cpp
+++ b/JS8_Mainwindow/processRxActivity.cpp
@@ -17,6 +17,10 @@ void UI_Constructor::processRxActivity() {
     qCDebug(mainwindow_js8)
         << m_messageBuffer.count() << "message buffers open";
 
+    // one transaction for the whole drain - each logged station persists,
+    // and a busy cycle would otherwise pay one autocommit per row
+    beginActivityBatch();
+
     while (!m_rxActivityQueue.isEmpty()) {
         ActivityDetail d = m_rxActivityQueue.dequeue();
 
@@ -147,6 +151,8 @@ void UI_Constructor::processRxActivity() {
             m_rxFrameBlockNumbers.remove(d.offset);
         }
     }
+
+    endActivityBatch();
 
 #if 0
     // TODO: this works but should also print in the rx window.

--- a/JS8_UI/Configuration.cpp
+++ b/JS8_UI/Configuration.cpp
@@ -1715,6 +1715,25 @@ Configuration::impl::impl(Configuration *self, QDir const &temp_directory,
                 Q_EMIT self_->auto_switch_bands_changed(auto_switch_bands);
             });
 
+    // Resetting activity now deletes every band's stored history, so
+    // ticking the box asks first; No unticks it
+    connect(ui_->reset_activity_check_box, &QCheckBox::clicked, this,
+            [this](bool checked) {
+                if (checked &&
+                    JS8MessageBox::Yes !=
+                        JS8MessageBox::query_message(
+                            this, tr("Reset Activity"),
+                            tr("Delete the stored call activity and RX "
+                               "history for every band at the next "
+                               "start?\n\nThis permanently deletes the "
+                               "stored history, not just what is on "
+                               "screen."),
+                            QString{}, JS8MessageBox::Yes | JS8MessageBox::No,
+                            JS8MessageBox::No)) {
+                    ui_->reset_activity_check_box->setChecked(false);
+                }
+            });
+
     // delegates
     auto stations_item_delegate = new QStyledItemDelegate{this};
     stations_item_delegate->setItemEditorFactory(item_editor_factory());

--- a/JS8_UI/Configuration.ui
+++ b/JS8_UI/Configuration.ui
@@ -427,6 +427,9 @@
                   </item>
                   <item>
                    <widget class="QCheckBox" name="reset_activity_check_box">
+                    <property name="toolTip">
+                     <string>Permanently deletes the stored call activity and RX history for every band at each start; asks when you turn it on.</string>
+                    </property>
                     <property name="text">
                      <string>Reset the Band Activity, Call Activity, and RX history at startup</string>
                     </property>

--- a/JS8_UI/MessagePanel.cpp
+++ b/JS8_UI/MessagePanel.cpp
@@ -210,7 +210,7 @@ void MessagePanel::populateMessages(QList<QPair<int, Message>> msgs) {
             dateItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
             ui->messageTableWidget->setItem(row, Column::Date, dateItem);
 
-            auto dial = (quint64)params.value("DIAL").toInt();
+            auto dial = params.value("DIAL").value<quint64>();
             auto dialItem = new QTableWidgetItem();
             dialItem->setData(Qt::EditRole, dial);
             dialItem->setData(Qt::DisplayRole, QString("%1 MHz").arg(Radio::pretty_frequency_MHz_string(dial)));

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -545,7 +545,7 @@ void UI_Constructor::readSettings() {
     // seeding it un-banded is what let one band's activity surface on
     // another at startup (#267). The legacy ini data is imported into the
     // database once, band-attributed via each record's dial frequency:
-    bool const activityReady = importLegacyActivityIfNeeded();
+    bool const activityReady = m_activityStorage->importLegacyActivityIfNeeded();
 
     // Preload the last-known band's activity so the panes are populated
     // even before (or without) a rig connection - once the rig reports a
@@ -565,34 +565,9 @@ void UI_Constructor::readSettings() {
         // filter exempts unread senders, and an empty count cache at
         // this point would age them out of the freshly seeded table
         refreshInboxCounts();
-        m_activityStartupTimer.start();
+        m_activityStorage->beginStartupGrace();
         restoreActivity(m_config.bands()->find(dial));
-
-        if (!activityDB()->isOpen() && !m_config.reset_activity()) {
-            // Degraded start: master restored the pane from the ini, and
-            // that copy is still there (this change never rewrites it).
-            // Show it rather than an empty pane - purely for display,
-            // since an unseeded bucket refuses to save.
-            m_settings->beginGroup("UI_Constructor");
-            auto const legacy =
-                m_settings->value("RXActivity", "").toString();
-            m_settings->endGroup();
-            if (!legacy.isEmpty()) {
-                ui->textEditRX->setHtml(legacy);
-                m_rxFrameBlockNumbers.clear();
-                // Mark the copy's extent: the recovery seed and the
-                // close-time sweep treat only text below it as session
-                // text (see m_rxTextLegacyBand).
-                auto const *doc = ui->textEditRX->document();
-                m_rxTextLegacyBand = m_activityBand;
-                m_rxTextLegacyBlocks = doc->blockCount();
-                if (doc->lastBlock().length() <= 1) {
-                    // an append may splice into a trailing empty block
-                    // (writeNoticeTextToUI's guard) - count it as below
-                    --m_rxTextLegacyBlocks;
-                }
-            }
-        }
+        m_activityStorage->showLegacyRxTextIfDegraded();
     }
 
     QTimer::singleShot(0, this, [this]{
@@ -777,72 +752,25 @@ void UI_Constructor::on_actionFocus_Call_Activity_Table_triggered() {
 // re-persist unread inbox senders, which is deliberate: unread senders
 // are always shown, and their rows key to their own message's band.)
 void UI_Constructor::on_actionClear_All_Activity_triggered() {
-    // This now deletes stored history for EVERY band, permanently - the
-    // ini no longer keeps a copy - so it asks first, as the context-menu
-    // path always has.
+    // Deletes every band's stored history permanently, so it asks first.
     if (QMessageBox::Yes !=
         QMessageBox::question(
-            this, "Clear All Activity",
-            "Clear all call activity and RX history for every band?\n\n"
-            "This permanently deletes the stored history, not just what "
-            "is on screen.",
-            QMessageBox::Yes | QMessageBox::No)) {
+            this, tr("Clear All Activity"),
+            tr("Clear all call activity and RX history for every "
+               "band?\n\n"
+               "This permanently deletes the stored history, not just "
+               "what is on screen."),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No)) {
         return;
     }
 
-    // Store first, UI second: clearing the panes before the store can
-    // leave a half-cleared state - the emptied pane arms the debounced
-    // saver, which then deletes the current band's stored text even
-    // though the user was told the clear had failed.
     // "All" spans bands: dropping only the current band's rows would let
-    // every other band's stored activity reload as if never cleared.
-    // The panes clear first - clearRXActivity() is also what unsticks the
-    // compose box, and master cleared unconditionally - and the store is
-    // wiped AFTER, because clearActivity()'s inbox refresh re-persists
-    // every unread sender and would otherwise repopulate the store the
-    // wipe had just emptied.
+    // every other band's stored activity reload as if never cleared. The
+    // panes clear first because clearActivity()'s inbox refresh
+    // re-persists every unread sender, which would otherwise repopulate
+    // the store right after the wipe.
     clearActivity();
-
-    bool const stored = m_activityStoreDisabled ||
-                        activityDB()->clearConfig(activityConfigId());
-    if (!stored) {
-        qCWarning(mainwindow_js8)
-            << "clear all activity failed:" << activityDB()->error();
-        showStatusMessage(tr("Could not clear stored activity (%1)")
-                              .arg(activityDB()->error()));
-        // the pane was cleared but the store was not: a save would write
-        // the emptied pane over stored text, so force a re-merge first
-        m_activitySeeded.remove(m_activityBand);
-        m_rxTextSaveTimer.stop();
-        m_rxTextSaveMaxTimer.stop();
-        m_seedRetryTimer.start();
-    }
-
-    // The legacy ini keys hold a full copy of what was just cleared, and
-    // master's writeSettings erased them at every close. Leaving them
-    // would keep the "cleared" activity readable on disk and let an
-    // older build resurrect it.
-    purgeLegacyActivityIni();
-
-    // "All" also means the session's RAM band caches - otherwise a hop
-    // to a previously visited band would restore its pre-clear snapshot
-    // and the next debounced save would write the cleared history
-    // straight back into the store.
-    m_callActivityBandCache.clear();
-    m_rxTextBandCache.clear();
-    m_bandActivityBandCache.clear();
-    m_heardGraphIncomingBandCache.clear();
-    m_heardGraphOutgoingBandCache.clear();
-    m_rxTextDirtyBands.clear();
-    // Every bucket must be re-seeded: on success because the store is
-    // empty (and clearActivity's inbox refresh may have written unread
-    // senders back into it), on failure because the panes no longer
-    // contain the stored history and a save would destroy it.
-    m_activitySeeded.clear();
-    m_rxTextLegacyBand.clear();
-    m_rxTextLegacyBlocks = 0;
-    m_rxTextLastSavedRevision = ui->textEditRX->document()->revision();
-    m_rxTextLastSavedBand = m_activityBand;
+    m_activityStorage->clearAllActivity();
 }
 
 void UI_Constructor::on_actionClear_Band_Activity_triggered() {
@@ -850,57 +778,11 @@ void UI_Constructor::on_actionClear_Band_Activity_triggered() {
 }
 
 void UI_Constructor::on_actionClear_RX_Activity_triggered() {
-    // Store first (see Clear All): if the delete fails, the pane keeps
-    // its text and no later seed can splice the stored history back in
-    // and re-persist it, silently undoing the clear.
-    bool const stored =
-        m_activityStoreDisabled ||
-        activityDB()->clearRxText(activityConfigId(), m_activityBand);
-    if (!stored) {
-        qCWarning(mainwindow_js8)
-            << "clear RX activity failed:" << activityDB()->error();
-        showStatusMessage(tr("Could not clear stored RX text (%1)")
-                              .arg(activityDB()->error()));
-        // The pane no longer holds the stored text, so a save would
-        // overwrite it: force a re-merge before saves resume, and stop
-        // the debounce the pane clear below arms - otherwise its retry
-        // seeds the bucket and puts the "cleared" text back on screen.
-        m_activitySeeded.remove(m_activityBand);
-        m_rxTextSaveTimer.stop();
-        m_rxTextSaveMaxTimer.stop();
-        m_seedRetryTimer.start(); // hold the retry off for its interval
-    }
-    if (m_activityBand == m_rxTextLegacyBand) {
-        // whatever the clear leaves on screen, it is not the legacy copy
-        m_rxTextLegacyBand.clear();
-        m_rxTextLegacyBlocks = 0;
-    }
-    // clears unconditionally - this is also the compose box's way out
-    clearRXActivity();
-    m_rxTextLastSavedRevision = ui->textEditRX->document()->revision();
-    m_rxTextLastSavedBand = m_activityBand;
-    m_rxTextDirtyBands.remove(m_activityBand);
+    m_activityStorage->clearRxActivity();
 }
 
 void UI_Constructor::on_actionClear_Call_Activity_triggered() {
-    if (!m_activityStoreDisabled &&
-        !activityDB()->deleteCalls(activityConfigId(), m_activityBand)) {
-        qCWarning(mainwindow_js8)
-            << "clear call activity failed:" << activityDB()->error();
-        showStatusMessage(tr("Could not clear stored call activity (%1)")
-                              .arg(activityDB()->error()));
-        // deliberately NOT un-seeded: the RX pane is untouched and still
-        // contains this bucket's stored text, so forcing a re-seed would
-        // splice that history in a second time. The rows simply return
-        // at the next session, which the message above reports.
-    }
-    clearCallActivity();
-    // Bucket-scoped by design: a row displayed here but stored under
-    // another band (its own dial's band - e.g. a decode that completed
-    // just after a QSY) is that band's history, which this action cannot
-    // see and must not destroy. Unread inbox senders reappear regardless
-    // - they are re-synthesized from inbox.db3, the source of truth for
-    // unread mail.
+    m_activityStorage->clearCallActivity();
 }
 
 void UI_Constructor::on_actionSetOffset_triggered() {
@@ -1344,11 +1226,7 @@ void UI_Constructor::updateCurrentBand() {
         // see the outgoing bucket as unconfirmed, or the startup guess's
         // pane - which now holds this band's decodes too - is written
         // under the guessed band
-        if (m_activityBandLoaded && m_activityBand != band_name) {
-            switchActivityBucket(band_name);
-        }
-        m_activityBandConfirmed = true;
-        m_activityBandConfirmedBands.insert(band_name);
+        m_activityStorage->bandUnchanged(band_name);
         return;
     }
 
@@ -1357,8 +1235,7 @@ void UI_Constructor::updateCurrentBand() {
     // grid, which would otherwise still be the outgoing band's. The
     // confirmation flag is set AFTER the switch, so the flush inside it
     // still treats the outgoing bucket as the startup guess it is.
-    switchActivityBucket(band_name);
-    m_activityBandConfirmed = true;
+    m_activityStorage->bandChanged(band_name);
 
     m_wideGraph->setBand(band_name);
 
@@ -1557,95 +1434,7 @@ void UI_Constructor::closeEvent(QCloseEvent *e) {
     }
     m_valid = false; // suppresses subprocess errors
     m_config.transceiver_offline();
-    // Final flush of the current band's RX text (covers anything the
-    // debounced save timer hasn't written yet). If the bucket was never
-    // seeded - the store was unusable at first visit - make one last
-    // seed attempt: saves are suppressed while unseeded, so without this
-    // the whole session's RX text would be discarded, where the legacy
-    // ini path always wrote it. The flag keeps the flush below from
-    // re-entering the seed's own retry (and its table rebuild) while the
-    // window is tearing down.
-    if (!m_activitySeeded.contains(m_activityBand) &&
-        !m_activityStoreDisabled && activityDB()->isOpen()) {
-        seedActivityForBand(m_activityBand);
-    }
-    m_activityShuttingDown = true;
-    m_activityBandConfirmed = true; // the guess, if any, ends here
-    saveRxTextForBand(m_activityBand);
-
-    // Bands whose text never reached the store - visited while it was
-    // down, or left before a seed succeeded - survive only in the RAM
-    // band cache, and this is their last chance. Append to whatever is
-    // stored rather than replacing it: the cached document does not
-    // contain that band's earlier history.
-    if (!m_activityStoreDisabled) {
-        foreach (auto const &dirty, m_rxTextDirtyBands) {
-            if (dirty == m_activityBand ||
-                !m_rxTextBandCache.contains(dirty)) {
-                continue;
-            }
-            if (!m_activityBandConfirmedBands.contains(dirty)) {
-                // this bucket was only ever the startup guess, and its
-                // pane collected text heard before the rig reported a
-                // band - writing it here would file that text under a
-                // band it was never heard on
-                continue;
-            }
-            auto cached = m_rxTextBandCache[dirty];
-            QTextDocument cachedDoc;
-            cachedDoc.setHtml(cached);
-            if (dirty == m_rxTextLegacyBand) {
-                // the cached top is the degraded start's legacy ini
-                // copy - already in the store via the import; only what
-                // the session added below it is worth sweeping
-                cached = htmlBelowLegacyCopy(&cachedDoc);
-                if (cached.isEmpty()) {
-                    continue;
-                }
-                cachedDoc.setHtml(cached);
-            }
-            if (cachedDoc.isEmpty()) {
-                // a cleared pane serialises to a full HTML skeleton, so
-                // the emptiness test has to be on the document: storing
-                // the skeleton would resurrect the cleared row
-                activityDB()->clearRxText(activityConfigId(), dirty);
-                continue;
-            }
-
-            if (m_activitySeeded.contains(dirty)) {
-                // the cached document already contains this bucket's
-                // stored history (that is what seeding merged in), so it
-                // replaces the row rather than being appended to it
-                activityDB()->saveRxText(activityConfigId(), dirty,
-                                         cached);
-                continue;
-            }
-
-            // never seeded: the cached text is this session's only, and
-            // whatever is stored is older history it does not contain
-            bool ok = false;
-            auto const storedHtml =
-                activityDB()->loadRxText(activityConfigId(), dirty, &ok);
-            if (!ok) {
-                continue; // cannot tell what is there; do not overwrite
-            }
-            if (storedHtml.isEmpty()) {
-                activityDB()->saveRxText(activityConfigId(), dirty,
-                                         cached);
-                continue;
-            }
-            QTextDocument doc;
-            doc.setHtml(storedHtml);
-            QTextCursor cursor(&doc);
-            cursor.movePosition(QTextCursor::End);
-            if (cursor.block().length() > 1) {
-                cursor.insertBlock();
-            }
-            cursor.insertHtml(cached);
-            activityDB()->saveRxText(activityConfigId(), dirty,
-                                     doc.toHtml());
-        }
-    }
+    m_activityStorage->flushOnClose();
     writeSettings();
     m_guiTimer.stop();
     m_prefixes.reset();
@@ -2484,7 +2273,7 @@ void UI_Constructor::logCallActivity(CallDetail d, bool spot) {
 
     // mirror the row to activity.db3 as it changes, so it survives any
     // kind of exit (write-on-change, not write-on-close)
-    persistCallActivity(d);
+    m_activityStorage->persistCallActivity(d);
 
     // enqueue for spotting to psk reporter
     if (spot) {
@@ -3115,62 +2904,20 @@ void UI_Constructor::cacheActivity(QString key) {
     m_heardGraphOutgoingBandCache[key] = m_heardGraphOutgoing;
 }
 
-// The one path that moves the panes from one storage bucket to another:
-// flush and park what is on screen under the bucket it belongs to, empty
-// the panes, then restore the target bucket's own view. Every caller -
-// a band change, the rig's first report correcting the startup guess -
-// goes through here, so no path can leave one bucket's activity on
-// screen under another's name (which is #267 itself).
-/**
- * @brief Move the activity panes from one storage bucket to another.
- * @param band The bucket to show: a band name, or "" for out-of-plan.
- *
- * Flushes and parks what is on screen under the bucket it belongs to,
- * clears the panes, then restores the target bucket's own view. Every
- * caller - a band change, and the rig's first report correcting the
- * startup guess - goes through here, so no path can leave one bucket's
- * activity on screen under another's name, which is issue #267 itself.
- */
-void UI_Constructor::switchActivityBucket(QString const &band) {
-    if (m_activityBandLoaded && m_activityBand == band) {
-        return;
-    }
-    if (m_activityBandLoaded) {
-        // saveRxTextForBand declines while the bucket is unconfirmed -
-        // the pane may hold text heard on the band we are moving TO -
-        // and marks it dirty, so cacheActivity below keeps it and the
-        // close-time sweep still gets a chance at it
-        saveRxTextForBand(m_activityBand);
-        cacheActivity(m_activityBand);
-    }
-
-    if (m_lastBand.isEmpty()) {
-        // The rig's first report, correcting the startup guess. Master
-        // cleared nothing here, so only the two per-bucket panes move:
-        // clearActivity() would also empty the compose box and the
-        // decode, command and spot queues the session has accumulated.
-        ui->textEditRX->clear();
-        m_rxFrameBlockNumbers.clear();
-        clearCallActivity();
-    } else {
-        clearActivity();
-    }
-    restoreActivity(band);
-}
-
 void UI_Constructor::restoreActivity(QString key) {
     // When re-entering the bucket already on screen (a seed retry after
     // the store recovers), the live panes are newer than any cache entry
     // and must not be replaced.
-    bool const sameBucket = m_activityBandLoaded && key == m_activityBand;
+    bool const sameBucket = m_activityStorage->isBucketLoaded() &&
+                            key == m_activityStorage->currentBucket();
 
     if (!sameBucket) {
         // Every cache is restored the same way, as on master: replace
         // when this bucket has a snapshot, otherwise leave the panes as
-        // the caller left them. switchActivityBucket() has already
-        // cleared them, so "no snapshot" correctly shows nothing; the
-        // startup preload deliberately does NOT clear, so the unread
-        // senders synthesized moments earlier survive into the seed.
+        // the caller left them. The bucket switch has already cleared
+        // them, so "no snapshot" correctly shows nothing; the startup
+        // preload deliberately does NOT clear, so the unread senders
+        // synthesized moments earlier survive into the seed.
         if (m_bandActivityBandCache.contains(key)) {
             m_bandActivity = m_bandActivityBandCache[key];
         }
@@ -3189,770 +2936,15 @@ void UI_Constructor::restoreActivity(QString key) {
         // the document was rebuilt: block indexes remembered for
         // in-progress multi-frame messages point into the old document
         m_rxFrameBlockNumbers.clear();
-        // what was restored is what the cache holds; disarm the saver
-        // and resync its change tracking - EXCEPT when a flush for this
-        // band failed earlier (dirty), where the tracking must keep
-        // reporting unsaved so the next flush retries
-        m_rxTextSaveTimer.stop();
-        m_rxTextSaveMaxTimer.stop();
-        m_rxTextLastSavedRevision =
-            m_rxTextDirtyBands.contains(key)
-                ? -1
-                : ui->textEditRX->document()->revision();
-        m_rxTextLastSavedBand = key;
-        if (m_rxTextDirtyBands.contains(key)) {
-            // this band's last flush failed: actually re-arm the timer,
-            // or a quiet band never retries (nothing else restarts it -
-            // only document activity does)
-            m_rxTextSaveTimer.start();
-        }
         QTimer::singleShot(0, this, [this]() {
             ui->textEditRX->verticalScrollBar()->setValue(
                 ui->textEditRX->verticalScrollBar()->maximum());
         });
     }
 
-    m_activityBand = key;
-    m_activityBandLoaded = true;
-
-    // first visit this session: merge the bucket's stored history in
-    if (!m_activitySeeded.contains(key)) {
-        seedActivityForBand(key);
-    }
+    m_activityStorage->bucketRestored(key, !sameBucket);
 
     displayActivity(true);
-}
-
-/**
- * @brief Path of the per-band activity store, beside the message inbox.
- *
- * Per-band persistent activity storage keyed by (configuration, band,
- * callsign) - see ActivityDB and issue #267.
- */
-QString UI_Constructor::activityPath() const {
-    return QDir::toNativeSeparators(
-        m_config.writeable_data_dir().absoluteFilePath("activity.db3"));
-}
-
-/**
- * @brief The activity store, opened on first use.
- *
- * A store that fails to open - or that closed itself after repeated
- * failures - is retried on a throttle rather than per call, and the
- * operator is told once per failure episode that activity is not being
- * saved. Callers may always use the returned object: every method on it
- * is a no-op while it is closed.
- */
-ActivityDB *UI_Constructor::activityDB() {
-    // a failed open (transient mount problem, contended lock at launch) is
-    // retried, throttled so a persistently broken store doesn't pay the
-    // open attempt on every decode
-    // Arm the reopen throttle however the handle ended up closed - a
-    // failed open() below, or the self-close after consecutive
-    // read/write failures - so a store that breaks mid-session is also
-    // retried, not just one that failed at launch. Discovery of a
-    // self-close is also the one operator-visible signal for it (the
-    // per-write warnings are suppressed once the handle is closed).
-    if (m_activityDB && !m_activityDB->isOpen() &&
-        !m_activityDBRetryTimer.isValid()) {
-        m_activityDBRetryTimer.start();
-        qCWarning(mainwindow_js8)
-            << "activity store closed after repeated failures:"
-            << m_activityDB->error();
-        showStatusMessage(
-            tr("Activity database unavailable - activity is not being "
-               "saved (%1)")
-                .arg(m_activityDB->error()));
-    }
-    bool const retrying = m_activityDB && !m_activityDB->isOpen() &&
-                          m_activityDBRetryTimer.isValid() &&
-                          m_activityDBRetryTimer.hasExpired(30 * 1000) &&
-                          m_activityBatchDepth == 0;
-    if (retrying) {
-        // never while a batch holds the old handle: callers inside
-        // beginActivityBatch()/endActivityBatch() would be left with a
-        // dangling pointer and a vanished transaction
-        m_activityDB.reset();
-    }
-    if (!m_activityDB) {
-        m_activityDB = std::make_unique<ActivityDB>(activityPath());
-        if (!m_activityDB->open()) {
-            qCWarning(mainwindow_js8)
-                << "could not open" << activityPath() << ":"
-                << m_activityDB->error();
-            // one visible sign per failure episode - NOT per 30s retry:
-            // showStatusMessage temporarily hides the statusbar's mode
-            // and frequency readouts, so a blink every retry would blank
-            // the operator's primary readouts indefinitely
-            if (!retrying) {
-                showStatusMessage(
-                    tr("Activity database unavailable - activity will "
-                       "not be saved (%1)")
-                        .arg(m_activityDB->error()));
-            }
-            m_activityDBRetryTimer.start();
-        } else {
-            m_activityDBRetryTimer.invalidate();
-            if (retrying && m_activityBandLoaded &&
-                !m_activitySeeded.contains(m_activityBand)) {
-                // the store recovered while the operator sat on a bucket
-                // that could never be seeded - seed it now (deferred:
-                // this accessor is called from paths a seed re-enters)
-                QTimer::singleShot(0, this, [this]() {
-                    if (m_activityBandLoaded &&
-                        !m_activitySeeded.contains(m_activityBand)) {
-                        seedActivityForBand(m_activityBand);
-                        displayActivity(true);
-                    }
-                });
-            }
-        }
-    }
-    return m_activityDB.get();
-}
-
-// Nested write bursts (a decode drain whose handlers also refresh inbox
-// counts, say) share one transaction; the outermost end commits.
-// Batches are LAZY: opening one only records the intent, and the
-// transaction starts at the first write inside it. A decode cycle that
-// turns out to persist nothing then costs nothing - no BEGIN IMMEDIATE
-// taking the write lock on the GUI thread (with its 5 s busy timeout),
-// and no store-reopen probe on behalf of a caller that never writes.
-/**
- * @brief Open a write batch; nested batches share one transaction.
- *
- * Lazy: the transaction starts at the first write inside the batch, so a
- * decode cycle that persists nothing costs nothing.
- */
-void UI_Constructor::beginActivityBatch() { ++m_activityBatchDepth; }
-
-/// @brief Start the transaction a batch deferred, at its first write.
-void UI_Constructor::startActivityBatchIfPending() {
-    if (m_activityBatchDepth > 0 && m_activityDB &&
-        m_activityDB->isOpen() && !m_activityDB->inTransaction()) {
-        m_activityDB->begin();
-    }
-}
-
-/// @brief Close the outermost batch, committing its transaction.
-void UI_Constructor::endActivityBatch() {
-    if (m_activityBatchDepth == 1) {
-        // commit on the same handle begin() used: no activityDB() call
-        // here, so the accessor cannot swap in a fresh instance first,
-        // and a handle that died mid-batch (no transaction any more)
-        // stays silent instead of logging a misleading empty error
-        if (m_activityDB && m_activityDB->inTransaction() &&
-            !m_activityDB->commit()) {
-            qCWarning(mainwindow_js8)
-                << "could not commit activity batch:"
-                << m_activityDB->error();
-        }
-    }
-    --m_activityBatchDepth;
-}
-
-// Activity is keyed by a per-configuration UUID generated once and
-// stored in the configuration's own settings - NOT by the configuration
-// name. The id follows the configuration through renames automatically,
-// is purged with the settings by MultiSettings' "Reset Configuration"
-// (orphaning the old rows and starting clean, with no wipe heuristics
-// that could misfire), and a clone shares its source's id - and hence
-// its activity view - until either is reset. The id is captured once:
-// during a configuration switch MultiSettings updates its state before
-// this window closes, and the outgoing configuration's final flush must
-// not land under the incoming configuration's key.
-/**
- * @brief The storage key for this MultiSettings configuration.
- * @return A UUID generated once into the configuration's own settings.
- */
-QString UI_Constructor::activityConfigId() const {
-    if (m_activityConfigId.isEmpty()) {
-        auto id = m_settings->value("ActivityDbId").toString();
-        if (id.isEmpty()) {
-            id = QUuid::createUuid().toString(QUuid::WithoutBraces);
-            m_settings->setValue("ActivityDbId", id);
-        }
-        m_activityConfigId = id;
-    }
-    return m_activityConfigId;
-}
-
-/// @brief Convert a displayed call detail into a storable row.
-ActivityDB::CallRecord UI_Constructor::toCallRecord(CallDetail const &d) const {
-    ActivityDB::CallRecord r;
-    r.callsign = d.call.trimmed();
-    r.through = d.through;
-    r.snr = d.snr;
-    r.grid = d.grid;
-    r.dial = d.dial;
-    r.offset = d.offset;
-    r.bits = d.bits;
-    r.tdrift = d.tdrift;
-    r.cqTimestamp = d.cqTimestamp;
-    r.ackTimestamp = d.ackTimestamp;
-    r.utcTimestamp = d.utcTimestamp;
-    r.submode = d.submode;
-    return r;
-}
-
-/// @brief Convert a stored row back into a displayed call detail.
-UI_Constructor::CallDetail
-UI_Constructor::fromCallRecord(ActivityDB::CallRecord const &r) const {
-    CallDetail cd = {};
-    cd.call = r.callsign;
-    cd.through = r.through;
-    cd.snr = r.snr;
-    cd.grid = r.grid;
-    cd.dial = r.dial;
-    cd.offset = r.offset;
-    cd.bits = r.bits;
-    cd.tdrift = r.tdrift;
-    cd.cqTimestamp = r.cqTimestamp;
-    cd.ackTimestamp = r.ackTimestamp;
-    cd.utcTimestamp = r.utcTimestamp;
-    cd.submode = r.submode;
-    return cd;
-}
-
-// Rows are filed under the band of their own dial frequency
-// (processDecodeEvent deliberately stamps records with the capture-time
-// dial, so decodes completing after a QSY and inbox senders keep the
-// band they were heard on - keying by the live band would be #267 all
-// over again). A dial that resolves to no band files under "" - the
-// out-of-plan bucket, which round-trips only to out-of-plan operation
-// and gives transverter/channelized users the persistence the legacy
-// un-banded ini provided. fallbackToCurrentBand is passed by the call
-// sites where a dial-less entry genuinely belongs to the bucket on
-// screen instead: a manually added station, a logbook grid backfill,
-// and qsy()'s offset write-back for those same rows.
-/**
- * @brief Write one call-activity row to the store.
- * @param d The row to persist.
- * @param fallbackToCurrentBand File a row carrying no dial under the
- *        bucket on screen; passed only where that is genuinely where it
- *        belongs (a manually added station, a logbook grid backfill).
- */
-void UI_Constructor::persistCallActivity(CallDetail const &d,
-                                         bool fallbackToCurrentBand) {
-    if (m_activityStoreDisabled || d.call.trimmed().isEmpty()) {
-        return;
-    }
-
-    auto band = m_config.bands()->find(d.dial);
-    if (band.isEmpty() && d.dial == 0 && fallbackToCurrentBand &&
-        m_activityBandConfirmed) {
-        // only once the rig has confirmed the bucket: filing under the
-        // startup guess would strand the row on a band the operator is
-        // not on (saveRxTextForBand refuses for the same reason)
-        band = m_activityBand;
-    }
-
-    auto const r = toCallRecord(d);
-    activityDB(); // resolve (and possibly recover) before the batch opens
-    startActivityBatchIfPending();
-    if (band != m_activityBand) {
-        // stored into a bucket other than the one on screen (a decode
-        // that completed after a QSY, an inbox sender carrying its
-        // message's dial): drop that bucket's cached view so the next
-        // visit re-seeds and the row is actually visible there
-        m_activitySeeded.remove(band);
-        m_callActivityBandCache.remove(band);
-    }
-
-    if (!activityDB()->upsertCall(activityConfigId(), band, r) &&
-        activityDB()->isOpen()) {
-        // a failed open is already reported (throttled) by activityDB()
-        qCWarning(mainwindow_js8) << "could not persist call activity for"
-                                  << r.callsign << ":"
-                                  << activityDB()->error();
-    }
-}
-
-// One-time-per-session merge of a bucket's stored history under whatever
-// the session has already accumulated for it: RAM wins per callsign on a
-// newer-or-equal timestamp, and the RX pane's own lines are appended
-// after the stored history. On failure the bucket stays unseeded - its
-// RX-text saves stay suppressed (nothing containing the stored history
-// is on screen, so a save would overwrite it) and the next visit, or the
-// reopen after a store failure, retries.
-/**
- * @brief Merge a bucket's stored history into the session, once.
- * @param band The bucket to seed.
- *
- * Runs at a bucket's first visit each session. Stored rows are merged
- * under whatever the session already holds - the newer of the two wins
- * per callsign, and stored enrichment (grid, ACK and CQ marks) survives
- * a bare re-hearing - and the stored RX text is placed behind the pane's
- * own lines. Until a bucket has been seeded its RX-text saves are
- * suppressed, so a document that does not contain the stored history can
- * never overwrite it; a failed seed is retried at the flush cadence.
- */
-/**
- * @brief HTML of everything below the degraded start's legacy ini copy.
- * @param doc The RX pane's document, or a cached copy of it.
- * @return The session text below the copy, or "" when there is none.
- */
-QString UI_Constructor::htmlBelowLegacyCopy(QTextDocument *doc) const {
-    if (doc->blockCount() <= m_rxTextLegacyBlocks) {
-        return {};
-    }
-    QTextCursor cursor(doc->findBlockByNumber(m_rxTextLegacyBlocks));
-    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
-    if (cursor.selection().toPlainText().trimmed().isEmpty()) {
-        return {};
-    }
-    return cursor.selection().toHtml();
-}
-
-void UI_Constructor::seedActivityForBand(QString const &band) {
-    if (m_activityStoreDisabled || !activityDB()->isOpen()) {
-        return;
-    }
-    auto const config = activityConfigId();
-
-    bool callsOk = false;
-    auto const stored = activityDB()->loadCalls(config, band, &callsOk);
-    if (callsOk) {
-        // Apply the callsign-aging setting to what the STORE
-        // contributes, mirroring master's save-time prune: it bounds
-        // what a session can load (the store itself keeps everything),
-        // and without it stale rows reach consumers that put an SNR on
-        // the air. Rows the session has already heard are never pruned -
-        // they are merged in below, untouched.
-        auto const aging = m_config.callsign_aging();
-        auto const agingNow = DriftingDateTime::currentDateTimeUtc();
-
-        QMap<QString, CallDetail> merged;
-        foreach (auto const &r, stored) {
-            auto const cd = fromCallRecord(r);
-            if (aging && !m_callActivity.contains(cd.call) &&
-                m_rxInboxCountCache.value(cd.call, 0) <= 0 &&
-                cd.utcTimestamp.isValid() &&
-                cd.utcTimestamp.secsTo(agingNow) / 60 >= aging) {
-                continue; // too old to show; still in the store
-            }
-            merged[cd.call] = cd;
-        }
-        // Explicit ordering, not QDateTime's operators: since Qt 6.8 a
-        // comparison involving an invalid QDateTime is UNORDERED, so
-        // both < and <= return false and a live row would lose to a
-        // stored one that carries no timestamp (every manually added
-        // station, and legacy-imported rows).
-        auto const newerThan = [](QDateTime const &lhs,
-                                  QDateTime const &rhs) {
-            if (!lhs.isValid()) return false;
-            if (!rhs.isValid()) return true;
-            return rhs < lhs;
-        };
-
-        QList<CallDetail> ramWinners;
-        for (auto it = m_callActivity.constBegin();
-             it != m_callActivity.constEnd(); ++it) {
-            auto const found = merged.constFind(it.key());
-            if (found != merged.constEnd() &&
-                newerThan(found->utcTimestamp, it->utcTimestamp)) {
-                continue; // the stored row is the newer one
-            }
-
-            auto live = it.value();
-            if (found != merged.constEnd()) {
-                // Keep the enrichment the stored row carries when the
-                // live one has none, mirroring the UPSERT's own CASE
-                // guards - otherwise a bare re-hearing would drop the
-                // grid and the ACK/CQ marks from the table while the
-                // database (correctly) kept them.
-                if (live.grid.isEmpty()) live.grid = found->grid;
-                if (!live.ackTimestamp.isValid())
-                    live.ackTimestamp = found->ackTimestamp;
-                if (!live.cqTimestamp.isValid())
-                    live.cqTimestamp = found->cqTimestamp;
-                if (newerThan(it->utcTimestamp, found->utcTimestamp)) {
-                    // heard while the store was unreachable: write it
-                    // through now, or it reverts at the next session
-                    ramWinners.append(live);
-                }
-            } else {
-                ramWinners.append(live);
-            }
-            merged[it.key()] = live;
-        }
-        m_callActivity = merged;
-        if (!ramWinners.isEmpty()) {
-            beginActivityBatch();
-            foreach (auto const &cd, ramWinners) {
-                if (cd.dial == 0) {
-                    // Bands::find(0) is "", so writing this here would
-                    // file it in the out-of-plan bucket rather than the
-                    // one that already holds it (a manual add is stored
-                    // when it is added). Leave it alone.
-                    continue;
-                }
-                persistCallActivity(cd);
-            }
-            endActivityBatch();
-        }
-
-
-
-    } else {
-        qCWarning(mainwindow_js8)
-            << "could not load call activity for band" << band << ":"
-            << activityDB()->error();
-        // retry later WITHOUT touching the RX pane: merging the stored
-        // text now would leave it spliced into an unseeded pane, and the
-        // retry would merge - and then persist - it a second time
-        return;
-    }
-
-    // NOTE: fresh activityDB() call - the loads can self-close a failing
-    // handle, and holding a pointer across them would dangle.
-    bool rxOk = false;
-    auto const storedHtml = activityDB()->loadRxText(config, band, &rxOk);
-    if (rxOk) {
-        auto sessionHtml = QString{};
-        if (band == m_rxTextLegacyBand) {
-            // The pane's top is the legacy ini copy shown by the
-            // degraded start - history the import already banked, not
-            // session text. Merging the whole pane would append a
-            // second copy of the history behind the stored one.
-            sessionHtml = htmlBelowLegacyCopy(ui->textEditRX->document());
-        } else if (!ui->textEditRX->toPlainText().trimmed().isEmpty()) {
-            sessionHtml = ui->textEditRX->toHtml();
-        }
-        if (!storedHtml.isEmpty()) {
-            ui->textEditRX->setHtml(storedHtml);
-            if (!sessionHtml.isEmpty()) {
-                auto cursor = QTextCursor(ui->textEditRX->document());
-                cursor.movePosition(QTextCursor::End);
-                // never splice the session's first line onto the last
-                // stored line (writeNoticeTextToUI uses the same guard)
-                if (cursor.block().length() > 1) {
-                    cursor.insertBlock();
-                }
-                cursor.insertHtml(sessionHtml);
-            }
-            // the document was rebuilt: stored block indexes are stale
-            m_rxFrameBlockNumbers.clear();
-            QTimer::singleShot(0, this, [this]() {
-                ui->textEditRX->verticalScrollBar()->setValue(
-                    ui->textEditRX->verticalScrollBar()->maximum());
-            });
-        }
-        if (band == m_rxTextLegacyBand) {
-            // consumed: the pane no longer holds an unaccounted copy -
-            // either the stored history replaced it, or (empty row) the
-            // pane's copy is now legitimately this bucket's document
-            m_rxTextLegacyBand.clear();
-            m_rxTextLegacyBlocks = 0;
-        }
-        m_rxTextSaveTimer.stop();
-        m_rxTextSaveMaxTimer.stop();
-        m_rxTextLastSavedBand = band;
-        if (sessionHtml.isEmpty()) {
-            // showing exactly the stored content - nothing to write back
-            m_rxTextLastSavedRevision =
-                ui->textEditRX->document()->revision();
-        } else {
-            // the merged document is newer than the stored row
-            m_rxTextLastSavedRevision = -1;
-        }
-    } else {
-        qCWarning(mainwindow_js8)
-            << "could not load RX text for band" << band << ":"
-            << activityDB()->error();
-    }
-
-    if (callsOk && rxOk) {
-        m_activitySeeded.insert(band);
-        if (m_rxTextLastSavedRevision == -1) {
-            saveRxTextForBand(band); // permitted now the bucket is seeded
-        }
-    }
-}
-
-/**
- * @brief Persist the RX pane for a bucket, if it is safe to do so.
- * @param band The bucket the pane's contents belong to.
- *
- * Declines while the bucket is only the startup guess (RX text carries
- * no per-line frequency, so it could be filed under a band it was never
- * heard on) or while the bucket is unseeded, marking it for the
- * close-time sweep in both cases. An empty pane removes the stored row
- * rather than storing an empty one.
- */
-void UI_Constructor::saveRxTextForBand(QString const &band) {
-    if (m_activityStoreDisabled) {
-        return; // a requested reset could not be applied - see the import
-    }
-    if (!m_activityBandConfirmed && band == m_activityBand &&
-        m_activityStartupTimer.isValid() &&
-        !m_activityStartupTimer.hasExpired(60 * 1000)) {
-        // The rig has not reported yet, so this bucket is only the last
-        // session's guess. RX text carries no per-line frequency, so
-        // filing it here could permanently mis-attribute a band's
-        // history; hold it in the pane until the bucket is confirmed
-        // (the grace period covers a station running without CAT).
-        m_rxTextDirtyBands.insert(band);
-        return;
-    }
-    if (!m_activitySeeded.contains(band)) {
-        // The bucket's stored history has not been merged into the
-        // on-screen document (store down or a read failed at first
-        // visit) - saving would overwrite that history with a document
-        // that does not contain it. Remember that this bucket has
-        // unsaved text, and retry the seed at this flush cadence, so one
-        // transient failure cannot disable persistence for a whole
-        // parked session; a successful seed saves the merged document.
-        m_rxTextDirtyBands.insert(band);
-        if (band == m_activityBand && !m_activityShuttingDown &&
-            activityDB()->isOpen() &&
-            (!m_seedRetryTimer.isValid() ||
-             m_seedRetryTimer.hasExpired(30 * 1000))) {
-            m_seedRetryTimer.start();
-            seedActivityForBand(band);
-            displayActivity(true);
-        }
-        return;
-    }
-
-    int const revision = ui->textEditRX->document()->revision();
-    if (revision == m_rxTextLastSavedRevision &&
-        band == m_rxTextLastSavedBand) {
-        return; // unchanged since the last save
-    }
-
-    activityDB(); // resolve (and possibly recover) before the batch opens
-    startActivityBatchIfPending();
-
-    bool ok;
-    if (ui->textEditRX->document()->isEmpty()) {
-        // an empty pane stores as no row at all - otherwise the debounced
-        // save that follows a Clear would resurrect an empty-skeleton row
-        ok = activityDB()->clearRxText(activityConfigId(), band);
-    } else {
-        ok = activityDB()->saveRxText(activityConfigId(), band,
-                                      ui->textEditRX->toHtml());
-    }
-
-    if (ok) {
-        m_rxTextLastSavedRevision = revision;
-        m_rxTextLastSavedBand = band;
-        m_rxTextDirtyBands.remove(band);
-    } else {
-        // Remember that this band's on-screen/cached text is newer than
-        // the store - the next restore of the band re-arms a save, and
-        // closeEvent sweeps still-dirty bands from the RAM cache. Re-arm
-        // the debounce too: the flush stopped both timers before calling
-        // us, and only new document activity would otherwise restart
-        // them, so a band that falls quiet after one failed save would
-        // never try again.
-        m_rxTextDirtyBands.insert(band);
-        if (!m_activityShuttingDown && band == m_activityBand) {
-            // Back off: a store that stays unwritable would otherwise
-            // spin at the 5 s debounce forever, and every attempt
-            // serialises the whole (unbounded) RX document on the GUI
-            // thread. One minute is still far inside the window the
-            // write-on-change design is protecting.
-            m_rxTextSaveTimer.start(60 * 1000);
-            if (!m_rxTextSaveMaxTimer.isActive()) {
-                m_rxTextSaveMaxTimer.start();
-            }
-        }
-        if (activityDB()->isOpen()) {
-            qCWarning(mainwindow_js8)
-                << "could not save RX text for band" << band << ":"
-                << activityDB()->error();
-        }
-    }
-}
-
-/**
- * @brief One-time import of the legacy .ini activity data into
- *        activity.db3, following the inbox_v1 -> inbox_v2 pattern: the
- *        legacy [CallActivity] group and RXActivity key are read once,
- *        never written again, and left in place for older versions of
- *        the software.
- *
- * Call activity rows are attributed to the band each record was actually
- * heard on, via its stored dial frequency - the legacy store had no band
- * dimension, which is how activity ended up displayed on whatever band
- * the rig was polled on at startup (#267). The RX text blob has no
- * per-line frequency, so it is attributed to the band of the last-known
- * dial frequency - the band the user last saw it on.
- */
-// Erase the legacy [CallActivity] group and RXActivity key. Master's
-// writeSettings rewrote both at every close, so a reset genuinely
-// destroyed the old data; leaving them would keep a full copy of
-// everything the user asked to erase.
-void UI_Constructor::purgeLegacyActivityIni() {
-    m_settings->beginGroup("CallActivity");
-    m_settings->remove(""); // the whole legacy group
-    m_settings->endGroup();
-    m_settings->beginGroup("UI_Constructor");
-    m_settings->remove("RXActivity");
-    m_settings->endGroup();
-}
-
-bool UI_Constructor::importLegacyActivityIfNeeded() {
-    auto *db = activityDB();
-    if (!db->isOpen()) {
-        if (m_config.reset_activity()) {
-            // The wipe cannot run, so nothing may be read or written
-            // this session - otherwise the store reopens later and
-            // splices back exactly what the user asked to erase. The
-            // legacy ini keys ARE erased now: they hold a copy of the
-            // same activity, and leaving them would let a later untick
-            // re-import the snapshot the user just asked to destroy.
-            m_activityStoreDisabled = true;
-            purgeLegacyActivityIni();
-        }
-        return false; // the database wipe retries at the next start
-    }
-
-    auto const config = activityConfigId();
-
-    // The fire-once marker lives in the configuration's own settings, so
-    // it travels WITH the configuration: a rename keeps it (no re-import
-    // resurrecting deleted stations under the new name), and a clone
-    // copies it along with the frozen legacy [CallActivity] snapshot the
-    // clone also inherits - which must likewise never be imported.
-    constexpr char importedKey[] = "ActivityDbImported";
-
-    if (m_config.reset_activity()) {
-        // The user asked to start clean. Wipe this configuration's
-        // stored activity AND the legacy ini keys: master's writeSettings
-        // removed the [CallActivity] group and rewrote RXActivity at
-        // every close, so a reset genuinely destroyed the old data.
-        // Leaving those keys behind would both hide a copy of everything
-        // the user asked to erase and let a later un-tick re-import a
-        // stale snapshot.
-        if (!db->clearConfig(config)) {
-            qCWarning(mainwindow_js8)
-                << "could not reset stored activity:" << db->error();
-            showStatusMessage(
-                tr("Could not reset stored activity - activity will not "
-                   "be saved this session (%1)")
-                    .arg(db->error()));
-            // Nothing is read and nothing is written for the rest of the
-            // session: the panes stay empty as asked, and no write can
-            // be destroyed by the wipe that retries at the next start.
-            m_activityStoreDisabled = true;
-            purgeLegacyActivityIni();
-            return false;
-        }
-
-        purgeLegacyActivityIni();
-        m_settings->setValue(importedKey, true);
-        return true;
-    }
-
-    if (m_settings->value(importedKey, false).toBool()) {
-        // The marker lives in the ini, the data in activity.db3 - a
-        // backup or a machine move that carries only JS8Call.ini would
-        // otherwise skip the import forever while the legacy keys sit
-        // there, readable and never read. If the marker is set but this
-        // configuration has nothing stored, import again.
-        bool probeOk = false;
-        if (db->hasConfig(config, &probeOk) || !probeOk) {
-            return true;
-        }
-        qCDebug(mainwindow_js8)
-            << "import marker set but no stored activity - re-importing";
-    }
-
-    // fallback band for records whose stored dial can't be resolved
-    // (manually added stations have dial == 0; out-of-band rows return
-    // ""): the band of the last-known dial frequency, i.e. the band the
-    // user last saw this data displayed on
-    m_settings->beginGroup("Common");
-    auto const lastDial =
-        m_settings
-            ->value("DialFreq", QVariant::fromValue<Frequency>(
-                                    Default::DIAL_FREQUENCY))
-            .value<Frequency>();
-    m_settings->endGroup();
-    auto const fallbackBand = m_config.bands()->find(lastDial);
-
-    // An empty fallbackBand is fine: "" is the out-of-plan bucket, which
-    // the panes load whenever the dial resolves to no band - exactly
-    // where a transverter/channelized user's un-banded legacy data
-    // should land.
-
-    // One transaction for the whole import, following Inbox's v1 -> v2
-    // migration: either every legacy row lands - and only then is the
-    // fire-once marker written - or nothing changes and the import
-    // retries on the next start. (Setting the marker after a partial
-    // import would silently lose the failed rows forever - the ini group
-    // is never rewritten, but never re-read either.)
-    if (!db->begin()) {
-        qCWarning(mainwindow_js8)
-            << "could not start legacy activity import:" << db->error();
-        return false;
-    }
-
-    bool allOk = true;
-    int imported = 0;
-    m_settings->beginGroup("CallActivity");
-    foreach (auto call, m_settings->allKeys()) {
-        auto values = m_settings->value(call).toMap();
-
-        ActivityDB::CallRecord r;
-        r.callsign = call;
-        r.snr = values.value("snr", -64).toInt();
-        r.grid = values.value("grid", "").toString();
-        r.dial = values.value("dial", 0).value<Frequency>();
-        r.offset = values.value("freq", 0).toInt();
-        r.tdrift = values.value("tdrift", 0).toFloat();
-        r.ackTimestamp = values.value("ackTimestamp").toDateTime();
-        r.utcTimestamp = values.value("utcTimestamp").toDateTime();
-        r.submode = values.value("submode", Varicode::JS8CallNormal).toInt();
-
-        // same rule as live persistence: a non-zero out-of-plan dial
-        // belongs to the "" bucket; only dial-less rows (master's manual
-        // adds) take the last-seen band
-        auto band = m_config.bands()->find(r.dial);
-        if (band.isEmpty() && r.dial == 0) {
-            band = fallbackBand;
-        }
-
-        if (db->upsertCall(config, band, r)) {
-            ++imported;
-        } else {
-            allOk = false;
-        }
-    }
-    m_settings->endGroup();
-
-    m_settings->beginGroup("UI_Constructor");
-    auto const html = m_settings->value("RXActivity", "").toString();
-    m_settings->endGroup();
-
-    if (!html.isEmpty()) {
-        // never clobber RX text a session has already stored for that
-        // band - the legacy blob is by definition the older data
-        bool haveOk = false;
-        auto const have = db->loadRxText(config, fallbackBand, &haveOk);
-        if (haveOk && have.isEmpty()) {
-            allOk = db->saveRxText(config, fallbackBand, html) && allOk;
-        } else if (!haveOk) {
-            allOk = false;
-        }
-    }
-
-    if (!allOk || !db->commit()) {
-        db->rollback();
-        qCWarning(mainwindow_js8)
-            << "legacy activity import failed - will retry on next start:"
-            << db->error();
-        return false;
-    }
-
-    m_settings->setValue(importedKey, true);
-
-    qCDebug(mainwindow_js8) << "imported" << imported
-                            << "legacy call activity rows into"
-                            << activityPath();
-    return true;
 }
 
 void UI_Constructor::clearActivity() {
@@ -6365,24 +5357,7 @@ void UI_Constructor::qsy(int const hzDelta) {
     // dial-less RAM-only entries must not be promoted into the store by
     // a waterfall nudge.
 
-    if (!m_callActivity.isEmpty()) {
-        beginActivityBatch();
-        for (auto [key, value] : m_callActivity.asKeyValueRange()) {
-            value.offset -= hzDelta;
-            // Write back the rows this bucket actually stores: those
-            // whose own dial resolves here, and dial-less rows (manual
-            // adds), which are filed under the bucket they were added
-            // on - hence the fallback, since Bands::find(0) is "". Rows
-            // keyed to another band did not QSY and keep their offsets.
-            auto const rowBand = m_config.bands()->find(value.dial);
-            if (rowBand == m_activityBand) {
-                persistCallActivity(value);
-            } else if (value.dial == 0 && !m_activityBand.isEmpty()) {
-                persistCallActivity(value, true);
-            }
-        }
-        endActivityBatch();
-    }
+    m_activityStorage->adjustCallActivityOffsets(hzDelta);
 
     displayActivity(true);
 }
@@ -6963,12 +5938,10 @@ QString UI_Constructor::callsignSelected(bool) {
         auto const offsetLo = selectedOffset - threshold;
         auto const offsetHi = selectedOffset + threshold;
 
-        // Aged-out stations are not on the air and must not claim a
-        // clicked decode: this result becomes the directed-reply target,
-        // so an unfiltered match would address a transmission to a
-        // station last heard weeks ago. The store keeps rows
-        // indefinitely, so the filter lives here as it does in the
-        // table's own render (unread senders stay exempt).
+        // Skip stations the Call Activity table no longer shows (see
+        // displayCallActivity): this result becomes the directed-reply
+        // target, and the unfiltered map could otherwise address a
+        // station last heard hours ago. Unread senders stay exempt.
         auto const aging = m_config.callsign_aging();
         auto const now = DriftingDateTime::currentDateTimeUtc();
 
@@ -7150,7 +6123,7 @@ void UI_Constructor::processActivity(bool force) {
     // one transaction for the whole drain: the rx AND command handlers
     // persist a row per station heard, and a busy cycle would otherwise
     // pay one autocommit per row
-    beginActivityBatch();
+    m_activityStorage->beginBatch();
 
     // Recent Rx Activity
     processRxActivity();
@@ -7170,7 +6143,7 @@ void UI_Constructor::processActivity(bool force) {
     // Process PSKReporter Spots
     processSpots();
 
-    endActivityBatch();
+    m_activityStorage->endBatch();
 
     m_rxDirty = false;
 }
@@ -7330,7 +6303,7 @@ void UI_Constructor::refreshInboxCounts() {
     if (inbox.open()) {
         // one transaction for the whole sender fan-out (each synthesized
         // sender persists through logCallActivity)
-        beginActivityBatch();
+        m_activityStorage->beginBatch();
         // reset inbox counts
         m_rxInboxCountCache.clear();
 
@@ -7380,7 +6353,7 @@ void UI_Constructor::refreshInboxCounts() {
             m_rxInboxCountCache[key] = groupMessageCounts[key];
         }
 
-        endActivityBatch();
+        m_activityStorage->endBatch();
     }
 }
 

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -248,7 +248,7 @@ void UI_Constructor::tryBandHop() {
             m->show();
 
 #if 0
-		  // TODO: jsherer - this is totally a hack because of the signal that gets emitted to clearActivity on band change...
+          // TODO: jsherer - this is totally a hack because of the signal that gets emitted to clearActivity on band change...
           QTimer *t = new QTimer(this);
           t->setInterval(250);
           t->setSingleShot(true);
@@ -321,10 +321,8 @@ void UI_Constructor::writeSettings() {
     m_settings->setValue("TimeDrift", DriftingDateTime::drift());
     m_settings->setValue("ShowTooltips", ui->actionShow_Tooltips->isChecked());
     m_settings->setValue("ShowStatusbar", ui->statusBar->isVisible());
-    // RXActivity now lives in activity.db3 (see ActivityDB), written as it
-    // changes. The legacy RXActivity ini key is deliberately no longer
-    // rewritten - older versions of the software can still read whatever
-    // it last held.
+    // RXActivity now lives in activity.db3 (see ActivityDB); the legacy
+    // ini key is left unwritten so older builds can still read it.
 
     m_settings->endGroup();
 
@@ -360,13 +358,9 @@ void UI_Constructor::writeSettings() {
 
     m_settings->endGroup();
 
-    // Call activity now lives in activity.db3 (see ActivityDB), written
-    // row-by-row as stations are heard rather than in bulk at shutdown, so
-    // a crash or SIGKILL no longer loses everything since the last clean
-    // close. The legacy [CallActivity] ini group is deliberately no longer
-    // rewritten - it is imported once (see importLegacyActivityIfNeeded)
-    // and then left in place for older versions of the software, following
-    // the inbox_v1 -> inbox_v2 migration pattern.
+    // Call activity now lives in activity.db3, written row-by-row as
+    // stations are heard; the legacy [CallActivity] group is imported
+    // once (importLegacyActivityIfNeeded) and left unwritten thereafter.
 }
 
 void UI_Constructor::applyPillSettings() {
@@ -395,7 +389,7 @@ void UI_Constructor::readSettings() {
     m_geometryNoControls =
         m_settings->value("geometryNoControls", saveGeometry()).toByteArray();
     restoreState(m_settings->value("state", saveState()).toByteArray());
-    
+
     // If messagePanel is docked ensure that it refreshes on program startup
     if (messagePanel_) {
         QTimer::singleShot(0, messagePanel_, [this]() {
@@ -438,10 +432,8 @@ void UI_Constructor::readSettings() {
     ui->actionShow_Statusbar->setChecked(
         m_settings->value("ShowStatusbar", true).toBool());
     ui->statusBar->setVisible(ui->actionShow_Statusbar->isChecked());
-    // RX text is loaded per-band from activity.db3 once the dial frequency
-    // (and hence the band) is known - see restoreActivity(). Loading
-    // the legacy un-banded RXActivity blob here is what attributed it to
-    // whatever band the rig happened to be polled on at startup (#267).
+    // RX text is loaded per-band once the dial frequency is known - see
+    // restoreActivity() (fixes #267: activity attributed to the wrong band)
     QTimer::singleShot(0, this, [this](){
         ui->textEditRX->verticalScrollBar()->setValue(
             ui->textEditRX->verticalScrollBar()->maximum());
@@ -540,19 +532,13 @@ void UI_Constructor::readSettings() {
         8);
     m_settings->endGroup();
 
-    // Call activity is loaded per-band from activity.db3 instead of being
-    // seeded here from the un-banded legacy [CallActivity] ini group -
-    // seeding it un-banded is what let one band's activity surface on
-    // another at startup (#267). The legacy ini data is imported into the
-    // database once, band-attributed via each record's dial frequency:
+    // Call activity is imported into activity.db3 once, band-attributed by
+    // each record's dial frequency (fixes #267), then loaded per-band.
     bool const activityReady = m_activityStorage->importLegacyActivityIfNeeded();
 
-    // Preload the last-known band's activity so the panes are populated
-    // even before (or without) a rig connection - once the rig reports a
-    // dial frequency, updateCurrentBand() switches to the right band's
-    // data if this guess was wrong. Skipped when a requested reset could
-    // not be applied: better empty panes than a session showing exactly
-    // what the user asked to remove.
+    // Preload the last-known band so the panes have data before (or
+    // without) a rig connection; updateCurrentBand() corrects the guess
+    // once the rig reports. Skipped if a requested reset failed to apply.
     if (activityReady || !m_config.reset_activity()) {
         m_settings->beginGroup("Common");
         auto const dial =
@@ -561,9 +547,8 @@ void UI_Constructor::readSettings() {
                                         Default::DIAL_FREQUENCY))
                 .value<Frequency>();
         m_settings->endGroup();
-        // populate the unread-message counts first: the seed's aging
-        // filter exempts unread senders, and an empty count cache at
-        // this point would age them out of the freshly seeded table
+        // must run before the seed below, or its aging filter won't see
+        // unread senders as exempt
         refreshInboxCounts();
         m_activityStorage->beginStartupGrace();
         restoreActivity(m_config.bands()->find(dial));
@@ -745,14 +730,11 @@ void UI_Constructor::on_actionFocus_Call_Activity_Table_triggered() {
     ui->tableWidgetCalls->setFocus();
 }
 
-// The explicit user-facing Clear actions also drop the matching stored
-// rows from activity.db3. (clearActivity() itself never deletes stored
-// rows - it also runs during band changes, where the outgoing band's
-// stored activity has to survive. Its refreshInboxCounts() call may
-// re-persist unread inbox senders, which is deliberate: unread senders
-// are always shown, and their rows key to their own message's band.)
+// The Clear actions also drop the matching rows from activity.db3;
+// clearActivity() itself never deletes stored rows, since it also runs
+// during ordinary band changes.
 void UI_Constructor::on_actionClear_All_Activity_triggered() {
-    // Deletes every band's stored history permanently, so it asks first.
+    // permanently deletes every band's stored history, so it asks first
     if (QMessageBox::Yes !=
         QMessageBox::question(
             this, tr("Clear All Activity"),
@@ -764,11 +746,8 @@ void UI_Constructor::on_actionClear_All_Activity_triggered() {
         return;
     }
 
-    // "All" spans bands: dropping only the current band's rows would let
-    // every other band's stored activity reload as if never cleared. The
-    // panes clear first because clearActivity()'s inbox refresh
-    // re-persists every unread sender, which would otherwise repopulate
-    // the store right after the wipe.
+    // panes clear first: clearActivity()'s inbox refresh re-persists
+    // unread senders, which would otherwise repopulate the store post-wipe
     clearActivity();
     m_activityStorage->clearAllActivity();
 }
@@ -959,7 +938,6 @@ void UI_Constructor::on_actionSettings_triggered() { openSettings(); }
 
 void UI_Constructor::openSettings(int tab) {
     m_config.select_tab(tab);
-    
     // Save scroll position before opening settings
     QScrollBar *bar = ui->textEditRX->verticalScrollBar();
     const bool wasAtBottom = (bar->value() == bar->maximum());
@@ -1024,7 +1002,7 @@ void UI_Constructor::openSettings(int tab) {
 
         m_opCall = m_config.opCall();
     }
-    
+
     // Restore scroll position after settings dialog
     QTimer::singleShot(0, this, [this, wasAtBottom, savedPos](){
         QScrollBar *bar = ui->textEditRX->verticalScrollBar();
@@ -1216,25 +1194,13 @@ void UI_Constructor::updateCurrentBand() {
     auto const &band_name = m_config.bands()->find(dial_frequency);
 
     if (m_lastBand == band_name) {
-        // The rig's report agrees with m_lastBand but the panes may be
-        // showing a different bucket - at startup they are preloaded
-        // from the LAST session's dial before the rig has reported one
-        // (e.g. the rig is parked on an out-of-plan frequency, whose
-        // activity lives in the "" bucket). Move the panes to the rig's
-        // actual bucket through the same path a band change takes.
-        // confirm only AFTER the switch: the flush inside it must still
-        // see the outgoing bucket as unconfirmed, or the startup guess's
-        // pane - which now holds this band's decodes too - is written
-        // under the guessed band
+        // panes may still show the startup-guessed bucket; move them
+        // to the rig's actual bucket even though the band name agrees
         m_activityStorage->bandUnchanged(band_name);
         return;
     }
 
-    // Move the panes to the new bucket BEFORE anything reads them: the
-    // WSJT-X status datagram below reports the selected DX call and its
-    // grid, which would otherwise still be the outgoing band's. The
-    // confirmation flag is set AFTER the switch, so the flush inside it
-    // still treats the outgoing bucket as the startup guess it is.
+    // switch panes before the WSJT-X status datagram below reads them
     m_activityStorage->bandChanged(band_name);
 
     m_wideGraph->setBand(band_name);
@@ -2905,19 +2871,11 @@ void UI_Constructor::cacheActivity(QString key) {
 }
 
 void UI_Constructor::restoreActivity(QString key) {
-    // When re-entering the bucket already on screen (a seed retry after
-    // the store recovers), the live panes are newer than any cache entry
-    // and must not be replaced.
+    // re-entering the bucket on screen: live panes are newer than any cache
     bool const sameBucket = m_activityStorage->isBucketLoaded() &&
                             key == m_activityStorage->currentBucket();
 
     if (!sameBucket) {
-        // Every cache is restored the same way, as on master: replace
-        // when this bucket has a snapshot, otherwise leave the panes as
-        // the caller left them. The bucket switch has already cleared
-        // them, so "no snapshot" correctly shows nothing; the startup
-        // preload deliberately does NOT clear, so the unread senders
-        // synthesized moments earlier survive into the seed.
         if (m_bandActivityBandCache.contains(key)) {
             m_bandActivity = m_bandActivityBandCache[key];
         }
@@ -2959,11 +2917,8 @@ void UI_Constructor::clearActivity() {
     m_rxCommandQueue.clear();
     m_lastTxMessage.clear();
 
-    // BEFORE the clears, as master ordered it: with the senders still in
-    // the map, refresh takes logCallActivity's update branch - the create
-    // branch would fire a call_new notification per unread sender on
-    // every band change. Senders reappear at the next refresh (message
-    // dock events), exactly as they always have.
+    // before the clears: with senders still in the map this hits the
+    // update branch, not the create branch that would notify per sender
     refreshInboxCounts();
     resetTimeDeltaAverage();
 
@@ -5347,24 +5302,16 @@ void UI_Constructor::qsy(int const hzDelta) {
 
     m_bandActivity.swap(bandActivity);
 
-    // Adjust call activity frequencies, mirroring each rewritten offset
-    // to the store (one transaction) - otherwise the stale persisted
-    // offsets come back at the next band round-trip or restart, and
-    // clicked decodes stop resolving to their stations. Only rows whose
-    // own dial belongs to the current band are written back: entries
-    // displayed here but keyed to another band (post-QSY stragglers,
-    // inbox senders carrying their message's dial) did not QSY, and
-    // dial-less RAM-only entries must not be promoted into the store by
-    // a waterfall nudge.
-
+    // mirrors the offset rewrite to the store, or stale offsets return
+    // at the next band round-trip and clicked decodes stop resolving
     m_activityStorage->adjustCallActivityOffsets(hzDelta);
 
     displayActivity(true);
 }
 
 void UI_Constructor::onDriftChanged(qint64 /*new_drift_ms*/) {
-    // here we reset the buffer position without clearing the buffer
-    // this makes the detected emit the correct k when drifting time
+    // resets k without clearing the buffer, so the detector emits the
+    // correct k across a drift change
     qCDebug(mainwindow_js8) << "Processing drift change.";
     m_detector->resetBufferPosition();
 }
@@ -5475,13 +5422,9 @@ void UI_Constructor::handle_transceiver_update(
 
     // ensure frequency display is correct
     // setRig();
-    // NOTE: the "state" property is deliberately set AFTER this call, as
-    // master did: the transceiver's very first report can carry a bogus
-    // frequency (e.g. the hamlib dummy backend's default when Rig=None),
-    // and the !state.isValid() guard in updateCurrentBand() discards it.
-    // The cost is a window until the second report during which RX text
-    // is appended to the preloaded bucket's pane; call activity is
-    // unaffected (rows are keyed by their own capture dial).
+    // "state" is set AFTER this call: the rig's first report can be bogus
+    // (e.g. hamlib's dummy backend with Rig=None), and updateCurrentBand()
+    // discards it via the !state.isValid() guard below.
     updateCurrentBand();
     displayDialFrequency();
     update_dynamic_property(ui->readFreq, "state", "ok");
@@ -5938,10 +5881,8 @@ QString UI_Constructor::callsignSelected(bool) {
         auto const offsetLo = selectedOffset - threshold;
         auto const offsetHi = selectedOffset + threshold;
 
-        // Skip stations the Call Activity table no longer shows (see
-        // displayCallActivity): this result becomes the directed-reply
-        // target, and the unfiltered map could otherwise address a
-        // station last heard hours ago. Unread senders stay exempt.
+        // Skip aged-out stations rather than let the reply/remove/block
+        // action silently target a neighbouring station instead.
         auto const aging = m_config.callsign_aging();
         auto const now = DriftingDateTime::currentDateTimeUtc();
 
@@ -5951,10 +5892,6 @@ QString UI_Constructor::callsignSelected(bool) {
                 if (aging && m_rxInboxCountCache.value(d.call, 0) <= 0 &&
                     d.utcTimestamp.isValid() &&
                     d.utcTimestamp.secsTo(now) / 60 >= aging) {
-                    // the best match for this offset has aged out:
-                    // select nothing rather than silently substituting a
-                    // neighbouring station, which would then receive the
-                    // directed reply (or the Remove/Block action)
                     return QString();
                 }
                 return d.call;
@@ -6120,9 +6057,7 @@ void UI_Constructor::processActivity(bool force) {
         return;
     }
 
-    // one transaction for the whole drain: the rx AND command handlers
-    // persist a row per station heard, and a busy cycle would otherwise
-    // pay one autocommit per row
+    // batch: avoid one autocommit per station across this whole drain
     m_activityStorage->beginBatch();
 
     // Recent Rx Activity
@@ -6301,8 +6236,7 @@ QString UI_Constructor::inboxPath() {
 void UI_Constructor::refreshInboxCounts() {
     auto inbox = Inbox(inboxPath());
     if (inbox.open()) {
-        // one transaction for the whole sender fan-out (each synthesized
-        // sender persists through logCallActivity)
+        // batch: each synthesized sender below persists via logCallActivity
         m_activityStorage->beginBatch();
         // reset inbox counts
         m_rxInboxCountCache.clear();

--- a/JS8_UI/mainwindow.cpp
+++ b/JS8_UI/mainwindow.cpp
@@ -321,7 +321,10 @@ void UI_Constructor::writeSettings() {
     m_settings->setValue("TimeDrift", DriftingDateTime::drift());
     m_settings->setValue("ShowTooltips", ui->actionShow_Tooltips->isChecked());
     m_settings->setValue("ShowStatusbar", ui->statusBar->isVisible());
-    m_settings->setValue("RXActivity", ui->textEditRX->toHtml());
+    // RXActivity now lives in activity.db3 (see ActivityDB), written as it
+    // changes. The legacy RXActivity ini key is deliberately no longer
+    // rewritten - older versions of the software can still read whatever
+    // it last held.
 
     m_settings->endGroup();
 
@@ -357,40 +360,13 @@ void UI_Constructor::writeSettings() {
 
     m_settings->endGroup();
 
-    auto now = DriftingDateTime::currentDateTimeUtc();
-    int callsignAging = m_config.callsign_aging();
-
-    m_settings->beginGroup("CallActivity");
-    m_settings->remove(""); // remove all keys in current group
-    foreach (auto cd, m_callActivity.values()) {
-        if (cd.call.trimmed().isEmpty()) {
-            continue;
-        }
-        if (callsignAging &&
-            cd.utcTimestamp.secsTo(now) / 60 >= callsignAging) {
-            continue;
-        }
-        m_settings->setValue(
-            cd.call.trimmed(),
-            QVariantMap{
-                {"snr", QVariant(cd.snr)},
-                {"grid", QVariant(cd.grid)},
-                {"dial", QVariant(cd.dial)},
-                {"freq", QVariant(cd.offset)},
-                {"tdrift", QVariant(cd.tdrift)},
-#if CACHE_CALL_DATETIME_AS_STRINGS
-                {"ackTimestamp",
-                 QVariant(cd.ackTimestamp.toString("yyyy-MM-dd hh:mm:ss"))},
-                {"utcTimestamp",
-                 QVariant(cd.utcTimestamp.toString("yyyy-MM-dd hh:mm:ss"))},
-#else
-                {"ackTimestamp", QVariant(cd.ackTimestamp)},
-                {"utcTimestamp", QVariant(cd.utcTimestamp)},
-#endif
-                {"submode", QVariant(cd.submode)},
-            });
-    }
-    m_settings->endGroup();
+    // Call activity now lives in activity.db3 (see ActivityDB), written
+    // row-by-row as stations are heard rather than in bulk at shutdown, so
+    // a crash or SIGKILL no longer loses everything since the last clean
+    // close. The legacy [CallActivity] ini group is deliberately no longer
+    // rewritten - it is imported once (see importLegacyActivityIfNeeded)
+    // and then left in place for older versions of the software, following
+    // the inbox_v1 -> inbox_v2 migration pattern.
 }
 
 void UI_Constructor::applyPillSettings() {
@@ -462,10 +438,10 @@ void UI_Constructor::readSettings() {
     ui->actionShow_Statusbar->setChecked(
         m_settings->value("ShowStatusbar", true).toBool());
     ui->statusBar->setVisible(ui->actionShow_Statusbar->isChecked());
-    ui->textEditRX->setHtml(
-        m_config.reset_activity()
-            ? ""
-            : m_settings->value("RXActivity", "").toString());
+    // RX text is loaded per-band from activity.db3 once the dial frequency
+    // (and hence the band) is known - see restoreActivity(). Loading
+    // the legacy un-banded RXActivity blob here is what attributed it to
+    // whatever band the rig happened to be polled on at startup (#267).
     QTimer::singleShot(0, this, [this](){
         ui->textEditRX->verticalScrollBar()->setValue(
             ui->textEditRX->verticalScrollBar()->maximum());
@@ -564,51 +540,59 @@ void UI_Constructor::readSettings() {
         8);
     m_settings->endGroup();
 
-    if (m_config.reset_activity()) {
-        // NOOP
-    } else {
-        m_settings->beginGroup("CallActivity");
-        foreach (auto call, m_settings->allKeys()) {
+    // Call activity is loaded per-band from activity.db3 instead of being
+    // seeded here from the un-banded legacy [CallActivity] ini group -
+    // seeding it un-banded is what let one band's activity surface on
+    // another at startup (#267). The legacy ini data is imported into the
+    // database once, band-attributed via each record's dial frequency:
+    bool const activityReady = importLegacyActivityIfNeeded();
 
-            auto values = m_settings->value(call).toMap();
-
-            auto snr = values.value("snr", -64).toInt();
-            auto grid = values.value("grid", "").toString();
-            auto dial = values.value("dial", 0).value<Frequency>();
-            auto freq = values.value("freq", 0).toInt();
-            auto tdrift = values.value("tdrift", 0).toFloat();
-
-#if CACHE_CALL_DATETIME_AS_STRINGS
-            auto ackTimestampStr = values.value("ackTimestamp", "").toString();
-            auto ackTimestamp =
-                QDateTime::fromString(ackTimestampStr, "yyyy-MM-dd hh:mm:ss");
-            ackTimestamp.setUtcOffset(0);
-
-            auto utcTimestampStr = values.value("utcTimestamp", "").toString();
-            auto utcTimestamp =
-                QDateTime::fromString(utcTimestampStr, "yyyy-MM-dd hh:mm:ss");
-            utcTimestamp.setUtcOffset(0);
-#else
-            auto ackTimestamp = values.value("ackTimestamp").toDateTime();
-            auto utcTimestamp = values.value("utcTimestamp").toDateTime();
-#endif
-            auto submode =
-                values.value("submode", Varicode::JS8CallNormal).toInt();
-
-            CallDetail cd = {};
-            cd.call = call;
-            cd.snr = snr;
-            cd.grid = grid;
-            cd.dial = dial;
-            cd.offset = freq;
-            cd.tdrift = tdrift;
-            cd.ackTimestamp = ackTimestamp;
-            cd.utcTimestamp = utcTimestamp;
-            cd.submode = submode;
-
-            logCallActivity(cd, false);
-        }
+    // Preload the last-known band's activity so the panes are populated
+    // even before (or without) a rig connection - once the rig reports a
+    // dial frequency, updateCurrentBand() switches to the right band's
+    // data if this guess was wrong. Skipped when a requested reset could
+    // not be applied: better empty panes than a session showing exactly
+    // what the user asked to remove.
+    if (activityReady || !m_config.reset_activity()) {
+        m_settings->beginGroup("Common");
+        auto const dial =
+            m_settings
+                ->value("DialFreq", QVariant::fromValue<Frequency>(
+                                        Default::DIAL_FREQUENCY))
+                .value<Frequency>();
         m_settings->endGroup();
+        // populate the unread-message counts first: the seed's aging
+        // filter exempts unread senders, and an empty count cache at
+        // this point would age them out of the freshly seeded table
+        refreshInboxCounts();
+        m_activityStartupTimer.start();
+        restoreActivity(m_config.bands()->find(dial));
+
+        if (!activityDB()->isOpen() && !m_config.reset_activity()) {
+            // Degraded start: master restored the pane from the ini, and
+            // that copy is still there (this change never rewrites it).
+            // Show it rather than an empty pane - purely for display,
+            // since an unseeded bucket refuses to save.
+            m_settings->beginGroup("UI_Constructor");
+            auto const legacy =
+                m_settings->value("RXActivity", "").toString();
+            m_settings->endGroup();
+            if (!legacy.isEmpty()) {
+                ui->textEditRX->setHtml(legacy);
+                m_rxFrameBlockNumbers.clear();
+                // Mark the copy's extent: the recovery seed and the
+                // close-time sweep treat only text below it as session
+                // text (see m_rxTextLegacyBand).
+                auto const *doc = ui->textEditRX->document();
+                m_rxTextLegacyBand = m_activityBand;
+                m_rxTextLegacyBlocks = doc->blockCount();
+                if (doc->lastBlock().length() <= 1) {
+                    // an append may splice into a trailing empty block
+                    // (writeNoticeTextToUI's guard) - count it as below
+                    --m_rxTextLegacyBlocks;
+                }
+            }
+        }
     }
 
     QTimer::singleShot(0, this, [this]{
@@ -786,8 +770,79 @@ void UI_Constructor::on_actionFocus_Call_Activity_Table_triggered() {
     ui->tableWidgetCalls->setFocus();
 }
 
+// The explicit user-facing Clear actions also drop the matching stored
+// rows from activity.db3. (clearActivity() itself never deletes stored
+// rows - it also runs during band changes, where the outgoing band's
+// stored activity has to survive. Its refreshInboxCounts() call may
+// re-persist unread inbox senders, which is deliberate: unread senders
+// are always shown, and their rows key to their own message's band.)
 void UI_Constructor::on_actionClear_All_Activity_triggered() {
+    // This now deletes stored history for EVERY band, permanently - the
+    // ini no longer keeps a copy - so it asks first, as the context-menu
+    // path always has.
+    if (QMessageBox::Yes !=
+        QMessageBox::question(
+            this, "Clear All Activity",
+            "Clear all call activity and RX history for every band?\n\n"
+            "This permanently deletes the stored history, not just what "
+            "is on screen.",
+            QMessageBox::Yes | QMessageBox::No)) {
+        return;
+    }
+
+    // Store first, UI second: clearing the panes before the store can
+    // leave a half-cleared state - the emptied pane arms the debounced
+    // saver, which then deletes the current band's stored text even
+    // though the user was told the clear had failed.
+    // "All" spans bands: dropping only the current band's rows would let
+    // every other band's stored activity reload as if never cleared.
+    // The panes clear first - clearRXActivity() is also what unsticks the
+    // compose box, and master cleared unconditionally - and the store is
+    // wiped AFTER, because clearActivity()'s inbox refresh re-persists
+    // every unread sender and would otherwise repopulate the store the
+    // wipe had just emptied.
     clearActivity();
+
+    bool const stored = m_activityStoreDisabled ||
+                        activityDB()->clearConfig(activityConfigId());
+    if (!stored) {
+        qCWarning(mainwindow_js8)
+            << "clear all activity failed:" << activityDB()->error();
+        showStatusMessage(tr("Could not clear stored activity (%1)")
+                              .arg(activityDB()->error()));
+        // the pane was cleared but the store was not: a save would write
+        // the emptied pane over stored text, so force a re-merge first
+        m_activitySeeded.remove(m_activityBand);
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_seedRetryTimer.start();
+    }
+
+    // The legacy ini keys hold a full copy of what was just cleared, and
+    // master's writeSettings erased them at every close. Leaving them
+    // would keep the "cleared" activity readable on disk and let an
+    // older build resurrect it.
+    purgeLegacyActivityIni();
+
+    // "All" also means the session's RAM band caches - otherwise a hop
+    // to a previously visited band would restore its pre-clear snapshot
+    // and the next debounced save would write the cleared history
+    // straight back into the store.
+    m_callActivityBandCache.clear();
+    m_rxTextBandCache.clear();
+    m_bandActivityBandCache.clear();
+    m_heardGraphIncomingBandCache.clear();
+    m_heardGraphOutgoingBandCache.clear();
+    m_rxTextDirtyBands.clear();
+    // Every bucket must be re-seeded: on success because the store is
+    // empty (and clearActivity's inbox refresh may have written unread
+    // senders back into it), on failure because the panes no longer
+    // contain the stored history and a save would destroy it.
+    m_activitySeeded.clear();
+    m_rxTextLegacyBand.clear();
+    m_rxTextLegacyBlocks = 0;
+    m_rxTextLastSavedRevision = ui->textEditRX->document()->revision();
+    m_rxTextLastSavedBand = m_activityBand;
 }
 
 void UI_Constructor::on_actionClear_Band_Activity_triggered() {
@@ -795,11 +850,57 @@ void UI_Constructor::on_actionClear_Band_Activity_triggered() {
 }
 
 void UI_Constructor::on_actionClear_RX_Activity_triggered() {
+    // Store first (see Clear All): if the delete fails, the pane keeps
+    // its text and no later seed can splice the stored history back in
+    // and re-persist it, silently undoing the clear.
+    bool const stored =
+        m_activityStoreDisabled ||
+        activityDB()->clearRxText(activityConfigId(), m_activityBand);
+    if (!stored) {
+        qCWarning(mainwindow_js8)
+            << "clear RX activity failed:" << activityDB()->error();
+        showStatusMessage(tr("Could not clear stored RX text (%1)")
+                              .arg(activityDB()->error()));
+        // The pane no longer holds the stored text, so a save would
+        // overwrite it: force a re-merge before saves resume, and stop
+        // the debounce the pane clear below arms - otherwise its retry
+        // seeds the bucket and puts the "cleared" text back on screen.
+        m_activitySeeded.remove(m_activityBand);
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_seedRetryTimer.start(); // hold the retry off for its interval
+    }
+    if (m_activityBand == m_rxTextLegacyBand) {
+        // whatever the clear leaves on screen, it is not the legacy copy
+        m_rxTextLegacyBand.clear();
+        m_rxTextLegacyBlocks = 0;
+    }
+    // clears unconditionally - this is also the compose box's way out
     clearRXActivity();
+    m_rxTextLastSavedRevision = ui->textEditRX->document()->revision();
+    m_rxTextLastSavedBand = m_activityBand;
+    m_rxTextDirtyBands.remove(m_activityBand);
 }
 
 void UI_Constructor::on_actionClear_Call_Activity_triggered() {
+    if (!m_activityStoreDisabled &&
+        !activityDB()->deleteCalls(activityConfigId(), m_activityBand)) {
+        qCWarning(mainwindow_js8)
+            << "clear call activity failed:" << activityDB()->error();
+        showStatusMessage(tr("Could not clear stored call activity (%1)")
+                              .arg(activityDB()->error()));
+        // deliberately NOT un-seeded: the RX pane is untouched and still
+        // contains this bucket's stored text, so forcing a re-seed would
+        // splice that history in a second time. The rows simply return
+        // at the next session, which the message above reports.
+    }
     clearCallActivity();
+    // Bucket-scoped by design: a row displayed here but stored under
+    // another band (its own dial's band - e.g. a decode that completed
+    // just after a QSY) is that band's history, which this action cannot
+    // see and must not destroy. Unread inbox senders reappear regardless
+    // - they are re-synthesized from inbox.db3, the source of truth for
+    // unread mail.
 }
 
 void UI_Constructor::on_actionSetOffset_triggered() {
@@ -1233,16 +1334,31 @@ void UI_Constructor::updateCurrentBand() {
     auto const &band_name = m_config.bands()->find(dial_frequency);
 
     if (m_lastBand == band_name) {
+        // The rig's report agrees with m_lastBand but the panes may be
+        // showing a different bucket - at startup they are preloaded
+        // from the LAST session's dial before the rig has reported one
+        // (e.g. the rig is parked on an out-of-plan frequency, whose
+        // activity lives in the "" bucket). Move the panes to the rig's
+        // actual bucket through the same path a band change takes.
+        // confirm only AFTER the switch: the flush inside it must still
+        // see the outgoing bucket as unconfirmed, or the startup guess's
+        // pane - which now holds this band's decodes too - is written
+        // under the guessed band
+        if (m_activityBandLoaded && m_activityBand != band_name) {
+            switchActivityBucket(band_name);
+        }
+        m_activityBandConfirmed = true;
+        m_activityBandConfirmedBands.insert(band_name);
         return;
     }
 
-    cacheActivity(m_lastBand);
-
-    // clear activity on startup if asked or on when the previous band is not
-    // empty
-    if (m_config.reset_activity() || !m_lastBand.isEmpty()) {
-        clearActivity();
-    }
+    // Move the panes to the new bucket BEFORE anything reads them: the
+    // WSJT-X status datagram below reports the selected DX call and its
+    // grid, which would otherwise still be the outgoing band's. The
+    // confirmation flag is set AFTER the switch, so the flush inside it
+    // still treats the outgoing bucket as the startup guess it is.
+    switchActivityBucket(band_name);
+    m_activityBandConfirmed = true;
 
     m_wideGraph->setBand(band_name);
 
@@ -1294,7 +1410,6 @@ void UI_Constructor::updateCurrentBand() {
     m_lastBand = band_name;
 
     band_changed();
-    restoreActivity(m_lastBand);
 }
 
 void UI_Constructor::displayDialFrequency() {
@@ -1442,6 +1557,95 @@ void UI_Constructor::closeEvent(QCloseEvent *e) {
     }
     m_valid = false; // suppresses subprocess errors
     m_config.transceiver_offline();
+    // Final flush of the current band's RX text (covers anything the
+    // debounced save timer hasn't written yet). If the bucket was never
+    // seeded - the store was unusable at first visit - make one last
+    // seed attempt: saves are suppressed while unseeded, so without this
+    // the whole session's RX text would be discarded, where the legacy
+    // ini path always wrote it. The flag keeps the flush below from
+    // re-entering the seed's own retry (and its table rebuild) while the
+    // window is tearing down.
+    if (!m_activitySeeded.contains(m_activityBand) &&
+        !m_activityStoreDisabled && activityDB()->isOpen()) {
+        seedActivityForBand(m_activityBand);
+    }
+    m_activityShuttingDown = true;
+    m_activityBandConfirmed = true; // the guess, if any, ends here
+    saveRxTextForBand(m_activityBand);
+
+    // Bands whose text never reached the store - visited while it was
+    // down, or left before a seed succeeded - survive only in the RAM
+    // band cache, and this is their last chance. Append to whatever is
+    // stored rather than replacing it: the cached document does not
+    // contain that band's earlier history.
+    if (!m_activityStoreDisabled) {
+        foreach (auto const &dirty, m_rxTextDirtyBands) {
+            if (dirty == m_activityBand ||
+                !m_rxTextBandCache.contains(dirty)) {
+                continue;
+            }
+            if (!m_activityBandConfirmedBands.contains(dirty)) {
+                // this bucket was only ever the startup guess, and its
+                // pane collected text heard before the rig reported a
+                // band - writing it here would file that text under a
+                // band it was never heard on
+                continue;
+            }
+            auto cached = m_rxTextBandCache[dirty];
+            QTextDocument cachedDoc;
+            cachedDoc.setHtml(cached);
+            if (dirty == m_rxTextLegacyBand) {
+                // the cached top is the degraded start's legacy ini
+                // copy - already in the store via the import; only what
+                // the session added below it is worth sweeping
+                cached = htmlBelowLegacyCopy(&cachedDoc);
+                if (cached.isEmpty()) {
+                    continue;
+                }
+                cachedDoc.setHtml(cached);
+            }
+            if (cachedDoc.isEmpty()) {
+                // a cleared pane serialises to a full HTML skeleton, so
+                // the emptiness test has to be on the document: storing
+                // the skeleton would resurrect the cleared row
+                activityDB()->clearRxText(activityConfigId(), dirty);
+                continue;
+            }
+
+            if (m_activitySeeded.contains(dirty)) {
+                // the cached document already contains this bucket's
+                // stored history (that is what seeding merged in), so it
+                // replaces the row rather than being appended to it
+                activityDB()->saveRxText(activityConfigId(), dirty,
+                                         cached);
+                continue;
+            }
+
+            // never seeded: the cached text is this session's only, and
+            // whatever is stored is older history it does not contain
+            bool ok = false;
+            auto const storedHtml =
+                activityDB()->loadRxText(activityConfigId(), dirty, &ok);
+            if (!ok) {
+                continue; // cannot tell what is there; do not overwrite
+            }
+            if (storedHtml.isEmpty()) {
+                activityDB()->saveRxText(activityConfigId(), dirty,
+                                         cached);
+                continue;
+            }
+            QTextDocument doc;
+            doc.setHtml(storedHtml);
+            QTextCursor cursor(&doc);
+            cursor.movePosition(QTextCursor::End);
+            if (cursor.block().length() > 1) {
+                cursor.insertBlock();
+            }
+            cursor.insertHtml(cached);
+            activityDB()->saveRxText(activityConfigId(), dirty,
+                                     doc.toHtml());
+        }
+    }
     writeSettings();
     m_guiTimer.stop();
     m_prefixes.reset();
@@ -2278,6 +2482,10 @@ void UI_Constructor::logCallActivity(CallDetail d, bool spot) {
         }
     }
 
+    // mirror the row to activity.db3 as it changes, so it survives any
+    // kind of exit (write-on-change, not write-on-close)
+    persistCallActivity(d);
+
     // enqueue for spotting to psk reporter
     if (spot) {
         m_rxCallQueue.append(d);
@@ -2895,6 +3103,10 @@ void UI_Constructor::stopTx2() {
 
 void UI_Constructor::TxAgain() { auto_tx_mode(true); }
 
+// The RAM band caches are the session's display layer, exactly as on
+// master: hops restore the panes verbatim, with or without a working
+// store. activity.db3 sits underneath as a write-through store plus a
+// once-per-session seed of each bucket's history (seedActivityForBand).
 void UI_Constructor::cacheActivity(QString key) {
     m_callActivityBandCache[key] = m_callActivity;
     m_bandActivityBandCache[key] = m_bandActivity;
@@ -2903,28 +3115,844 @@ void UI_Constructor::cacheActivity(QString key) {
     m_heardGraphOutgoingBandCache[key] = m_heardGraphOutgoing;
 }
 
+// The one path that moves the panes from one storage bucket to another:
+// flush and park what is on screen under the bucket it belongs to, empty
+// the panes, then restore the target bucket's own view. Every caller -
+// a band change, the rig's first report correcting the startup guess -
+// goes through here, so no path can leave one bucket's activity on
+// screen under another's name (which is #267 itself).
+/**
+ * @brief Move the activity panes from one storage bucket to another.
+ * @param band The bucket to show: a band name, or "" for out-of-plan.
+ *
+ * Flushes and parks what is on screen under the bucket it belongs to,
+ * clears the panes, then restores the target bucket's own view. Every
+ * caller - a band change, and the rig's first report correcting the
+ * startup guess - goes through here, so no path can leave one bucket's
+ * activity on screen under another's name, which is issue #267 itself.
+ */
+void UI_Constructor::switchActivityBucket(QString const &band) {
+    if (m_activityBandLoaded && m_activityBand == band) {
+        return;
+    }
+    if (m_activityBandLoaded) {
+        // saveRxTextForBand declines while the bucket is unconfirmed -
+        // the pane may hold text heard on the band we are moving TO -
+        // and marks it dirty, so cacheActivity below keeps it and the
+        // close-time sweep still gets a chance at it
+        saveRxTextForBand(m_activityBand);
+        cacheActivity(m_activityBand);
+    }
+
+    if (m_lastBand.isEmpty()) {
+        // The rig's first report, correcting the startup guess. Master
+        // cleared nothing here, so only the two per-bucket panes move:
+        // clearActivity() would also empty the compose box and the
+        // decode, command and spot queues the session has accumulated.
+        ui->textEditRX->clear();
+        m_rxFrameBlockNumbers.clear();
+        clearCallActivity();
+    } else {
+        clearActivity();
+    }
+    restoreActivity(band);
+}
+
 void UI_Constructor::restoreActivity(QString key) {
-    if (m_callActivityBandCache.contains(key)) {
-        m_callActivity = m_callActivityBandCache[key];
+    // When re-entering the bucket already on screen (a seed retry after
+    // the store recovers), the live panes are newer than any cache entry
+    // and must not be replaced.
+    bool const sameBucket = m_activityBandLoaded && key == m_activityBand;
+
+    if (!sameBucket) {
+        // Every cache is restored the same way, as on master: replace
+        // when this bucket has a snapshot, otherwise leave the panes as
+        // the caller left them. switchActivityBucket() has already
+        // cleared them, so "no snapshot" correctly shows nothing; the
+        // startup preload deliberately does NOT clear, so the unread
+        // senders synthesized moments earlier survive into the seed.
+        if (m_bandActivityBandCache.contains(key)) {
+            m_bandActivity = m_bandActivityBandCache[key];
+        }
+        if (m_heardGraphIncomingBandCache.contains(key)) {
+            m_heardGraphIncoming = m_heardGraphIncomingBandCache[key];
+        }
+        if (m_heardGraphOutgoingBandCache.contains(key)) {
+            m_heardGraphOutgoing = m_heardGraphOutgoingBandCache[key];
+        }
+        if (m_callActivityBandCache.contains(key)) {
+            m_callActivity = m_callActivityBandCache[key];
+        }
+        if (m_rxTextBandCache.contains(key)) {
+            ui->textEditRX->setHtml(m_rxTextBandCache[key]);
+        }
+        // the document was rebuilt: block indexes remembered for
+        // in-progress multi-frame messages point into the old document
+        m_rxFrameBlockNumbers.clear();
+        // what was restored is what the cache holds; disarm the saver
+        // and resync its change tracking - EXCEPT when a flush for this
+        // band failed earlier (dirty), where the tracking must keep
+        // reporting unsaved so the next flush retries
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_rxTextLastSavedRevision =
+            m_rxTextDirtyBands.contains(key)
+                ? -1
+                : ui->textEditRX->document()->revision();
+        m_rxTextLastSavedBand = key;
+        if (m_rxTextDirtyBands.contains(key)) {
+            // this band's last flush failed: actually re-arm the timer,
+            // or a quiet band never retries (nothing else restarts it -
+            // only document activity does)
+            m_rxTextSaveTimer.start();
+        }
+        QTimer::singleShot(0, this, [this]() {
+            ui->textEditRX->verticalScrollBar()->setValue(
+                ui->textEditRX->verticalScrollBar()->maximum());
+        });
     }
 
-    if (m_bandActivityBandCache.contains(key)) {
-        m_bandActivity = m_bandActivityBandCache[key];
-    }
+    m_activityBand = key;
+    m_activityBandLoaded = true;
 
-    if (m_rxTextBandCache.contains(key)) {
-        ui->textEditRX->setHtml(m_rxTextBandCache[key]);
-    }
-
-    if (m_heardGraphIncomingBandCache.contains(key)) {
-        m_heardGraphIncoming = m_heardGraphIncomingBandCache[key];
-    }
-
-    if (m_heardGraphOutgoingBandCache.contains(key)) {
-        m_heardGraphOutgoing = m_heardGraphOutgoingBandCache[key];
+    // first visit this session: merge the bucket's stored history in
+    if (!m_activitySeeded.contains(key)) {
+        seedActivityForBand(key);
     }
 
     displayActivity(true);
+}
+
+/**
+ * @brief Path of the per-band activity store, beside the message inbox.
+ *
+ * Per-band persistent activity storage keyed by (configuration, band,
+ * callsign) - see ActivityDB and issue #267.
+ */
+QString UI_Constructor::activityPath() const {
+    return QDir::toNativeSeparators(
+        m_config.writeable_data_dir().absoluteFilePath("activity.db3"));
+}
+
+/**
+ * @brief The activity store, opened on first use.
+ *
+ * A store that fails to open - or that closed itself after repeated
+ * failures - is retried on a throttle rather than per call, and the
+ * operator is told once per failure episode that activity is not being
+ * saved. Callers may always use the returned object: every method on it
+ * is a no-op while it is closed.
+ */
+ActivityDB *UI_Constructor::activityDB() {
+    // a failed open (transient mount problem, contended lock at launch) is
+    // retried, throttled so a persistently broken store doesn't pay the
+    // open attempt on every decode
+    // Arm the reopen throttle however the handle ended up closed - a
+    // failed open() below, or the self-close after consecutive
+    // read/write failures - so a store that breaks mid-session is also
+    // retried, not just one that failed at launch. Discovery of a
+    // self-close is also the one operator-visible signal for it (the
+    // per-write warnings are suppressed once the handle is closed).
+    if (m_activityDB && !m_activityDB->isOpen() &&
+        !m_activityDBRetryTimer.isValid()) {
+        m_activityDBRetryTimer.start();
+        qCWarning(mainwindow_js8)
+            << "activity store closed after repeated failures:"
+            << m_activityDB->error();
+        showStatusMessage(
+            tr("Activity database unavailable - activity is not being "
+               "saved (%1)")
+                .arg(m_activityDB->error()));
+    }
+    bool const retrying = m_activityDB && !m_activityDB->isOpen() &&
+                          m_activityDBRetryTimer.isValid() &&
+                          m_activityDBRetryTimer.hasExpired(30 * 1000) &&
+                          m_activityBatchDepth == 0;
+    if (retrying) {
+        // never while a batch holds the old handle: callers inside
+        // beginActivityBatch()/endActivityBatch() would be left with a
+        // dangling pointer and a vanished transaction
+        m_activityDB.reset();
+    }
+    if (!m_activityDB) {
+        m_activityDB = std::make_unique<ActivityDB>(activityPath());
+        if (!m_activityDB->open()) {
+            qCWarning(mainwindow_js8)
+                << "could not open" << activityPath() << ":"
+                << m_activityDB->error();
+            // one visible sign per failure episode - NOT per 30s retry:
+            // showStatusMessage temporarily hides the statusbar's mode
+            // and frequency readouts, so a blink every retry would blank
+            // the operator's primary readouts indefinitely
+            if (!retrying) {
+                showStatusMessage(
+                    tr("Activity database unavailable - activity will "
+                       "not be saved (%1)")
+                        .arg(m_activityDB->error()));
+            }
+            m_activityDBRetryTimer.start();
+        } else {
+            m_activityDBRetryTimer.invalidate();
+            if (retrying && m_activityBandLoaded &&
+                !m_activitySeeded.contains(m_activityBand)) {
+                // the store recovered while the operator sat on a bucket
+                // that could never be seeded - seed it now (deferred:
+                // this accessor is called from paths a seed re-enters)
+                QTimer::singleShot(0, this, [this]() {
+                    if (m_activityBandLoaded &&
+                        !m_activitySeeded.contains(m_activityBand)) {
+                        seedActivityForBand(m_activityBand);
+                        displayActivity(true);
+                    }
+                });
+            }
+        }
+    }
+    return m_activityDB.get();
+}
+
+// Nested write bursts (a decode drain whose handlers also refresh inbox
+// counts, say) share one transaction; the outermost end commits.
+// Batches are LAZY: opening one only records the intent, and the
+// transaction starts at the first write inside it. A decode cycle that
+// turns out to persist nothing then costs nothing - no BEGIN IMMEDIATE
+// taking the write lock on the GUI thread (with its 5 s busy timeout),
+// and no store-reopen probe on behalf of a caller that never writes.
+/**
+ * @brief Open a write batch; nested batches share one transaction.
+ *
+ * Lazy: the transaction starts at the first write inside the batch, so a
+ * decode cycle that persists nothing costs nothing.
+ */
+void UI_Constructor::beginActivityBatch() { ++m_activityBatchDepth; }
+
+/// @brief Start the transaction a batch deferred, at its first write.
+void UI_Constructor::startActivityBatchIfPending() {
+    if (m_activityBatchDepth > 0 && m_activityDB &&
+        m_activityDB->isOpen() && !m_activityDB->inTransaction()) {
+        m_activityDB->begin();
+    }
+}
+
+/// @brief Close the outermost batch, committing its transaction.
+void UI_Constructor::endActivityBatch() {
+    if (m_activityBatchDepth == 1) {
+        // commit on the same handle begin() used: no activityDB() call
+        // here, so the accessor cannot swap in a fresh instance first,
+        // and a handle that died mid-batch (no transaction any more)
+        // stays silent instead of logging a misleading empty error
+        if (m_activityDB && m_activityDB->inTransaction() &&
+            !m_activityDB->commit()) {
+            qCWarning(mainwindow_js8)
+                << "could not commit activity batch:"
+                << m_activityDB->error();
+        }
+    }
+    --m_activityBatchDepth;
+}
+
+// Activity is keyed by a per-configuration UUID generated once and
+// stored in the configuration's own settings - NOT by the configuration
+// name. The id follows the configuration through renames automatically,
+// is purged with the settings by MultiSettings' "Reset Configuration"
+// (orphaning the old rows and starting clean, with no wipe heuristics
+// that could misfire), and a clone shares its source's id - and hence
+// its activity view - until either is reset. The id is captured once:
+// during a configuration switch MultiSettings updates its state before
+// this window closes, and the outgoing configuration's final flush must
+// not land under the incoming configuration's key.
+/**
+ * @brief The storage key for this MultiSettings configuration.
+ * @return A UUID generated once into the configuration's own settings.
+ */
+QString UI_Constructor::activityConfigId() const {
+    if (m_activityConfigId.isEmpty()) {
+        auto id = m_settings->value("ActivityDbId").toString();
+        if (id.isEmpty()) {
+            id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+            m_settings->setValue("ActivityDbId", id);
+        }
+        m_activityConfigId = id;
+    }
+    return m_activityConfigId;
+}
+
+/// @brief Convert a displayed call detail into a storable row.
+ActivityDB::CallRecord UI_Constructor::toCallRecord(CallDetail const &d) const {
+    ActivityDB::CallRecord r;
+    r.callsign = d.call.trimmed();
+    r.through = d.through;
+    r.snr = d.snr;
+    r.grid = d.grid;
+    r.dial = d.dial;
+    r.offset = d.offset;
+    r.bits = d.bits;
+    r.tdrift = d.tdrift;
+    r.cqTimestamp = d.cqTimestamp;
+    r.ackTimestamp = d.ackTimestamp;
+    r.utcTimestamp = d.utcTimestamp;
+    r.submode = d.submode;
+    return r;
+}
+
+/// @brief Convert a stored row back into a displayed call detail.
+UI_Constructor::CallDetail
+UI_Constructor::fromCallRecord(ActivityDB::CallRecord const &r) const {
+    CallDetail cd = {};
+    cd.call = r.callsign;
+    cd.through = r.through;
+    cd.snr = r.snr;
+    cd.grid = r.grid;
+    cd.dial = r.dial;
+    cd.offset = r.offset;
+    cd.bits = r.bits;
+    cd.tdrift = r.tdrift;
+    cd.cqTimestamp = r.cqTimestamp;
+    cd.ackTimestamp = r.ackTimestamp;
+    cd.utcTimestamp = r.utcTimestamp;
+    cd.submode = r.submode;
+    return cd;
+}
+
+// Rows are filed under the band of their own dial frequency
+// (processDecodeEvent deliberately stamps records with the capture-time
+// dial, so decodes completing after a QSY and inbox senders keep the
+// band they were heard on - keying by the live band would be #267 all
+// over again). A dial that resolves to no band files under "" - the
+// out-of-plan bucket, which round-trips only to out-of-plan operation
+// and gives transverter/channelized users the persistence the legacy
+// un-banded ini provided. fallbackToCurrentBand is passed by the call
+// sites where a dial-less entry genuinely belongs to the bucket on
+// screen instead: a manually added station, a logbook grid backfill,
+// and qsy()'s offset write-back for those same rows.
+/**
+ * @brief Write one call-activity row to the store.
+ * @param d The row to persist.
+ * @param fallbackToCurrentBand File a row carrying no dial under the
+ *        bucket on screen; passed only where that is genuinely where it
+ *        belongs (a manually added station, a logbook grid backfill).
+ */
+void UI_Constructor::persistCallActivity(CallDetail const &d,
+                                         bool fallbackToCurrentBand) {
+    if (m_activityStoreDisabled || d.call.trimmed().isEmpty()) {
+        return;
+    }
+
+    auto band = m_config.bands()->find(d.dial);
+    if (band.isEmpty() && d.dial == 0 && fallbackToCurrentBand &&
+        m_activityBandConfirmed) {
+        // only once the rig has confirmed the bucket: filing under the
+        // startup guess would strand the row on a band the operator is
+        // not on (saveRxTextForBand refuses for the same reason)
+        band = m_activityBand;
+    }
+
+    auto const r = toCallRecord(d);
+    activityDB(); // resolve (and possibly recover) before the batch opens
+    startActivityBatchIfPending();
+    if (band != m_activityBand) {
+        // stored into a bucket other than the one on screen (a decode
+        // that completed after a QSY, an inbox sender carrying its
+        // message's dial): drop that bucket's cached view so the next
+        // visit re-seeds and the row is actually visible there
+        m_activitySeeded.remove(band);
+        m_callActivityBandCache.remove(band);
+    }
+
+    if (!activityDB()->upsertCall(activityConfigId(), band, r) &&
+        activityDB()->isOpen()) {
+        // a failed open is already reported (throttled) by activityDB()
+        qCWarning(mainwindow_js8) << "could not persist call activity for"
+                                  << r.callsign << ":"
+                                  << activityDB()->error();
+    }
+}
+
+// One-time-per-session merge of a bucket's stored history under whatever
+// the session has already accumulated for it: RAM wins per callsign on a
+// newer-or-equal timestamp, and the RX pane's own lines are appended
+// after the stored history. On failure the bucket stays unseeded - its
+// RX-text saves stay suppressed (nothing containing the stored history
+// is on screen, so a save would overwrite it) and the next visit, or the
+// reopen after a store failure, retries.
+/**
+ * @brief Merge a bucket's stored history into the session, once.
+ * @param band The bucket to seed.
+ *
+ * Runs at a bucket's first visit each session. Stored rows are merged
+ * under whatever the session already holds - the newer of the two wins
+ * per callsign, and stored enrichment (grid, ACK and CQ marks) survives
+ * a bare re-hearing - and the stored RX text is placed behind the pane's
+ * own lines. Until a bucket has been seeded its RX-text saves are
+ * suppressed, so a document that does not contain the stored history can
+ * never overwrite it; a failed seed is retried at the flush cadence.
+ */
+/**
+ * @brief HTML of everything below the degraded start's legacy ini copy.
+ * @param doc The RX pane's document, or a cached copy of it.
+ * @return The session text below the copy, or "" when there is none.
+ */
+QString UI_Constructor::htmlBelowLegacyCopy(QTextDocument *doc) const {
+    if (doc->blockCount() <= m_rxTextLegacyBlocks) {
+        return {};
+    }
+    QTextCursor cursor(doc->findBlockByNumber(m_rxTextLegacyBlocks));
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    if (cursor.selection().toPlainText().trimmed().isEmpty()) {
+        return {};
+    }
+    return cursor.selection().toHtml();
+}
+
+void UI_Constructor::seedActivityForBand(QString const &band) {
+    if (m_activityStoreDisabled || !activityDB()->isOpen()) {
+        return;
+    }
+    auto const config = activityConfigId();
+
+    bool callsOk = false;
+    auto const stored = activityDB()->loadCalls(config, band, &callsOk);
+    if (callsOk) {
+        // Apply the callsign-aging setting to what the STORE
+        // contributes, mirroring master's save-time prune: it bounds
+        // what a session can load (the store itself keeps everything),
+        // and without it stale rows reach consumers that put an SNR on
+        // the air. Rows the session has already heard are never pruned -
+        // they are merged in below, untouched.
+        auto const aging = m_config.callsign_aging();
+        auto const agingNow = DriftingDateTime::currentDateTimeUtc();
+
+        QMap<QString, CallDetail> merged;
+        foreach (auto const &r, stored) {
+            auto const cd = fromCallRecord(r);
+            if (aging && !m_callActivity.contains(cd.call) &&
+                m_rxInboxCountCache.value(cd.call, 0) <= 0 &&
+                cd.utcTimestamp.isValid() &&
+                cd.utcTimestamp.secsTo(agingNow) / 60 >= aging) {
+                continue; // too old to show; still in the store
+            }
+            merged[cd.call] = cd;
+        }
+        // Explicit ordering, not QDateTime's operators: since Qt 6.8 a
+        // comparison involving an invalid QDateTime is UNORDERED, so
+        // both < and <= return false and a live row would lose to a
+        // stored one that carries no timestamp (every manually added
+        // station, and legacy-imported rows).
+        auto const newerThan = [](QDateTime const &lhs,
+                                  QDateTime const &rhs) {
+            if (!lhs.isValid()) return false;
+            if (!rhs.isValid()) return true;
+            return rhs < lhs;
+        };
+
+        QList<CallDetail> ramWinners;
+        for (auto it = m_callActivity.constBegin();
+             it != m_callActivity.constEnd(); ++it) {
+            auto const found = merged.constFind(it.key());
+            if (found != merged.constEnd() &&
+                newerThan(found->utcTimestamp, it->utcTimestamp)) {
+                continue; // the stored row is the newer one
+            }
+
+            auto live = it.value();
+            if (found != merged.constEnd()) {
+                // Keep the enrichment the stored row carries when the
+                // live one has none, mirroring the UPSERT's own CASE
+                // guards - otherwise a bare re-hearing would drop the
+                // grid and the ACK/CQ marks from the table while the
+                // database (correctly) kept them.
+                if (live.grid.isEmpty()) live.grid = found->grid;
+                if (!live.ackTimestamp.isValid())
+                    live.ackTimestamp = found->ackTimestamp;
+                if (!live.cqTimestamp.isValid())
+                    live.cqTimestamp = found->cqTimestamp;
+                if (newerThan(it->utcTimestamp, found->utcTimestamp)) {
+                    // heard while the store was unreachable: write it
+                    // through now, or it reverts at the next session
+                    ramWinners.append(live);
+                }
+            } else {
+                ramWinners.append(live);
+            }
+            merged[it.key()] = live;
+        }
+        m_callActivity = merged;
+        if (!ramWinners.isEmpty()) {
+            beginActivityBatch();
+            foreach (auto const &cd, ramWinners) {
+                if (cd.dial == 0) {
+                    // Bands::find(0) is "", so writing this here would
+                    // file it in the out-of-plan bucket rather than the
+                    // one that already holds it (a manual add is stored
+                    // when it is added). Leave it alone.
+                    continue;
+                }
+                persistCallActivity(cd);
+            }
+            endActivityBatch();
+        }
+
+
+
+    } else {
+        qCWarning(mainwindow_js8)
+            << "could not load call activity for band" << band << ":"
+            << activityDB()->error();
+        // retry later WITHOUT touching the RX pane: merging the stored
+        // text now would leave it spliced into an unseeded pane, and the
+        // retry would merge - and then persist - it a second time
+        return;
+    }
+
+    // NOTE: fresh activityDB() call - the loads can self-close a failing
+    // handle, and holding a pointer across them would dangle.
+    bool rxOk = false;
+    auto const storedHtml = activityDB()->loadRxText(config, band, &rxOk);
+    if (rxOk) {
+        auto sessionHtml = QString{};
+        if (band == m_rxTextLegacyBand) {
+            // The pane's top is the legacy ini copy shown by the
+            // degraded start - history the import already banked, not
+            // session text. Merging the whole pane would append a
+            // second copy of the history behind the stored one.
+            sessionHtml = htmlBelowLegacyCopy(ui->textEditRX->document());
+        } else if (!ui->textEditRX->toPlainText().trimmed().isEmpty()) {
+            sessionHtml = ui->textEditRX->toHtml();
+        }
+        if (!storedHtml.isEmpty()) {
+            ui->textEditRX->setHtml(storedHtml);
+            if (!sessionHtml.isEmpty()) {
+                auto cursor = QTextCursor(ui->textEditRX->document());
+                cursor.movePosition(QTextCursor::End);
+                // never splice the session's first line onto the last
+                // stored line (writeNoticeTextToUI uses the same guard)
+                if (cursor.block().length() > 1) {
+                    cursor.insertBlock();
+                }
+                cursor.insertHtml(sessionHtml);
+            }
+            // the document was rebuilt: stored block indexes are stale
+            m_rxFrameBlockNumbers.clear();
+            QTimer::singleShot(0, this, [this]() {
+                ui->textEditRX->verticalScrollBar()->setValue(
+                    ui->textEditRX->verticalScrollBar()->maximum());
+            });
+        }
+        if (band == m_rxTextLegacyBand) {
+            // consumed: the pane no longer holds an unaccounted copy -
+            // either the stored history replaced it, or (empty row) the
+            // pane's copy is now legitimately this bucket's document
+            m_rxTextLegacyBand.clear();
+            m_rxTextLegacyBlocks = 0;
+        }
+        m_rxTextSaveTimer.stop();
+        m_rxTextSaveMaxTimer.stop();
+        m_rxTextLastSavedBand = band;
+        if (sessionHtml.isEmpty()) {
+            // showing exactly the stored content - nothing to write back
+            m_rxTextLastSavedRevision =
+                ui->textEditRX->document()->revision();
+        } else {
+            // the merged document is newer than the stored row
+            m_rxTextLastSavedRevision = -1;
+        }
+    } else {
+        qCWarning(mainwindow_js8)
+            << "could not load RX text for band" << band << ":"
+            << activityDB()->error();
+    }
+
+    if (callsOk && rxOk) {
+        m_activitySeeded.insert(band);
+        if (m_rxTextLastSavedRevision == -1) {
+            saveRxTextForBand(band); // permitted now the bucket is seeded
+        }
+    }
+}
+
+/**
+ * @brief Persist the RX pane for a bucket, if it is safe to do so.
+ * @param band The bucket the pane's contents belong to.
+ *
+ * Declines while the bucket is only the startup guess (RX text carries
+ * no per-line frequency, so it could be filed under a band it was never
+ * heard on) or while the bucket is unseeded, marking it for the
+ * close-time sweep in both cases. An empty pane removes the stored row
+ * rather than storing an empty one.
+ */
+void UI_Constructor::saveRxTextForBand(QString const &band) {
+    if (m_activityStoreDisabled) {
+        return; // a requested reset could not be applied - see the import
+    }
+    if (!m_activityBandConfirmed && band == m_activityBand &&
+        m_activityStartupTimer.isValid() &&
+        !m_activityStartupTimer.hasExpired(60 * 1000)) {
+        // The rig has not reported yet, so this bucket is only the last
+        // session's guess. RX text carries no per-line frequency, so
+        // filing it here could permanently mis-attribute a band's
+        // history; hold it in the pane until the bucket is confirmed
+        // (the grace period covers a station running without CAT).
+        m_rxTextDirtyBands.insert(band);
+        return;
+    }
+    if (!m_activitySeeded.contains(band)) {
+        // The bucket's stored history has not been merged into the
+        // on-screen document (store down or a read failed at first
+        // visit) - saving would overwrite that history with a document
+        // that does not contain it. Remember that this bucket has
+        // unsaved text, and retry the seed at this flush cadence, so one
+        // transient failure cannot disable persistence for a whole
+        // parked session; a successful seed saves the merged document.
+        m_rxTextDirtyBands.insert(band);
+        if (band == m_activityBand && !m_activityShuttingDown &&
+            activityDB()->isOpen() &&
+            (!m_seedRetryTimer.isValid() ||
+             m_seedRetryTimer.hasExpired(30 * 1000))) {
+            m_seedRetryTimer.start();
+            seedActivityForBand(band);
+            displayActivity(true);
+        }
+        return;
+    }
+
+    int const revision = ui->textEditRX->document()->revision();
+    if (revision == m_rxTextLastSavedRevision &&
+        band == m_rxTextLastSavedBand) {
+        return; // unchanged since the last save
+    }
+
+    activityDB(); // resolve (and possibly recover) before the batch opens
+    startActivityBatchIfPending();
+
+    bool ok;
+    if (ui->textEditRX->document()->isEmpty()) {
+        // an empty pane stores as no row at all - otherwise the debounced
+        // save that follows a Clear would resurrect an empty-skeleton row
+        ok = activityDB()->clearRxText(activityConfigId(), band);
+    } else {
+        ok = activityDB()->saveRxText(activityConfigId(), band,
+                                      ui->textEditRX->toHtml());
+    }
+
+    if (ok) {
+        m_rxTextLastSavedRevision = revision;
+        m_rxTextLastSavedBand = band;
+        m_rxTextDirtyBands.remove(band);
+    } else {
+        // Remember that this band's on-screen/cached text is newer than
+        // the store - the next restore of the band re-arms a save, and
+        // closeEvent sweeps still-dirty bands from the RAM cache. Re-arm
+        // the debounce too: the flush stopped both timers before calling
+        // us, and only new document activity would otherwise restart
+        // them, so a band that falls quiet after one failed save would
+        // never try again.
+        m_rxTextDirtyBands.insert(band);
+        if (!m_activityShuttingDown && band == m_activityBand) {
+            // Back off: a store that stays unwritable would otherwise
+            // spin at the 5 s debounce forever, and every attempt
+            // serialises the whole (unbounded) RX document on the GUI
+            // thread. One minute is still far inside the window the
+            // write-on-change design is protecting.
+            m_rxTextSaveTimer.start(60 * 1000);
+            if (!m_rxTextSaveMaxTimer.isActive()) {
+                m_rxTextSaveMaxTimer.start();
+            }
+        }
+        if (activityDB()->isOpen()) {
+            qCWarning(mainwindow_js8)
+                << "could not save RX text for band" << band << ":"
+                << activityDB()->error();
+        }
+    }
+}
+
+/**
+ * @brief One-time import of the legacy .ini activity data into
+ *        activity.db3, following the inbox_v1 -> inbox_v2 pattern: the
+ *        legacy [CallActivity] group and RXActivity key are read once,
+ *        never written again, and left in place for older versions of
+ *        the software.
+ *
+ * Call activity rows are attributed to the band each record was actually
+ * heard on, via its stored dial frequency - the legacy store had no band
+ * dimension, which is how activity ended up displayed on whatever band
+ * the rig was polled on at startup (#267). The RX text blob has no
+ * per-line frequency, so it is attributed to the band of the last-known
+ * dial frequency - the band the user last saw it on.
+ */
+// Erase the legacy [CallActivity] group and RXActivity key. Master's
+// writeSettings rewrote both at every close, so a reset genuinely
+// destroyed the old data; leaving them would keep a full copy of
+// everything the user asked to erase.
+void UI_Constructor::purgeLegacyActivityIni() {
+    m_settings->beginGroup("CallActivity");
+    m_settings->remove(""); // the whole legacy group
+    m_settings->endGroup();
+    m_settings->beginGroup("UI_Constructor");
+    m_settings->remove("RXActivity");
+    m_settings->endGroup();
+}
+
+bool UI_Constructor::importLegacyActivityIfNeeded() {
+    auto *db = activityDB();
+    if (!db->isOpen()) {
+        if (m_config.reset_activity()) {
+            // The wipe cannot run, so nothing may be read or written
+            // this session - otherwise the store reopens later and
+            // splices back exactly what the user asked to erase. The
+            // legacy ini keys ARE erased now: they hold a copy of the
+            // same activity, and leaving them would let a later untick
+            // re-import the snapshot the user just asked to destroy.
+            m_activityStoreDisabled = true;
+            purgeLegacyActivityIni();
+        }
+        return false; // the database wipe retries at the next start
+    }
+
+    auto const config = activityConfigId();
+
+    // The fire-once marker lives in the configuration's own settings, so
+    // it travels WITH the configuration: a rename keeps it (no re-import
+    // resurrecting deleted stations under the new name), and a clone
+    // copies it along with the frozen legacy [CallActivity] snapshot the
+    // clone also inherits - which must likewise never be imported.
+    constexpr char importedKey[] = "ActivityDbImported";
+
+    if (m_config.reset_activity()) {
+        // The user asked to start clean. Wipe this configuration's
+        // stored activity AND the legacy ini keys: master's writeSettings
+        // removed the [CallActivity] group and rewrote RXActivity at
+        // every close, so a reset genuinely destroyed the old data.
+        // Leaving those keys behind would both hide a copy of everything
+        // the user asked to erase and let a later un-tick re-import a
+        // stale snapshot.
+        if (!db->clearConfig(config)) {
+            qCWarning(mainwindow_js8)
+                << "could not reset stored activity:" << db->error();
+            showStatusMessage(
+                tr("Could not reset stored activity - activity will not "
+                   "be saved this session (%1)")
+                    .arg(db->error()));
+            // Nothing is read and nothing is written for the rest of the
+            // session: the panes stay empty as asked, and no write can
+            // be destroyed by the wipe that retries at the next start.
+            m_activityStoreDisabled = true;
+            purgeLegacyActivityIni();
+            return false;
+        }
+
+        purgeLegacyActivityIni();
+        m_settings->setValue(importedKey, true);
+        return true;
+    }
+
+    if (m_settings->value(importedKey, false).toBool()) {
+        // The marker lives in the ini, the data in activity.db3 - a
+        // backup or a machine move that carries only JS8Call.ini would
+        // otherwise skip the import forever while the legacy keys sit
+        // there, readable and never read. If the marker is set but this
+        // configuration has nothing stored, import again.
+        bool probeOk = false;
+        if (db->hasConfig(config, &probeOk) || !probeOk) {
+            return true;
+        }
+        qCDebug(mainwindow_js8)
+            << "import marker set but no stored activity - re-importing";
+    }
+
+    // fallback band for records whose stored dial can't be resolved
+    // (manually added stations have dial == 0; out-of-band rows return
+    // ""): the band of the last-known dial frequency, i.e. the band the
+    // user last saw this data displayed on
+    m_settings->beginGroup("Common");
+    auto const lastDial =
+        m_settings
+            ->value("DialFreq", QVariant::fromValue<Frequency>(
+                                    Default::DIAL_FREQUENCY))
+            .value<Frequency>();
+    m_settings->endGroup();
+    auto const fallbackBand = m_config.bands()->find(lastDial);
+
+    // An empty fallbackBand is fine: "" is the out-of-plan bucket, which
+    // the panes load whenever the dial resolves to no band - exactly
+    // where a transverter/channelized user's un-banded legacy data
+    // should land.
+
+    // One transaction for the whole import, following Inbox's v1 -> v2
+    // migration: either every legacy row lands - and only then is the
+    // fire-once marker written - or nothing changes and the import
+    // retries on the next start. (Setting the marker after a partial
+    // import would silently lose the failed rows forever - the ini group
+    // is never rewritten, but never re-read either.)
+    if (!db->begin()) {
+        qCWarning(mainwindow_js8)
+            << "could not start legacy activity import:" << db->error();
+        return false;
+    }
+
+    bool allOk = true;
+    int imported = 0;
+    m_settings->beginGroup("CallActivity");
+    foreach (auto call, m_settings->allKeys()) {
+        auto values = m_settings->value(call).toMap();
+
+        ActivityDB::CallRecord r;
+        r.callsign = call;
+        r.snr = values.value("snr", -64).toInt();
+        r.grid = values.value("grid", "").toString();
+        r.dial = values.value("dial", 0).value<Frequency>();
+        r.offset = values.value("freq", 0).toInt();
+        r.tdrift = values.value("tdrift", 0).toFloat();
+        r.ackTimestamp = values.value("ackTimestamp").toDateTime();
+        r.utcTimestamp = values.value("utcTimestamp").toDateTime();
+        r.submode = values.value("submode", Varicode::JS8CallNormal).toInt();
+
+        // same rule as live persistence: a non-zero out-of-plan dial
+        // belongs to the "" bucket; only dial-less rows (master's manual
+        // adds) take the last-seen band
+        auto band = m_config.bands()->find(r.dial);
+        if (band.isEmpty() && r.dial == 0) {
+            band = fallbackBand;
+        }
+
+        if (db->upsertCall(config, band, r)) {
+            ++imported;
+        } else {
+            allOk = false;
+        }
+    }
+    m_settings->endGroup();
+
+    m_settings->beginGroup("UI_Constructor");
+    auto const html = m_settings->value("RXActivity", "").toString();
+    m_settings->endGroup();
+
+    if (!html.isEmpty()) {
+        // never clobber RX text a session has already stored for that
+        // band - the legacy blob is by definition the older data
+        bool haveOk = false;
+        auto const have = db->loadRxText(config, fallbackBand, &haveOk);
+        if (haveOk && have.isEmpty()) {
+            allOk = db->saveRxText(config, fallbackBand, html) && allOk;
+        } else if (!haveOk) {
+            allOk = false;
+        }
+    }
+
+    if (!allOk || !db->commit()) {
+        db->rollback();
+        qCWarning(mainwindow_js8)
+            << "legacy activity import failed - will retry on next start:"
+            << db->error();
+        return false;
+    }
+
+    m_settings->setValue(importedKey, true);
+
+    qCDebug(mainwindow_js8) << "imported" << imported
+                            << "legacy call activity rows into"
+                            << activityPath();
+    return true;
 }
 
 void UI_Constructor::clearActivity() {
@@ -2939,6 +3967,11 @@ void UI_Constructor::clearActivity() {
     m_rxCommandQueue.clear();
     m_lastTxMessage.clear();
 
+    // BEFORE the clears, as master ordered it: with the senders still in
+    // the map, refresh takes logCallActivity's update branch - the create
+    // branch would fire a call_new notification per unread sender on
+    // every band change. Senders reappear at the next refresh (message
+    // dock events), exactly as they always have.
     refreshInboxCounts();
     resetTimeDeltaAverage();
 
@@ -5322,10 +6355,33 @@ void UI_Constructor::qsy(int const hzDelta) {
 
     m_bandActivity.swap(bandActivity);
 
-    // Adjust call activity frequencies.
+    // Adjust call activity frequencies, mirroring each rewritten offset
+    // to the store (one transaction) - otherwise the stale persisted
+    // offsets come back at the next band round-trip or restart, and
+    // clicked decodes stop resolving to their stations. Only rows whose
+    // own dial belongs to the current band are written back: entries
+    // displayed here but keyed to another band (post-QSY stragglers,
+    // inbox senders carrying their message's dial) did not QSY, and
+    // dial-less RAM-only entries must not be promoted into the store by
+    // a waterfall nudge.
 
-    for (auto [key, value] : m_callActivity.asKeyValueRange()) {
-        value.offset -= hzDelta;
+    if (!m_callActivity.isEmpty()) {
+        beginActivityBatch();
+        for (auto [key, value] : m_callActivity.asKeyValueRange()) {
+            value.offset -= hzDelta;
+            // Write back the rows this bucket actually stores: those
+            // whose own dial resolves here, and dial-less rows (manual
+            // adds), which are filed under the bucket they were added
+            // on - hence the fallback, since Bands::find(0) is "". Rows
+            // keyed to another band did not QSY and keep their offsets.
+            auto const rowBand = m_config.bands()->find(value.dial);
+            if (rowBand == m_activityBand) {
+                persistCallActivity(value);
+            } else if (value.dial == 0 && !m_activityBand.isEmpty()) {
+                persistCallActivity(value, true);
+            }
+        }
+        endActivityBatch();
     }
 
     displayActivity(true);
@@ -5444,6 +6500,13 @@ void UI_Constructor::handle_transceiver_update(
 
     // ensure frequency display is correct
     // setRig();
+    // NOTE: the "state" property is deliberately set AFTER this call, as
+    // master did: the transceiver's very first report can carry a bogus
+    // frequency (e.g. the hamlib dummy backend's default when Rig=None),
+    // and the !state.isValid() guard in updateCurrentBand() discards it.
+    // The cost is a window until the second report during which RX text
+    // is appended to the preloaded bucket's pane; call activity is
+    // unaffected (rows are keyed by their own capture dial).
     updateCurrentBand();
     displayDialFrequency();
     update_dynamic_property(ui->readFreq, "state", "ok");
@@ -5900,9 +6963,27 @@ QString UI_Constructor::callsignSelected(bool) {
         auto const offsetLo = selectedOffset - threshold;
         auto const offsetHi = selectedOffset + threshold;
 
+        // Aged-out stations are not on the air and must not claim a
+        // clicked decode: this result becomes the directed-reply target,
+        // so an unfiltered match would address a transmission to a
+        // station last heard weeks ago. The store keeps rows
+        // indefinitely, so the filter lives here as it does in the
+        // table's own render (unread senders stay exempt).
+        auto const aging = m_config.callsign_aging();
+        auto const now = DriftingDateTime::currentDateTimeUtc();
+
         for (auto const &key : keys) {
             if (auto const &d = m_callActivity[key];
                 offsetLo <= d.offset && d.offset <= offsetHi) {
+                if (aging && m_rxInboxCountCache.value(d.call, 0) <= 0 &&
+                    d.utcTimestamp.isValid() &&
+                    d.utcTimestamp.secsTo(now) / 60 >= aging) {
+                    // the best match for this offset has aged out:
+                    // select nothing rather than silently substituting a
+                    // neighbouring station, which would then receive the
+                    // directed reply (or the Remove/Block action)
+                    return QString();
+                }
                 return d.call;
             }
         }
@@ -6066,6 +7147,11 @@ void UI_Constructor::processActivity(bool force) {
         return;
     }
 
+    // one transaction for the whole drain: the rx AND command handlers
+    // persist a row per station heard, and a busy cycle would otherwise
+    // pay one autocommit per row
+    beginActivityBatch();
+
     // Recent Rx Activity
     processRxActivity();
 
@@ -6083,6 +7169,8 @@ void UI_Constructor::processActivity(bool force) {
 
     // Process PSKReporter Spots
     processSpots();
+
+    endActivityBatch();
 
     m_rxDirty = false;
 }
@@ -6240,6 +7328,9 @@ QString UI_Constructor::inboxPath() {
 void UI_Constructor::refreshInboxCounts() {
     auto inbox = Inbox(inboxPath());
     if (inbox.open()) {
+        // one transaction for the whole sender fan-out (each synthesized
+        // sender persists through logCallActivity)
+        beginActivityBatch();
         // reset inbox counts
         m_rxInboxCountCache.clear();
 
@@ -6265,10 +7356,10 @@ void UI_Constructor::refreshInboxCounts() {
                 auto const snr = params.value("SNR").toInt();
                 auto const dial = params.value("DIAL").value<Frequency>();
                 auto const offset = params.value("OFFSET").toInt();
-                auto const tdrift = params.value("TDRIFT").toInt();
+                auto const tdrift = params.value("TDRIFT").toFloat();
                 auto const submode = params.value("SUBMODE").toInt();
 
-                CallDetail cd;
+                CallDetail cd = {};
                 cd.call = from;
                 cd.snr = snr;
                 cd.dial = dial;
@@ -6288,6 +7379,8 @@ void UI_Constructor::refreshInboxCounts() {
         foreach (auto key, groupMessageCounts.keys()) {
             m_rxInboxCountCache[key] = groupMessageCounts[key];
         }
+
+        endActivityBatch();
     }
 }
 

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -12,6 +12,7 @@
 #include "JS8_JSC/JSC_checker.h"
 #include "JS8_Logbook/LogBook.h"
 #include "JS8_Main/APRSISClient.h"
+#include "JS8_Main/ActivityDB.h"
 #include "JS8_Main/AprsInboundRelay.h"
 #include "JS8_Main/Bands.h"
 #include "JS8_Main/DirectedMessageHighlighter.h"
@@ -103,6 +104,7 @@
 #include <QStyleFactory>
 #include <QtCore/QtGlobal>
 #include <QTableWidget>
+#include <QTextDocumentFragment>
 #include <QTextEdit>
 #include <QThread>
 #include <QTime>
@@ -112,6 +114,7 @@
 #include <QToolTip>
 #include <QUdpSocket>
 #include <QUrl>
+#include <QUuid>
 #include <QVariant>
 #include <QVector>
 #include <QVersionNumber>
@@ -127,6 +130,7 @@
 #include <cstring>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string_view>
@@ -251,6 +255,7 @@ class UI_Constructor : public QMainWindow {
     void logHeardGraph(QString from, QString to);
     QString lookupCallInCompoundCache(QString const &call);
     void cacheActivity(QString key);
+    void switchActivityBucket(QString const &band);
     void restoreActivity(QString key);
     void clearActivity();
     void clearBandActivity();
@@ -593,6 +598,76 @@ class UI_Constructor : public QMainWindow {
     Frequency m_lastDialFreq;
     QString m_lastBand;
 
+    // per-band persistent activity storage (activity.db3) - issue #267
+    std::unique_ptr<ActivityDB> m_activityDB;
+    QElapsedTimer m_activityDBRetryTimer; // throttles reopen attempts
+    // The storage bucket the on-screen call activity / RX text belongs
+    // to: a band name, or "" - the out-of-plan bucket, which persists
+    // activity heard on dials outside the band plan (transverter IFs,
+    // channelized operation) the way the legacy un-banded ini did.
+    // Usually this equals m_lastBand, but at startup the panes are
+    // preloaded from the last-known dial before the rig has reported
+    // one, and that data must be flushed to - and cleared as - the
+    // bucket it was loaded from, not whatever the rig later reports.
+    QString m_activityBand;
+    bool m_activityBandLoaded = false; // false until the first restore
+    // Buckets whose stored rows have been seeded into the session's RAM
+    // caches. Seeding happens once per bucket per session; until it has
+    // succeeded, RX-text saves for that bucket are suppressed - the
+    // on-screen document does not contain the stored history, so saving
+    // it would overwrite (or, empty, delete) that history.
+    QSet<QString> m_activitySeeded;
+    // Degraded start: the store was down, so readSettings showed the
+    // legacy ini copy in the RX pane. That copy is history the one-time
+    // import already banked - only text BELOW it is session text. These
+    // mark which bucket shows it and how many blocks it spans, so the
+    // recovery seed and the close-time sweep never merge a second copy
+    // of the history behind the stored one.
+    QString m_rxTextLegacyBand;
+    int m_rxTextLegacyBlocks = 0;
+    // Depth counter so nested write bursts (a decode drain that calls
+    // refreshInboxCounts, say) share one transaction.
+    int m_activityBatchDepth = 0;
+    // Bands whose latest RX text never reached the store (a flush failed
+    // while the store was down): restores re-arm their saves and
+    // closeEvent sweeps the stragglers from the RAM band cache.
+    QSet<QString> m_rxTextDirtyBands;
+    // Set when a requested startup reset could not be applied: nothing
+    // is read or written for the rest of the session, so the panes stay
+    // as empty as the user asked and no write of this session can be
+    // destroyed by the wipe that retries at the next start.
+    bool m_activityStoreDisabled = false;
+    // Set in closeEvent: suppresses the seed retry that a final flush
+    // would otherwise trigger while the window is tearing down.
+    bool m_activityShuttingDown = false;
+    // False until the rig has actually reported a band (or the startup
+    // grace period lapses, covering Rig=None). While false the storage
+    // bucket is only the last session's guess, so RX text - which has no
+    // per-line frequency - must not be filed under it.
+    bool m_activityBandConfirmed = false;
+    // Buckets the rig has actually reported this session. The close-time
+    // sweep writes only these: a bucket that was never confirmed holds a
+    // pane that may contain text heard on a different band.
+    QSet<QString> m_activityBandConfirmedBands;
+    QElapsedTimer m_activityStartupTimer;
+    QElapsedTimer m_seedRetryTimer; // throttles failed-seed retries
+    QTimer m_rxTextSaveTimer; // debounces RX-text writes to activity.db3
+    // Cap on the debounce: sustained sub-interval document changes (busy
+    // nets, fast submodes) restart m_rxTextSaveTimer indefinitely, so this
+    // timer - armed once and not restarted - bounds how stale the stored
+    // copy can get.
+    QTimer m_rxTextSaveMaxTimer;
+    // Storage id captured at first use: MultiSettings updates its
+    // current configuration BEFORE this window closes during a
+    // configuration switch, so reading it at close time would file the
+    // outgoing configuration's activity under the incoming one.
+    mutable QString m_activityConfigId;
+    // Skip unchanged RX-text rewrites via the document's revision
+    // counter - unlike hashing toHtml(), checking it costs nothing, so
+    // an idle debounce tick never serializes the (unbounded) document.
+    int m_rxTextLastSavedRevision = -1;
+    QString m_rxTextLastSavedBand;
+
     Detector *m_detector;
     unsigned m_FFTSize;
     SoundInput *m_soundInput;
@@ -910,11 +985,16 @@ class UI_Constructor : public QMainWindow {
 
     QMap<QString, int> m_rxInboxCountCache; // call -> count
 
+    // The RAM band caches remain the session's display layer, exactly as
+    // on master: band round-trips restore the panes verbatim, with or
+    // without a working store. activity.db3 sits underneath as a
+    // write-through store plus a once-per-session seed of each bucket's
+    // history (see seedActivityForBand).
     QMap<QString, QMap<QString, CallDetail>>
-        m_callActivityBandCache; // band -> call activity
+        m_callActivityBandCache; // bucket -> call activity
+    QMap<QString, QString> m_rxTextBandCache; // bucket -> rx text
     QMap<QString, QMap<int, QList<ActivityDetail>>>
         m_bandActivityBandCache;              // band -> band activity
-    QMap<QString, QString> m_rxTextBandCache; // band -> rx text
     QMap<QString, QMap<QString, QSet<QString>>>
         m_heardGraphOutgoingBandCache; // band -> heard in
     QMap<QString, QMap<QString, QSet<QString>>>
@@ -1041,6 +1121,26 @@ class UI_Constructor : public QMainWindow {
     QString hbBlockingPath() const;
     void pushNotificationHandler(); // JS8_Mainwindow/pushNotificationHandler.cpp
     QString msgNotifyPath() const;
+
+    // per-band persistent activity storage (activity.db3) - issue #267
+    QString activityPath() const;
+    ActivityDB *activityDB();
+    QString activityConfigId() const;
+    void persistCallActivity(CallDetail const &,
+                             bool fallbackToCurrentBand = false);
+    // single conversion pair, so a CallDetail field added later fails to
+    // persist/restore loudly at the one site instead of silently in
+    // hand-copied blocks
+    ActivityDB::CallRecord toCallRecord(CallDetail const &) const;
+    CallDetail fromCallRecord(ActivityDB::CallRecord const &) const;
+    void seedActivityForBand(QString const &band);
+    QString htmlBelowLegacyCopy(QTextDocument *doc) const;
+    void purgeLegacyActivityIni();
+    void beginActivityBatch();
+    void startActivityBatchIfPending();
+    void endActivityBatch();
+    void saveRxTextForBand(QString const &band);
+    bool importLegacyActivityIfNeeded();
     void removeStoredMessageNotification(int msgId);
     void refreshInboxCounts();
     bool hasMessageHistory(QString call);

--- a/JS8_UI/mainwindow.h
+++ b/JS8_UI/mainwindow.h
@@ -12,9 +12,10 @@
 #include "JS8_JSC/JSC_checker.h"
 #include "JS8_Logbook/LogBook.h"
 #include "JS8_Main/APRSISClient.h"
-#include "JS8_Main/ActivityDB.h"
+#include "JS8_Main/ActivityStorageController.h"
 #include "JS8_Main/AprsInboundRelay.h"
 #include "JS8_Main/Bands.h"
+#include "JS8_Main/CallDetail.h"
 #include "JS8_Main/DirectedMessageHighlighter.h"
 #include "JS8_Main/DriftingDateTime.h"
 #include "JS8_Main/FrequencyList.h"
@@ -104,7 +105,6 @@
 #include <QStyleFactory>
 #include <QtCore/QtGlobal>
 #include <QTableWidget>
-#include <QTextDocumentFragment>
 #include <QTextEdit>
 #include <QThread>
 #include <QTime>
@@ -114,7 +114,6 @@
 #include <QToolTip>
 #include <QUdpSocket>
 #include <QUrl>
-#include <QUuid>
 #include <QVariant>
 #include <QVector>
 #include <QVersionNumber>
@@ -197,7 +196,9 @@ class UI_Constructor : public QMainWindow {
     friend class WSJTXMessageMapper; // Allow WSJTXMessageMapper to access
                                      // private members
 
-    struct CallDetail;
+    // Defined in JS8_Main/CallDetail.h so the activity storage layer can
+    // convert to and from it without including this header.
+    using CallDetail = ::CallDetail;
     struct CommandDetail;
 
   public:
@@ -255,7 +256,6 @@ class UI_Constructor : public QMainWindow {
     void logHeardGraph(QString from, QString to);
     QString lookupCallInCompoundCache(QString const &call);
     void cacheActivity(QString key);
-    void switchActivityBucket(QString const &band);
     void restoreActivity(QString key);
     void clearActivity();
     void clearBandActivity();
@@ -598,75 +598,10 @@ class UI_Constructor : public QMainWindow {
     Frequency m_lastDialFreq;
     QString m_lastBand;
 
-    // per-band persistent activity storage (activity.db3) - issue #267
-    std::unique_ptr<ActivityDB> m_activityDB;
-    QElapsedTimer m_activityDBRetryTimer; // throttles reopen attempts
-    // The storage bucket the on-screen call activity / RX text belongs
-    // to: a band name, or "" - the out-of-plan bucket, which persists
-    // activity heard on dials outside the band plan (transverter IFs,
-    // channelized operation) the way the legacy un-banded ini did.
-    // Usually this equals m_lastBand, but at startup the panes are
-    // preloaded from the last-known dial before the rig has reported
-    // one, and that data must be flushed to - and cleared as - the
-    // bucket it was loaded from, not whatever the rig later reports.
-    QString m_activityBand;
-    bool m_activityBandLoaded = false; // false until the first restore
-    // Buckets whose stored rows have been seeded into the session's RAM
-    // caches. Seeding happens once per bucket per session; until it has
-    // succeeded, RX-text saves for that bucket are suppressed - the
-    // on-screen document does not contain the stored history, so saving
-    // it would overwrite (or, empty, delete) that history.
-    QSet<QString> m_activitySeeded;
-    // Degraded start: the store was down, so readSettings showed the
-    // legacy ini copy in the RX pane. That copy is history the one-time
-    // import already banked - only text BELOW it is session text. These
-    // mark which bucket shows it and how many blocks it spans, so the
-    // recovery seed and the close-time sweep never merge a second copy
-    // of the history behind the stored one.
-    QString m_rxTextLegacyBand;
-    int m_rxTextLegacyBlocks = 0;
-    // Depth counter so nested write bursts (a decode drain that calls
-    // refreshInboxCounts, say) share one transaction.
-    int m_activityBatchDepth = 0;
-    // Bands whose latest RX text never reached the store (a flush failed
-    // while the store was down): restores re-arm their saves and
-    // closeEvent sweeps the stragglers from the RAM band cache.
-    QSet<QString> m_rxTextDirtyBands;
-    // Set when a requested startup reset could not be applied: nothing
-    // is read or written for the rest of the session, so the panes stay
-    // as empty as the user asked and no write of this session can be
-    // destroyed by the wipe that retries at the next start.
-    bool m_activityStoreDisabled = false;
-    // Set in closeEvent: suppresses the seed retry that a final flush
-    // would otherwise trigger while the window is tearing down.
-    bool m_activityShuttingDown = false;
-    // False until the rig has actually reported a band (or the startup
-    // grace period lapses, covering Rig=None). While false the storage
-    // bucket is only the last session's guess, so RX text - which has no
-    // per-line frequency - must not be filed under it.
-    bool m_activityBandConfirmed = false;
-    // Buckets the rig has actually reported this session. The close-time
-    // sweep writes only these: a bucket that was never confirmed holds a
-    // pane that may contain text heard on a different band.
-    QSet<QString> m_activityBandConfirmedBands;
-    QElapsedTimer m_activityStartupTimer;
-    QElapsedTimer m_seedRetryTimer; // throttles failed-seed retries
-    QTimer m_rxTextSaveTimer; // debounces RX-text writes to activity.db3
-    // Cap on the debounce: sustained sub-interval document changes (busy
-    // nets, fast submodes) restart m_rxTextSaveTimer indefinitely, so this
-    // timer - armed once and not restarted - bounds how stale the stored
-    // copy can get.
-    QTimer m_rxTextSaveMaxTimer;
-    // Storage id captured at first use: MultiSettings updates its
-    // current configuration BEFORE this window closes during a
-    // configuration switch, so reading it at close time would file the
-    // outgoing configuration's activity under the incoming one.
-    mutable QString m_activityConfigId;
-    // Skip unchanged RX-text rewrites via the document's revision
-    // counter - unlike hashing toHtml(), checking it costs nothing, so
-    // an idle debounce tick never serializes the (unbounded) document.
-    int m_rxTextLastSavedRevision = -1;
-    QString m_rxTextLastSavedBand;
+    // Per-band persistent activity storage (activity.db3) - issue #267.
+    // Everything above ActivityDB lives in the controller; the window
+    // keeps only this pointer and thin delegating calls.
+    std::unique_ptr<ActivityStorageController> m_activityStorage;
 
     Detector *m_detector;
     unsigned m_FFTSize;
@@ -772,21 +707,6 @@ class UI_Constructor : public QMainWindow {
     QString m_rptRcvd;
     QString m_msgSent0;
     QString m_opCall;
-
-    struct CallDetail {
-        QString call;
-        QString through;
-        QString grid;
-        Frequency dial;
-        int offset;
-        QDateTime cqTimestamp;
-        QDateTime ackTimestamp;
-        QDateTime utcTimestamp;
-        int snr;
-        int bits;
-        float tdrift;
-        int submode;
-    };
 
     struct CommandDetail {
         bool isCompound;
@@ -1121,26 +1041,6 @@ class UI_Constructor : public QMainWindow {
     QString hbBlockingPath() const;
     void pushNotificationHandler(); // JS8_Mainwindow/pushNotificationHandler.cpp
     QString msgNotifyPath() const;
-
-    // per-band persistent activity storage (activity.db3) - issue #267
-    QString activityPath() const;
-    ActivityDB *activityDB();
-    QString activityConfigId() const;
-    void persistCallActivity(CallDetail const &,
-                             bool fallbackToCurrentBand = false);
-    // single conversion pair, so a CallDetail field added later fails to
-    // persist/restore loudly at the one site instead of silently in
-    // hand-copied blocks
-    ActivityDB::CallRecord toCallRecord(CallDetail const &) const;
-    CallDetail fromCallRecord(ActivityDB::CallRecord const &) const;
-    void seedActivityForBand(QString const &band);
-    QString htmlBelowLegacyCopy(QTextDocument *doc) const;
-    void purgeLegacyActivityIni();
-    void beginActivityBatch();
-    void startActivityBatchIfPending();
-    void endActivityBatch();
-    void saveRxTextForBand(QString const &band);
-    bool importLegacyActivityIfNeeded();
     void removeStoredMessageNotification(int msgId);
     void refreshInboxCounts();
     bool hasMessageHistory(QString call);


### PR DESCRIPTION
Fixes #267

Call Activity and the RX text panel were stored in RAM and only saved to the .ini when JS8Call closed normally, with all bands mixed together, so:
1. a crash loses everything since the last clean close,
2. on restart the mixed history all lands on whichever band the rig is on.

What it does:
- Saves call activity and RX text to a new database, activity.db3, keyed by configuration, band and callsign.
- Saves as it goes, within a few seconds of hearing something, so a crash or power cut only loses the last few seconds. The database survives being interrupted mid-write.
- Imports your existing .ini history once, each record filed under the band it was actually heard on. The .ini is left alone so older builds still work.
- Each configuration keeps its own history: a clone starts with a copy of its parent's and the two diverge from then on, renames carry it over, and a settings reset starts clean.
- Ticking 'Reset ... at startup' now asks first, and a QSY from outside the band plan no longer carries the previous band's activity across.
- Controller logging moved to its own category — use activitystoragecontroller.js8, not mainwindow.js8.
- Also fixes stored message dial frequencies above 2.1 GHz being read back through a 32-bit conversion.

Developed with [vibe.andeye](https://github.com/andeyePro/vibe) with Fable 5 leading Opus 5 adversarial teams, reviewed on my shack Pi (Debian 13 aarch64, Qt 6.8.2) and IC-725:  
- Tested against master on the same profile: after a kill -9 mid-session everything comes back on restart whereas master loses whatever came after its last clean close. 
- Bands each keep their own history across restarts including after a power cut.
- Making the database unreadable shows a warning and JS8Call carries on, then picks the database back up once it is readable again. 

Not tested: 
- issue 2. above, as my station doesn't give CAT frequency, 
- Windows/macOS builds (but compiles).

**Known issues:**
- ~~Control -> Clear Activity... -> Clear All Activity, or checking 'Reset the Band Activity, Call Activity, and RX history at startup', etc. on a clone would now also delete the clone's parent's history, or vice versa.~~
- ~~ActivityStorageController logs under `mainwindow_js8`, a leftover from when it lived in mainwindow.cpp; changing to `activitystoragecontroller_js8`.~~